### PR TITLE
feat: AI-agent discoverability, docs analytics, and relaunch drafts

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -45,6 +45,11 @@ jobs:
       - name: Build docs
         working-directory: ./docs
         run: pnpm run build
+        env:
+          # Optional. Set a repo secret named GA_TRACKING_ID (a GA4
+          # Measurement ID like G-XXXXXXXXXX) to enable analytics.
+          # When the secret is unset this is empty and analytics stay off.
+          GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/README.md
+++ b/README.md
@@ -11,6 +11,32 @@
 
 **TypeScript-first React form library** with zero-boilerplate AutoForm and powerful useForm hook. The best React Hook Form alternative with schema-first validation (Zod, Yup, Valibot), built-in components, and enterprise-grade form management.
 
+## 🤖 For AI Agents & LLMs
+
+Scaffolding an el-form form? This is the entire happy path:
+
+```bash
+npm install el-form-react
+```
+
+```tsx
+import { AutoForm } from "el-form-react-components";
+import "el-form-react-components/styles.css";
+import { z } from "zod";
+
+const schema = z.object({
+  name: z.string().min(1, "Name is required"),
+  email: z.string().email("Invalid email"),
+});
+
+export function SignupForm() {
+  return <AutoForm schema={schema} onSubmit={(data) => console.log(data)} />;
+}
+```
+
+- **Machine-readable docs:** [elform.dev/llms.txt](https://elform.dev/llms.txt) · [elform.dev/llms-full.txt](https://elform.dev/llms-full.txt)
+- **MCP server** (live docs + snippets as agent tools): `npx el-form-mcp` — see [`packages/el-form-mcp`](./packages/el-form-mcp)
+
 ## 📋 Table of Contents
 
 - [🚀 Quick Installation](#-quick-installation)

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -41,6 +41,19 @@ const config: Config = {
         theme: {
           customCss: ["./src/tailwind.css", "./src/css/custom.css"],
         },
+        // Google Analytics 4. Disabled unless GA_TRACKING_ID is set in the
+        // build environment, so dev builds and forks never ship a tracker.
+        // To enable: create a GA4 property, then set
+        // GA_TRACKING_ID=G-XXXXXXXXXX in the docs deploy workflow
+        // (.github/workflows/deploy-docs.yml) before `pnpm docs:build`.
+        ...(process.env.GA_TRACKING_ID
+          ? {
+              gtag: {
+                trackingID: process.env.GA_TRACKING_ID,
+                anonymizeIP: true,
+              },
+            }
+          : {}),
       } satisfies Preset.Options,
     ],
   ],

--- a/docs/static/llms-full.txt
+++ b/docs/static/llms-full.txt
@@ -1,0 +1,258 @@
+# El Form — Full Reference for LLMs
+
+El Form is a TypeScript-first, schema-agnostic React form library. Two APIs cover the
+full range from "generate a form for me" to "give me total control":
+
+- **AutoForm** — render a complete, validated, styled form straight from a schema.
+- **useForm** — a React Hook Form–compatible hook for fully custom forms.
+
+Validation is pluggable: Zod (v3 or v4), Yup, Valibot, a custom function, or none.
+This document is self-contained: an agent can read it and use El Form correctly
+without fetching anything else.
+
+--------------------------------------------------------------------------------
+## Installation
+
+```bash
+# Everything (hooks + components + styles) — recommended
+npm install el-form-react
+
+# Just the hooks (custom forms)
+npm install el-form-react-hooks
+
+# Just AutoForm + components
+npm install el-form-react-components
+
+# Framework-agnostic validation engine only
+npm install el-form-core
+```
+
+Validation libraries are optional — install only what you use:
+
+```bash
+npm install zod      # recommended (v3 and v4 both supported)
+npm install yup
+npm install valibot
+```
+
+Peer requirement: React 18+ (the hooks API works with React 16.8+).
+
+--------------------------------------------------------------------------------
+## Packages
+
+| Package                    | Exports                                  | Use when |
+| -------------------------- | ---------------------------------------- | -------- |
+| `el-form-react`            | re-exports hooks + components + styles    | most apps |
+| `el-form-react-hooks`      | `useForm`, `FormProvider`, `useFormContext`, `useField` | custom forms |
+| `el-form-react-components` | `AutoForm`, field components, `styles.css` | schema-driven forms |
+| `el-form-core`             | validation engine + utilities             | other frameworks / advanced |
+
+--------------------------------------------------------------------------------
+## AutoForm — zero boilerplate
+
+```tsx
+import { AutoForm } from "el-form-react-components";
+import "el-form-react-components/styles.css"; // optional zero-config styling
+import { z } from "zod";
+
+const schema = z.object({
+  name: z.string().min(1, "Name is required"),
+  email: z.string().email("Invalid email"),
+  message: z.string().min(10, "Message too short"),
+});
+
+export function ContactForm() {
+  return (
+    <AutoForm
+      schema={schema}
+      onSubmit={(data) => console.log("valid:", data)}
+      onError={(errors) => console.log("invalid:", errors)}
+    />
+  );
+}
+```
+
+### Customizing fields, layout, and async validation
+
+```tsx
+<AutoForm
+  schema={schema}
+  fields={[
+    { name: "name", label: "Full Name", placeholder: "Jane Doe", colSpan: 6 },
+    { name: "email", label: "Email", placeholder: "jane@example.com", colSpan: 6 },
+    { name: "message", type: "textarea", label: "Message", colSpan: 12 },
+  ]}
+  layout="grid"
+  columns={12}
+  fieldValidators={{
+    email: { onChangeAsync: checkEmailAvailable, asyncDebounceMs: 500 },
+  }}
+  onSubmit={handleSubmit}
+/>
+```
+
+Common field config keys: `name`, `type` ("text" | "email" | "password" |
+"number" | "textarea" | "select" | ...), `label`, `placeholder`, `colSpan`,
+`required`, `min`, `max`, `rows`, `options` (for selects).
+
+### Custom error component
+
+```tsx
+import type { AutoFormErrorProps } from "el-form-react-components";
+
+const ErrorList: React.FC<AutoFormErrorProps> = ({ errors, touched }) => {
+  const entries = Object.entries(errors).filter(([f]) => touched[f]);
+  if (entries.length === 0) return null;
+  return (
+    <ul>
+      {entries.map(([field, error]) => (
+        <li key={field}>{field}: {error}</li>
+      ))}
+    </ul>
+  );
+};
+
+<AutoForm schema={schema} customErrorComponent={ErrorList} onSubmit={handleSubmit} />;
+```
+
+--------------------------------------------------------------------------------
+## useForm — full control
+
+```tsx
+import { useForm } from "el-form-react-hooks";
+import { z } from "zod";
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+});
+
+export function LoginForm() {
+  const { register, handleSubmit, formState } = useForm({
+    validators: { onChange: schema },
+    defaultValues: { email: "", password: "" },
+  });
+
+  return (
+    <form onSubmit={handleSubmit((data) => console.log(data))}>
+      <input {...register("email")} placeholder="Email" />
+      {formState.errors.email && <span>{formState.errors.email}</span>}
+
+      <input {...register("password")} type="password" placeholder="Password" />
+      {formState.errors.password && <span>{formState.errors.password}</span>}
+
+      <button type="submit" disabled={formState.isSubmitting}>
+        {formState.isSubmitting ? "Signing in..." : "Sign In"}
+      </button>
+    </form>
+  );
+}
+```
+
+`useForm` returns (most-used): `register`, `handleSubmit`, `formState`
+(`errors`, `touched`, `isDirty`, `isSubmitting`, `isValid`), `watch`,
+`setError`, `clearErrors`, `reset`, `setValue`, `getValues`.
+
+Validation triggers are configured per event:
+
+```tsx
+useForm({ validators: { onChange: schema } }); // validate on change
+useForm({ validators: { onBlur: schema } });   // validate on blur
+useForm({ validators: { onSubmit: schema } }); // validate on submit
+```
+
+--------------------------------------------------------------------------------
+## Validation approaches
+
+```tsx
+// Zod (recommended)
+const form = useForm({ validators: { onChange: zodSchema } });
+
+// Yup
+import * as yup from "yup";
+const yupSchema = yup.object({ name: yup.string().required() });
+const form = useForm({ validators: { onChange: yupSchema } });
+
+// Valibot
+import * as v from "valibot";
+const valibotSchema = v.object({ name: v.pipe(v.string(), v.minLength(1)) });
+const form = useForm({ validators: { onChange: valibotSchema } });
+
+// Custom function — return a message string (or undefined when valid)
+const form = useForm({
+  validators: {
+    onChange: ({ values }) =>
+      values.email?.includes("@") ? undefined : "Invalid email",
+  },
+});
+
+// No validation — just state management
+const form = useForm({ defaultValues: { email: "" } });
+```
+
+--------------------------------------------------------------------------------
+## Error handling
+
+```tsx
+const { setError, clearErrors, formState } = useForm();
+
+setError("email", "This email is already taken"); // field error
+setError("general", "Something went wrong");        // form-level error
+clearErrors("email"); // clear one
+clearErrors();        // clear all
+
+// API errors on submit
+const onSubmit = async (data) => {
+  try {
+    await submit(data);
+  } catch (err) {
+    if (err.fieldErrors) {
+      Object.entries(err.fieldErrors).forEach(([f, m]) => setError(f, m as string));
+    } else {
+      setError("general", "Submission failed. Please try again.");
+    }
+  }
+};
+```
+
+--------------------------------------------------------------------------------
+## Reusable field components
+
+```tsx
+import { FormProvider, useFormContext } from "el-form-react-hooks";
+
+function Field({ name, label }) {
+  const { register, formState } = useFormContext();
+  return (
+    <label>
+      {label}
+      <input {...register(name)} />
+      {formState.errors[name] && <span>{formState.errors[name]}</span>}
+    </label>
+  );
+}
+
+function App() {
+  const form = useForm({ defaultValues: { email: "" } });
+  return (
+    <FormProvider form={form}>
+      <form onSubmit={form.handleSubmit(console.log)}>
+        <Field name="email" label="Email" />
+      </form>
+    </FormProvider>
+  );
+}
+```
+
+Three reusability patterns are supported: **context** (`FormProvider` +
+`useFormContext`), **prop-passing** (`<Field form={form} />`), and **hybrid**
+(`form || useFormContext()`).
+
+--------------------------------------------------------------------------------
+## Links
+
+- Docs: https://elform.dev/docs/intro
+- Index for LLMs: https://elform.dev/llms.txt
+- GitHub: https://github.com/colorpulse6/el-form
+- npm: https://www.npmjs.com/package/el-form-react
+- MCP server: `npx el-form-mcp`

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -1,0 +1,55 @@
+# El Form
+
+> El Form is a TypeScript-first, schema-agnostic React form library. It offers two complementary APIs: **AutoForm**, which generates a complete, validated, styled form from a schema with zero boilerplate; and **useForm**, a React Hook Form–compatible hook for full programmatic control. Validation is pluggable — use Zod (v3 or v4), Yup, Valibot, a custom function, or none at all — without rewriting the form.
+
+Install everything with `npm install el-form-react`. The library is modular, so you can install only the layer you need.
+
+Key facts:
+- AutoForm: `import { AutoForm } from "el-form-react-components"` — pass a `schema`, get a working form. Import `"el-form-react-components/styles.css"` for zero-config styling.
+- useForm: `import { useForm } from "el-form-react-hooks"` — `register`, `handleSubmit`, `formState`, `watch`, `setError`, `clearErrors` (familiar React Hook Form API).
+- Validation-agnostic: Zod (v3 + v4), Yup, Valibot, custom validators, or no validation. Validation libraries are optional peer installs.
+- TypeScript-first with strong inference. Works with Next.js, Vite, Remix, CRA. React 18+.
+- MIT licensed. Repo: https://github.com/colorpulse6/el-form
+
+## Packages
+- `el-form-react`: everything (hooks + components + styles) — recommended default.
+- `el-form-react-hooks`: `useForm`, `FormProvider`, `useField` — for custom forms.
+- `el-form-react-components`: `AutoForm` + prebuilt field components.
+- `el-form-core`: framework-agnostic validation engine (build your own bindings).
+
+## Docs
+- [Introduction](https://elform.dev/docs/intro): What El Form is and when to use AutoForm vs useForm.
+- [Quick Start](https://elform.dev/docs/quick-start): Build your first form in a few minutes.
+- [Installation](https://elform.dev/docs/installation): Choosing a package, optional validators, styling.
+- [Examples](https://elform.dev/docs/examples): Common real-world form patterns.
+- [Field Types](https://elform.dev/docs/field-types): How schema types map to inputs.
+- [FAQ](https://elform.dev/docs/faq): Common questions and gotchas.
+
+## API
+- [API Overview](https://elform.dev/docs/api/overview): All exports at a glance.
+- [useForm](https://elform.dev/docs/api/use-form): Options, returned state, and methods.
+- [AutoForm](https://elform.dev/docs/api/auto-form): Props, field config, layout, custom components.
+- [Field Components](https://elform.dev/docs/api/field-components): Built-in field building blocks.
+- [FormProvider](https://elform.dev/docs/api/form-provider): Sharing a form instance via context.
+
+## Concepts
+- [Philosophy](https://elform.dev/docs/concepts/philosophy): Design goals and trade-offs.
+- [Validation](https://elform.dev/docs/concepts/validation): Schema-agnostic validation in depth.
+- [Form State](https://elform.dev/docs/concepts/form-state): values, errors, touched, dirty, submission.
+- [Component Reusability](https://elform.dev/docs/concepts/component-reusability): Context, prop-passing, hybrid.
+- [Performance](https://elform.dev/docs/concepts/performance): Minimizing re-renders.
+
+## Guides
+- [useForm Guide](https://elform.dev/docs/guides/use-form): Full control over custom forms.
+- [AutoForm Guide](https://elform.dev/docs/guides/auto-form): Customizing generated forms.
+- [Error Handling](https://elform.dev/docs/guides/error-handling): Field, form, and API errors.
+- [Array Fields](https://elform.dev/docs/guides/array-fields): Dynamic, repeatable field groups.
+- [Async Validation](https://elform.dev/docs/guides/async-validation): Debounced server-side checks.
+- [Conditional Rendering](https://elform.dev/docs/guides/conditional-rendering): Show/hide fields by state.
+- [Custom Components](https://elform.dev/docs/guides/custom-components): Bring your own inputs.
+- [UI Library Integration](https://elform.dev/docs/guides/integration-with-ui-libraries): MUI, shadcn/ui, etc.
+
+## Optional
+- [GitHub repository](https://github.com/colorpulse6/el-form): Source, issues, changelog.
+- [npm: el-form-react](https://www.npmjs.com/package/el-form-react): Package and versions.
+- [Full reference for LLMs](https://elform.dev/llms-full.txt): Self-contained usage doc.

--- a/launch/devto-article.md
+++ b/launch/devto-article.md
@@ -1,0 +1,142 @@
+---
+title: "Type-safe React forms without the boilerplate: a tour of El Form"
+published: false
+description: "El Form gives you AutoForm (generate a form from a schema) and a React Hook Form–compatible useForm hook — with pluggable Zod/Yup/Valibot validation."
+tags: react, typescript, webdev, forms
+canonical_url: https://elform.dev
+cover_image: ""
+---
+
+> Draft for dev.to. Set `published: true` when you're ready, add a `cover_image`
+> URL (1000×420), and double-check the canonical URL. Posting via the dev.to
+> editor preserves this frontmatter.
+
+Forms are where a lot of React apps get tedious: wire up state, wire up
+validation, wire up error display, repeat. I built **[El Form](https://elform.dev)**
+to collapse that work while still letting you drop down to full control when a
+form gets weird.
+
+It has two APIs over one core, and validation is pluggable (Zod, Yup, Valibot, a
+function, or nothing). Let's build something with each.
+
+## Install
+
+```bash
+npm install el-form-react zod
+```
+
+`el-form-react` bundles the hooks and components. `el-form-react-hooks`,
+`el-form-react-components`, and `el-form-core` are available separately if you
+want to install only one layer.
+
+## 1. AutoForm: a full form from a schema
+
+Define a schema, render `<AutoForm />`, done — validation, error display, and
+styling included.
+
+```tsx
+import { AutoForm } from "el-form-react-components";
+import "el-form-react-components/styles.css";
+import { z } from "zod";
+
+const signupSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  email: z.string().email("Enter a valid email"),
+  age: z.number().min(18, "Must be 18 or older"),
+});
+
+export function Signup() {
+  return (
+    <AutoForm
+      schema={signupSchema}
+      onSubmit={(data) => console.log("✅", data)}
+      onError={(errors) => console.log("❌", errors)}
+    />
+  );
+}
+```
+
+Need to tweak the layout or labels? Pass `fields`:
+
+```tsx
+<AutoForm
+  schema={signupSchema}
+  fields={[
+    { name: "name", label: "Full name", colSpan: 6 },
+    { name: "email", label: "Email", colSpan: 6 },
+    { name: "age", label: "Age", type: "number", colSpan: 12 },
+  ]}
+  layout="grid"
+  columns={12}
+  onSubmit={(data) => console.log(data)}
+/>
+```
+
+## 2. useForm: full control
+
+When you want to render every input yourself, `useForm` gives you a familiar
+React Hook Form–style API:
+
+```tsx
+import { useForm } from "el-form-react-hooks";
+import { z } from "zod";
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8, "At least 8 characters"),
+});
+
+export function Login() {
+  const { register, handleSubmit, formState } = useForm({
+    validators: { onChange: schema },
+    defaultValues: { email: "", password: "" },
+  });
+
+  return (
+    <form onSubmit={handleSubmit((data) => console.log(data))}>
+      <input {...register("email")} placeholder="Email" />
+      {formState.errors.email && <small>{formState.errors.email}</small>}
+
+      <input {...register("password")} type="password" placeholder="Password" />
+      {formState.errors.password && <small>{formState.errors.password}</small>}
+
+      <button disabled={formState.isSubmitting}>Sign in</button>
+    </form>
+  );
+}
+```
+
+## 3. Bring your own validation
+
+The same form works with Zod, Yup, Valibot, a plain function, or nothing — swap
+the validator without touching the rest of the form:
+
+```tsx
+// Custom function: return a message string, or undefined when valid
+const form = useForm({
+  validators: {
+    onChange: ({ values }) =>
+      values.email?.includes("@") ? undefined : "Invalid email",
+  },
+  defaultValues: { email: "" },
+});
+```
+
+Zod v3 and v4 are both supported, so you're not forced to migrate schemas to
+adopt the library.
+
+## When should you use it?
+
+- **Reach for AutoForm** when the form is "render these fields, validate, submit."
+- **Reach for useForm** when you need custom markup, conditional fields, or
+  multi-step flows.
+- **Stick with React Hook Form** if you're happy with it and don't need AutoForm
+  or validator-swapping — El Form's useForm is intentionally close to it.
+
+## Try it
+
+- Docs: https://elform.dev
+- GitHub (MIT): https://github.com/colorpulse6/el-form
+
+If you build something with it, I'd love to hear what worked and what didn't —
+the API is still young and feedback genuinely shapes it.

--- a/launch/reddit-reactjs.md
+++ b/launch/reddit-reactjs.md
@@ -1,0 +1,61 @@
+# r/reactjs draft
+
+> Post at https://www.reddit.com/r/reactjs/submit
+> Read the rules first. r/reactjs allows "I made this" posts but they must add
+> value and use the right flair. If there's a pinned "Show off Saturday" /
+> "Beginner's Thread", consider posting there too.
+> Suggested flair: "Show /r/reactjs" (or "Resource").
+
+## Title
+
+```
+I built El Form – a schema-agnostic React form library (Zod/Yup/Valibot) with an AutoForm generator
+```
+
+## Body
+
+I've been working on **El Form**, a TypeScript-first form library, and I'd love
+feedback from people who build a lot of forms.
+
+The idea is one consistent API with two entry points:
+
+- **AutoForm** — give it a schema, get a full validated form. Zero boilerplate:
+
+```tsx
+import { AutoForm } from "el-form-react-components";
+import "el-form-react-components/styles.css";
+import { z } from "zod";
+
+const schema = z.object({
+  name: z.string().min(1, "Name is required"),
+  email: z.string().email("Invalid email"),
+});
+
+<AutoForm schema={schema} onSubmit={(data) => console.log(data)} />;
+```
+
+- **useForm** — a React Hook Form–style hook when you want to render every input
+  yourself (`register`, `handleSubmit`, `formState`, `watch`, `setError`, ...).
+
+The thing I most wanted: **validation is pluggable**. Zod (v3 and v4), Yup,
+Valibot, a custom function, or no validation at all — and you can switch without
+rewriting the form. Packages are modular so you only bundle what you use.
+
+It's MIT and tested against Zod v3 + v4 in CI.
+
+- Docs: https://elform.dev
+- GitHub: https://github.com/colorpulse6/el-form
+
+Questions I'd love answers to:
+1. Is AutoForm's field-config API intuitive, or would you rather compose fields manually?
+2. Anything that would stop you from trying it over React Hook Form?
+3. Which validation library do you actually reach for these days?
+
+Not trying to claim it beats the incumbents — just scratching an itch and looking
+for honest critique. Thanks!
+
+## Tips
+
+- Engage in the comments quickly and genuinely; r/reactjs downvotes drive-by promo.
+- Don't cross-post the identical text to 5 subreddits the same hour — it reads as spam.
+- Good fit beyond r/reactjs: r/webdev (Showoff Saturday), r/typescript.

--- a/launch/show-hn.md
+++ b/launch/show-hn.md
@@ -1,0 +1,63 @@
+# Show HN draft
+
+> Post at https://news.ycombinator.com/submit
+> Title must start with "Show HN:". Keep it under 80 chars.
+> First comment (posted by you, right after submitting) carries the context.
+
+## Title
+
+```
+Show HN: El Form – type-safe React forms with zero-boilerplate AutoForm
+```
+
+## URL
+
+```
+https://elform.dev
+```
+
+## First comment (post immediately after submitting)
+
+Hi HN, I'm the author. El Form is a React form library I've been building solo.
+It has two APIs that share one core:
+
+- **AutoForm** generates a complete, validated, styled form from a schema
+  (`<AutoForm schema={schema} onSubmit={...} />`). Good for the 80% of forms
+  that are "render these fields, validate, submit."
+- **useForm** is a React Hook Form–compatible hook for when you want to lay out
+  every input yourself.
+
+The part I cared most about: validation is **schema-agnostic**. You can use Zod
+(v3 or v4), Yup, Valibot, a plain function, or nothing — and switch between them
+without rewriting the form. The packages are split so you only ship what you use
+(`el-form-core` is ~4KB, the full `el-form-react` ~29KB).
+
+```tsx
+import { AutoForm } from "el-form-react-components";
+import { z } from "zod";
+
+const schema = z.object({
+  email: z.string().email(),
+  age: z.number().min(18),
+});
+
+<AutoForm schema={schema} onSubmit={(data) => console.log(data)} />;
+```
+
+Why another form library when React Hook Form exists? Two reasons: I wanted
+AutoForm-style generation and full-control hooks under one consistent API, and I
+wanted to never be locked to a single validation library. If those don't matter
+to you, RHF is great and you should use it.
+
+It's MIT, TypeScript-first, and tested against Zod v3 and v4 in CI. Docs:
+https://elform.dev — Repo: https://github.com/colorpulse6/el-form
+
+Honest status: it's young and low-traffic, so I'd genuinely value feedback on the
+API, the AutoForm field-config ergonomics, and anything that feels off. Happy to
+answer questions.
+
+## Tips
+
+- Best days/times: Tue–Thu, ~8–10am ET. Avoid weekends.
+- Don't ask for upvotes anywhere — against HN rules.
+- Reply to every comment; the discussion is the point.

--- a/packages/el-form-mcp/README.md
+++ b/packages/el-form-mcp/README.md
@@ -1,0 +1,72 @@
+# el-form-mcp
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server that gives AI
+agents accurate, up-to-date knowledge of [El Form](https://elform.dev) — plus a
+tool that generates ready-to-paste form code.
+
+## Why
+
+If an agent is scaffolding a React form, this server lets it pull El Form's real
+API and emit correct code instead of guessing.
+
+## Run
+
+```bash
+npx el-form-mcp
+```
+
+The server speaks MCP over stdio.
+
+## Use it from an MCP client
+
+**Claude Desktop / Claude Code** (`mcpServers` config):
+
+```json
+{
+  "mcpServers": {
+    "el-form": {
+      "command": "npx",
+      "args": ["-y", "el-form-mcp"]
+    }
+  }
+}
+```
+
+## Tools
+
+| Tool | Description |
+| ---- | ----------- |
+| `el_form_overview` | What El Form is, the two APIs, packages, install commands. |
+| `el_form_list_topics` | List the documentation topics available. |
+| `el_form_get_topic` | Full text of one topic (installation, autoform, useform, validation, error-handling, reusability, field-types, faq). |
+| `el_form_search` | Keyword search across the docs; returns the most relevant sections. |
+| `el_form_scaffold_form` | Generate AutoForm or useForm code + a matching Zod schema from a list of fields. |
+
+### Example: `el_form_scaffold_form`
+
+Input:
+
+```json
+{
+  "api": "autoform",
+  "fields": [
+    { "name": "email", "type": "email", "label": "Email" },
+    { "name": "role", "type": "select", "label": "Role", "options": ["admin", "user"] },
+    { "name": "bio", "type": "textarea", "optional": true }
+  ]
+}
+```
+
+Returns a complete `<AutoForm>` component with a generated Zod schema.
+
+## Develop
+
+```bash
+pnpm install
+pnpm --filter el-form-mcp build
+pnpm --filter el-form-mcp start
+```
+
+## License
+
+MIT

--- a/packages/el-form-mcp/package.json
+++ b/packages/el-form-mcp/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "el-form-mcp",
+  "version": "0.1.0",
+  "description": "Model Context Protocol (MCP) server that exposes El Form docs and code generation to AI agents.",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "el-form-mcp": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "start": "node dist/index.js",
+    "type-check": "tsc --noEmit"
+  },
+  "keywords": [
+    "el-form",
+    "mcp",
+    "model-context-protocol",
+    "react",
+    "forms",
+    "ai",
+    "llm"
+  ],
+  "author": "",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/colorpulse6/el-form.git",
+    "directory": "packages/el-form-mcp"
+  },
+  "homepage": "https://elform.dev",
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsup": "^8.5.0",
+    "typescript": "^5.8.3"
+  }
+}

--- a/packages/el-form-mcp/src/index.ts
+++ b/packages/el-form-mcp/src/index.ts
@@ -1,0 +1,207 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type CallToolResult,
+  type Tool,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  OVERVIEW,
+  getTopic,
+  listTopics,
+  searchKnowledge,
+} from "./knowledge.js";
+import { scaffoldForm, type FieldSpec } from "./scaffold.js";
+
+const TOPIC_KEYS = listTopics().map((t) => t.key);
+
+const TOOLS: Tool[] = [
+  {
+    name: "el_form_overview",
+    description:
+      "Get a high-level overview of El Form (what it is, the two APIs, packages) plus install commands. Call this first when you need to use El Form.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "el_form_list_topics",
+    description:
+      "List the available El Form documentation topics that can be fetched with el_form_get_topic.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "el_form_get_topic",
+    description:
+      "Get the full text of one El Form documentation topic (installation, autoform, useform, validation, error-handling, reusability, field-types, faq).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        topic: {
+          type: "string",
+          enum: TOPIC_KEYS,
+          description: "Topic key from el_form_list_topics.",
+        },
+      },
+      required: ["topic"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "el_form_search",
+    description:
+      "Search El Form docs for a keyword or phrase and return the most relevant topic sections.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Search terms, e.g. 'async validation' or 'array fields'.",
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "el_form_scaffold_form",
+    description:
+      "Generate ready-to-paste El Form code (AutoForm or useForm) plus a matching Zod schema from a list of fields.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        fields: {
+          type: "array",
+          minItems: 1,
+          description: "The form fields to generate.",
+          items: {
+            type: "object",
+            properties: {
+              name: { type: "string", description: "Field key, e.g. 'email'." },
+              type: {
+                type: "string",
+                enum: [
+                  "text",
+                  "email",
+                  "password",
+                  "number",
+                  "textarea",
+                  "checkbox",
+                  "select",
+                  "date",
+                  "url",
+                  "tel",
+                ],
+                description: "Input type (default 'text').",
+              },
+              label: {
+                type: "string",
+                description: "Human label (defaults to a humanized name).",
+              },
+              optional: {
+                type: "boolean",
+                description: "If true, the field is not required.",
+              },
+              options: {
+                type: "array",
+                items: { type: "string" },
+                description: "Choices for a 'select' field.",
+              },
+            },
+            required: ["name"],
+            additionalProperties: false,
+          },
+        },
+        api: {
+          type: "string",
+          enum: ["autoform", "useform"],
+          description: "Which API to generate (default 'autoform').",
+        },
+      },
+      required: ["fields"],
+      additionalProperties: false,
+    },
+  },
+];
+
+function text(value: string, isError = false): CallToolResult {
+  return { content: [{ type: "text", text: value }], isError };
+}
+
+const server = new Server(
+  { name: "el-form-mcp", version: "0.1.0" },
+  { capabilities: { tools: {} } }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (request): Promise<CallToolResult> => {
+  const { name } = request.params;
+  const args = (request.params.arguments ?? {}) as Record<string, unknown>;
+
+  try {
+    switch (name) {
+      case "el_form_overview":
+        return text(OVERVIEW);
+
+      case "el_form_list_topics": {
+        const list = listTopics()
+          .map((t) => `- ${t.key}: ${t.title}`)
+          .join("\n");
+        return text(`Available topics (fetch with el_form_get_topic):\n\n${list}`);
+      }
+
+      case "el_form_get_topic": {
+        const topic = getTopic(String(args.topic ?? ""));
+        if (!topic) {
+          return text(
+            `Unknown topic "${String(args.topic ?? "")}". Use el_form_list_topics.`,
+            true
+          );
+        }
+        return text(`# ${topic.title}\n\n${topic.content}`);
+      }
+
+      case "el_form_search": {
+        const query = String(args.query ?? "").trim();
+        if (!query) return text("Provide a non-empty 'query'.", true);
+        const hits = searchKnowledge(query);
+        if (hits.length === 0) {
+          return text(`No matches for "${query}". Try el_form_list_topics.`);
+        }
+        const body = hits
+          .map((h) => `## ${h.title} (${h.key})\n\n${h.snippet}`)
+          .join("\n\n---\n\n");
+        return text(body);
+      }
+
+      case "el_form_scaffold_form": {
+        const fields = args.fields as FieldSpec[] | undefined;
+        const api = (args.api === "useform" ? "useform" : "autoform") as
+          | "autoform"
+          | "useform";
+        if (!Array.isArray(fields) || fields.length === 0) {
+          return text("Provide a non-empty 'fields' array.", true);
+        }
+        const code = scaffoldForm(fields, api);
+        return text("```tsx\n" + code + "\n```");
+      }
+
+      default:
+        return text(`Unknown tool: ${name}`, true);
+    }
+  } catch (err) {
+    return text(`Error: ${(err as Error).message}`, true);
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  // stdout is the protocol channel; log to stderr only.
+  console.error("el-form-mcp running on stdio");
+}
+
+main().catch((err) => {
+  console.error("el-form-mcp fatal:", err);
+  process.exit(1);
+});

--- a/packages/el-form-mcp/src/knowledge.ts
+++ b/packages/el-form-mcp/src/knowledge.ts
@@ -1,0 +1,293 @@
+// Embedded El Form knowledge served by the MCP server. Kept dependency-free and
+// backtick-free so the strings stay simple; code samples use indentation.
+
+export interface Topic {
+  key: string;
+  title: string;
+  content: string;
+}
+
+export const OVERVIEW = [
+  "El Form is a TypeScript-first, schema-agnostic React form library.",
+  "",
+  "Two APIs over one core:",
+  "  - AutoForm: generate a complete, validated, styled form from a schema.",
+  "  - useForm: a React Hook Form-compatible hook for fully custom forms.",
+  "",
+  "Install everything:  npm install el-form-react",
+  "Validation is pluggable: Zod (v3 or v4), Yup, Valibot, a custom function, or none.",
+  "",
+  "Next steps for an agent:",
+  "  - el_form_list_topics / el_form_get_topic for details.",
+  "  - el_form_search to find a specific guide.",
+  "  - el_form_scaffold_form to generate ready-to-paste code from a field list.",
+  "",
+  "Docs: https://elform.dev  |  Full reference: https://elform.dev/llms-full.txt",
+].join("\n");
+
+export const KNOWLEDGE: Topic[] = [
+  {
+    key: "installation",
+    title: "Installation",
+    content: [
+      "El Form is modular. Pick a package:",
+      "",
+      "  npm install el-form-react             (everything: hooks + components + styles)",
+      "  npm install el-form-react-hooks       (useForm, FormProvider, useField)",
+      "  npm install el-form-react-components  (AutoForm + prebuilt fields)",
+      "  npm install el-form-core              (framework-agnostic engine)",
+      "",
+      "Validation libraries are optional peer installs:",
+      "  npm install zod      (recommended; v3 and v4 supported)",
+      "  npm install yup",
+      "  npm install valibot",
+      "",
+      "Peer requirement: React 18+ (the hooks API works with 16.8+).",
+      "Works with Next.js, Vite, Remix, CRA.",
+      'For AutoForm styling, also import "el-form-react-components/styles.css".',
+    ].join("\n"),
+  },
+  {
+    key: "autoform",
+    title: "AutoForm",
+    content: [
+      "AutoForm generates a full validated, styled form from a schema.",
+      "",
+      '  import { AutoForm } from "el-form-react-components";',
+      '  import "el-form-react-components/styles.css";',
+      '  import { z } from "zod";',
+      "",
+      "  const schema = z.object({",
+      '    name: z.string().min(1, "Name is required"),',
+      '    email: z.string().email("Invalid email"),',
+      "  });",
+      "",
+      "  export function ContactForm() {",
+      "    return (",
+      "      <AutoForm",
+      "        schema={schema}",
+      "        onSubmit={(data) => console.log(data)}",
+      "        onError={(errors) => console.log(errors)}",
+      "      />",
+      "    );",
+      "  }",
+      "",
+      "Customize with the fields prop and a grid layout:",
+      "",
+      "  <AutoForm",
+      "    schema={schema}",
+      "    fields={[",
+      '      { name: "name", label: "Full name", colSpan: 6 },',
+      '      { name: "email", label: "Email", colSpan: 6 },',
+      '      { name: "bio", type: "textarea", label: "Bio", colSpan: 12 },',
+      "    ]}",
+      '    layout="grid"',
+      "    columns={12}",
+      "    onSubmit={handleSubmit}",
+      "  />",
+      "",
+      "Common field keys: name, type, label, placeholder, colSpan, required, min, max, rows, options.",
+      "Async field validation: fieldValidators={{ email: { onChangeAsync: check, asyncDebounceMs: 500 } }}.",
+      "Custom error UI: pass customErrorComponent (props: { errors, touched }).",
+    ].join("\n"),
+  },
+  {
+    key: "useform",
+    title: "useForm",
+    content: [
+      "useForm is a React Hook Form-compatible hook for fully custom forms.",
+      "",
+      '  import { useForm } from "el-form-react-hooks";',
+      '  import { z } from "zod";',
+      "",
+      "  const schema = z.object({",
+      "    email: z.string().email(),",
+      "    password: z.string().min(8),",
+      "  });",
+      "",
+      "  export function LoginForm() {",
+      "    const { register, handleSubmit, formState } = useForm({",
+      "      validators: { onChange: schema },",
+      '      defaultValues: { email: "", password: "" },',
+      "    });",
+      "",
+      "    return (",
+      "      <form onSubmit={handleSubmit((data) => console.log(data))}>",
+      '        <input {...register("email")} placeholder="Email" />',
+      "        {formState.errors.email && <span>{formState.errors.email}</span>}",
+      '        <input {...register("password")} type="password" />',
+      "        {formState.errors.password && <span>{formState.errors.password}</span>}",
+      "        <button disabled={formState.isSubmitting}>Sign in</button>",
+      "      </form>",
+      "    );",
+      "  }",
+      "",
+      "Returns: register, handleSubmit, formState (errors, touched, isDirty, isSubmitting,",
+      "isValid), watch, setError, clearErrors, reset, setValue, getValues.",
+      "Validation triggers: validators: { onChange | onBlur | onSubmit: schema }.",
+    ].join("\n"),
+  },
+  {
+    key: "validation",
+    title: "Validation",
+    content: [
+      "Validation is pluggable. The same form works with any of these:",
+      "",
+      "  // Zod (recommended; v3 and v4)",
+      "  useForm({ validators: { onChange: zodSchema } });",
+      "",
+      "  // Yup",
+      '  import * as yup from "yup";',
+      "  useForm({ validators: { onChange: yup.object({ name: yup.string().required() }) } });",
+      "",
+      "  // Valibot",
+      '  import * as v from "valibot";',
+      "  useForm({ validators: { onChange: v.object({ name: v.pipe(v.string(), v.minLength(1)) }) } });",
+      "",
+      "  // Custom function: return a message string, or undefined when valid",
+      '  useForm({ validators: { onChange: ({ values }) => values.email?.includes("@") ? undefined : "Invalid email" } });',
+      "",
+      "  // No validation (state only)",
+      '  useForm({ defaultValues: { email: "" } });',
+      "",
+      "Mix a schema with per-field async validators via fieldValidators.",
+    ].join("\n"),
+  },
+  {
+    key: "error-handling",
+    title: "Error handling",
+    content: [
+      "AutoForm shows errors automatically. For manual control:",
+      "",
+      "  const { setError, clearErrors, formState } = useForm();",
+      "",
+      '  setError("email", "This email is already taken");  // field error',
+      '  setError("general", "Something went wrong");         // form-level error',
+      '  clearErrors("email");  // clear one',
+      "  clearErrors();         // clear all",
+      "",
+      "Handling API errors on submit:",
+      "",
+      "  const onSubmit = async (data) => {",
+      "    try {",
+      "      await submit(data);",
+      "    } catch (err) {",
+      "      if (err.fieldErrors) {",
+      "        Object.entries(err.fieldErrors).forEach(([f, m]) => setError(f, m));",
+      "      } else {",
+      '        setError("general", "Submission failed. Please try again.");',
+      "      }",
+      "    }",
+      "  };",
+      "",
+      "AutoForm custom error component receives { errors, touched }.",
+    ].join("\n"),
+  },
+  {
+    key: "reusability",
+    title: "Reusable field components",
+    content: [
+      "Three patterns for reusable fields:",
+      "",
+      "  // 1. Context (TanStack-style)",
+      '  import { FormProvider, useFormContext } from "el-form-react-hooks";',
+      "  function Field({ name, label }) {",
+      "    const { register, formState } = useFormContext();",
+      "    return (",
+      "      <label>{label}",
+      "        <input {...register(name)} />",
+      "        {formState.errors[name] && <span>{formState.errors[name]}</span>}",
+      "      </label>",
+      "    );",
+      "  }",
+      "  <FormProvider form={form}><Field name=\"email\" label=\"Email\" /></FormProvider>",
+      "",
+      "  // 2. Prop-passing (Conform-style)",
+      '  <Field name="email" label="Email" form={form} />',
+      "",
+      "  // 3. Hybrid",
+      "  const active = form || useFormContext();",
+    ].join("\n"),
+  },
+  {
+    key: "field-types",
+    title: "Field types",
+    content: [
+      "AutoForm infers inputs from your schema; override per field with the type key.",
+      "Supported types include:",
+      "  text, email, password, number, textarea, select, checkbox, date, url, tel.",
+      "",
+      "Selects take options:",
+      '  { name: "role", type: "select", label: "Role", options: ["admin", "user"] }',
+      "",
+      "Numbers accept min/max; textareas accept rows.",
+    ].join("\n"),
+  },
+  {
+    key: "faq",
+    title: "FAQ",
+    content: [
+      "- Zod 3 or 4? Both work. Use 4 for new projects; 3 is fine (e.g. some Astro setups).",
+      "- Need a validation library? No. Use a custom function or none.",
+      "- Like React Hook Form? useForm is intentionally close (register/handleSubmit/formState).",
+      "  AutoForm is the extra: generate the whole form from a schema.",
+      '- Styling? Import "el-form-react-components/styles.css", or use your own classNames.',
+      "- TypeScript? First-class; types infer from your schema. JS works too.",
+      "- Bundle size: el-form-core ~4KB, el-form-react ~29KB.",
+    ].join("\n"),
+  },
+];
+
+export function listTopics(): { key: string; title: string }[] {
+  return KNOWLEDGE.map((t) => ({ key: t.key, title: t.title }));
+}
+
+export function getTopic(key: string): Topic | undefined {
+  return KNOWLEDGE.find((t) => t.key === key.trim().toLowerCase());
+}
+
+export interface SearchHit {
+  key: string;
+  title: string;
+  snippet: string;
+  score: number;
+}
+
+export function searchKnowledge(query: string): SearchHit[] {
+  const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return [];
+  const hits: SearchHit[] = [];
+  for (const topic of KNOWLEDGE) {
+    const haystack = (topic.title + "\n" + topic.content).toLowerCase();
+    let score = 0;
+    for (const tok of tokens) {
+      let idx = haystack.indexOf(tok);
+      while (idx !== -1) {
+        score += 1;
+        idx = haystack.indexOf(tok, idx + tok.length);
+      }
+    }
+    if (score > 0) {
+      hits.push({
+        key: topic.key,
+        title: topic.title,
+        score,
+        snippet: makeSnippet(topic.content, tokens),
+      });
+    }
+  }
+  return hits.sort((a, b) => b.score - a.score).slice(0, 4);
+}
+
+function makeSnippet(content: string, tokens: string[]): string {
+  const lower = content.toLowerCase();
+  let first = -1;
+  for (const tok of tokens) {
+    const i = lower.indexOf(tok);
+    if (i !== -1 && (first === -1 || i < first)) first = i;
+  }
+  if (first === -1) return content.slice(0, 320);
+  const start = Math.max(0, first - 80);
+  const end = Math.min(content.length, first + 320);
+  return (start > 0 ? "..." : "") + content.slice(start, end) + (end < content.length ? "..." : "");
+}

--- a/packages/el-form-mcp/src/scaffold.ts
+++ b/packages/el-form-mcp/src/scaffold.ts
@@ -1,0 +1,198 @@
+// Deterministic El Form code generation from a simple field spec.
+
+export type FieldType =
+  | "text"
+  | "email"
+  | "password"
+  | "number"
+  | "textarea"
+  | "checkbox"
+  | "select"
+  | "date"
+  | "url"
+  | "tel";
+
+export interface FieldSpec {
+  name: string;
+  type?: FieldType;
+  label?: string;
+  optional?: boolean;
+  options?: string[];
+}
+
+export function scaffoldForm(
+  fields: FieldSpec[],
+  api: "autoform" | "useform" = "autoform"
+): string {
+  return api === "useform" ? scaffoldUseForm(fields) : scaffoldAutoForm(fields);
+}
+
+function humanize(name: string): string {
+  return name
+    .replace(/[_-]+/g, " ")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function zodForField(f: FieldSpec): string {
+  const label = f.label ?? humanize(f.name);
+  let base: string;
+  switch (f.type) {
+    case "number":
+      base = "z.number()";
+      break;
+    case "email":
+      base = 'z.string().email("Enter a valid email")';
+      break;
+    case "url":
+      base = 'z.string().url("Enter a valid URL")';
+      break;
+    case "checkbox":
+      base = "z.boolean()";
+      break;
+    case "date":
+      base = "z.string()";
+      break;
+    case "select":
+      if (f.options && f.options.length > 0) {
+        base = `z.enum([${f.options.map((o) => JSON.stringify(o)).join(", ")}])`;
+      } else {
+        base = "z.string()";
+      }
+      break;
+    case "password":
+      base = `z.string().min(8, ${JSON.stringify(`${label} must be at least 8 characters`)})`;
+      break;
+    case "textarea":
+    case "text":
+    case "tel":
+    default:
+      base = `z.string().min(1, ${JSON.stringify(`${label} is required`)})`;
+      break;
+  }
+  if (f.optional) {
+    if (base.startsWith("z.string().min(1")) base = "z.string()";
+    base += ".optional()";
+  }
+  return base;
+}
+
+function buildSchema(fields: FieldSpec[]): string {
+  const lines = fields.map((f) => `  ${f.name}: ${zodForField(f)},`);
+  return `const schema = z.object({\n${lines.join("\n")}\n});`;
+}
+
+function scaffoldAutoForm(fields: FieldSpec[]): string {
+  const fieldConfig = fields
+    .map((f) => {
+      const parts = [
+        `name: ${JSON.stringify(f.name)}`,
+        `label: ${JSON.stringify(f.label ?? humanize(f.name))}`,
+      ];
+      if (f.type && f.type !== "text") parts.push(`type: ${JSON.stringify(f.type)}`);
+      if (f.type === "select" && f.options) parts.push(`options: ${JSON.stringify(f.options)}`);
+      return `        { ${parts.join(", ")} },`;
+    })
+    .join("\n");
+
+  return [
+    'import { AutoForm } from "el-form-react-components";',
+    'import "el-form-react-components/styles.css";',
+    'import { z } from "zod";',
+    "",
+    buildSchema(fields),
+    "",
+    "export function GeneratedForm() {",
+    "  return (",
+    "    <AutoForm",
+    "      schema={schema}",
+    "      fields={[",
+    fieldConfig,
+    "      ]}",
+    "      onSubmit={(data) => console.log(data)}",
+    "    />",
+    "  );",
+    "}",
+  ].join("\n");
+}
+
+function inputType(f: FieldSpec): string {
+  switch (f.type) {
+    case "email":
+    case "password":
+    case "number":
+    case "date":
+    case "url":
+    case "tel":
+      return f.type;
+    default:
+      return "text";
+  }
+}
+
+function defaultValueFor(f: FieldSpec): string {
+  if (f.type === "checkbox") return "false";
+  if (f.type === "number") return "undefined";
+  if (f.type === "select" && f.options && f.options.length > 0) {
+    return JSON.stringify(f.options[0]);
+  }
+  return '""';
+}
+
+function renderInput(f: FieldSpec): string {
+  const label = f.label ?? humanize(f.name);
+  const error = `        {formState.errors.${f.name} && <span>{formState.errors.${f.name}}</span>}`;
+  let control: string;
+  if (f.type === "textarea") {
+    control = `        <textarea {...register(${JSON.stringify(f.name)})} placeholder=${JSON.stringify(label)} />`;
+  } else if (f.type === "checkbox") {
+    control = `        <input type="checkbox" {...register(${JSON.stringify(f.name)})} />`;
+  } else if (f.type === "select") {
+    const opts = (f.options ?? [])
+      .map((o) => `          <option value=${JSON.stringify(o)}>${o}</option>`)
+      .join("\n");
+    control = `        <select {...register(${JSON.stringify(f.name)})}>\n${opts}\n        </select>`;
+  } else {
+    control = `        <input {...register(${JSON.stringify(f.name)})} type="${inputType(f)}" placeholder=${JSON.stringify(label)} />`;
+  }
+  return [
+    "      <div>",
+    `        <label>${label}</label>`,
+    control,
+    error,
+    "      </div>",
+  ].join("\n");
+}
+
+function scaffoldUseForm(fields: FieldSpec[]): string {
+  const defaults = fields.map((f) => `      ${f.name}: ${defaultValueFor(f)},`).join("\n");
+  const inputs = fields.map(renderInput).join("\n\n");
+
+  return [
+    'import { useForm } from "el-form-react-hooks";',
+    'import { z } from "zod";',
+    "",
+    buildSchema(fields),
+    "",
+    "export function GeneratedForm() {",
+    "  const { register, handleSubmit, formState } = useForm({",
+    "    validators: { onChange: schema },",
+    "    defaultValues: {",
+    defaults,
+    "    },",
+    "  });",
+    "",
+    "  return (",
+    "    <form onSubmit={handleSubmit((data) => console.log(data))}>",
+    inputs,
+    "",
+    "      <button type=\"submit\" disabled={formState.isSubmitting}>",
+    "        Submit",
+    "      </button>",
+    "    </form>",
+    "  );",
+    "}",
+  ].join("\n");
+}

--- a/packages/el-form-mcp/tsconfig.json
+++ b/packages/el-form-mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/packages/el-form-mcp/tsup.config.ts
+++ b/packages/el-form-mcp/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  target: "node18",
+  clean: true,
+  sourcemap: true,
+  // Make dist/index.js directly executable as the `el-form-mcp` bin.
+  banner: { js: "#!/usr/bin/env node" },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,22 @@ importers:
         specifier: ^2.0.0
         version: 2.1.9(jsdom@24.1.3)
 
+  packages/el-form-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.0.0
+        version: 1.29.0(zod@4.0.17)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.19
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.0(postcss@8.5.4)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+
   packages/el-form-react:
     dependencies:
       el-form-core:
@@ -4365,6 +4381,15 @@ packages:
     dependencies:
       '@hapi/hoek': 9.3.0
 
+  /@hono/node-server@1.19.14(hono@4.12.23):
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+    dependencies:
+      hono: 4.12.23
+    dev: false
+
   /@humanwhocodes/config-array@0.13.0:
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -4415,7 +4440,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 17.0.45
+      '@types/node': 22.19.19
       '@types/yargs': 17.0.33
       chalk: 4.1.2
     dev: false
@@ -4515,6 +4540,37 @@ packages:
       '@types/mdx': 2.0.13
       '@types/react': 18.3.23
       react: 18.3.1
+    dev: false
+
+  /@modelcontextprotocol/sdk@1.29.0(zod@4.0.17):
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.23)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.23
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.0.17
+      zod-to-json-schema: 3.25.2(zod@4.0.17)
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@napi-rs/wasm-runtime@0.2.12:
@@ -5657,26 +5713,26 @@ packages:
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 17.0.45
+      '@types/node': 22.19.19
     dev: false
 
   /@types/bonjour@3.5.13:
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.19.19
     dev: false
 
   /@types/connect-history-api-fallback@1.5.4:
     resolution: {integrity: sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==}
     dependencies:
       '@types/express-serve-static-core': 5.0.6
-      '@types/node': 17.0.45
+      '@types/node': 22.19.19
     dev: false
 
   /@types/connect@3.4.38:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.19.19
     dev: false
 
   /@types/debug@4.1.12:
@@ -5718,7 +5774,7 @@ packages:
   /@types/express-serve-static-core@4.19.6:
     resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.19.19
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.5
@@ -5727,7 +5783,7 @@ packages:
   /@types/express-serve-static-core@5.0.6:
     resolution: {integrity: sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.19.19
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.5
@@ -5769,7 +5825,7 @@ packages:
   /@types/http-proxy@1.17.16:
     resolution: {integrity: sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.19.19
     dev: false
 
   /@types/istanbul-lib-coverage@2.0.6:
@@ -5813,7 +5869,7 @@ packages:
   /@types/node-forge@1.3.11:
     resolution: {integrity: sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.19.19
     dev: false
 
   /@types/node@12.20.55:
@@ -5822,6 +5878,12 @@ packages:
 
   /@types/node@17.0.45:
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+    dev: false
+
+  /@types/node@22.19.19:
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
+    dependencies:
+      undici-types: 6.21.0
 
   /@types/normalize-package-data@2.4.4:
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -5887,14 +5949,14 @@ packages:
   /@types/sax@1.2.7:
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.19.19
     dev: false
 
   /@types/send@0.17.5:
     resolution: {integrity: sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==}
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 17.0.45
+      '@types/node': 22.19.19
     dev: false
 
   /@types/serve-index@1.9.4:
@@ -5907,14 +5969,14 @@ packages:
     resolution: {integrity: sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==}
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 17.0.45
+      '@types/node': 22.19.19
       '@types/send': 0.17.5
     dev: false
 
   /@types/sockjs@0.3.36:
     resolution: {integrity: sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.19.19
     dev: false
 
   /@types/unist@2.0.11:
@@ -5926,7 +5988,7 @@ packages:
   /@types/ws@8.18.1:
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.19.19
     dev: false
 
   /@types/yargs-parser@21.0.3:
@@ -6499,6 +6561,14 @@ packages:
       negotiator: 0.6.3
     dev: false
 
+  /accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+    dev: false
+
   /acorn-jsx@5.3.2(acorn@8.14.1):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -6557,6 +6627,17 @@ packages:
         optional: true
     dependencies:
       ajv: 8.17.1
+
+  /ajv-formats@3.0.1(ajv@8.17.1):
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.17.1
+    dev: false
 
   /ajv-keywords@3.5.2(ajv@6.12.6):
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -6940,6 +7021,23 @@ packages:
       raw-body: 2.5.2
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.0
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -7435,9 +7533,19 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
+  /content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+    dev: false
+
   /content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+    dev: false
+
+  /content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
     dev: false
 
   /convert-source-map@2.0.0:
@@ -7445,6 +7553,11 @@ packages:
 
   /cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+    dev: false
+
+  /cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
     dev: false
 
   /cookie@0.7.1:
@@ -7490,6 +7603,14 @@ packages:
 
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+    dev: false
+
+  /cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
     dev: false
 
   /cosmiconfig@6.0.0:
@@ -7836,6 +7957,18 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
+
+  /debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: false
 
   /decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -8703,7 +8836,7 @@ packages:
     resolution: {integrity: sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==}
     engines: {node: '>= 0.8'}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.19.19
       require-like: 0.1.2
     dev: false
 
@@ -8714,6 +8847,18 @@ packages:
   /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  /eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+    dev: false
+
+  /eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      eventsource-parser: 3.1.0
+    dev: false
 
   /execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -8734,6 +8879,16 @@ packages:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
     dev: true
+
+  /express-rate-limit@8.5.2(express@5.2.1):
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+    dev: false
 
   /express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
@@ -8769,6 +8924,42 @@ packages:
       statuses: 2.0.1
       type-is: 1.6.18
       utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.1
+      cookie-signature: 1.2.2
+      debug: 4.4.1
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.1
+      type-is: 2.1.0
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8901,6 +9092,20 @@ packages:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+    dependencies:
+      debug: 4.4.1
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -9057,6 +9262,11 @@ packages:
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+    dev: false
+
+  /fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
     dev: false
 
   /fs-extra@10.1.0:
@@ -9516,6 +9726,11 @@ packages:
       react-is: 16.13.1
     dev: false
 
+  /hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+    engines: {node: '>=16.9.0'}
+    dev: false
+
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
     dev: true
@@ -9664,6 +9879,17 @@ packages:
       toidentifier: 1.0.1
     dev: false
 
+  /http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+    dev: false
+
   /http-parser-js@0.5.10:
     resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
     dev: false
@@ -9747,6 +9973,13 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
+
+  /iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: false
 
   /icss-utils@5.1.0(postcss@8.5.6):
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
@@ -9857,6 +10090,11 @@ packages:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
     dependencies:
       loose-envify: 1.4.0
+
+  /ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+    dev: false
 
   /ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -10095,6 +10333,10 @@ packages:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
     dev: true
 
+  /is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+    dev: false
+
   /is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -10268,7 +10510,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 17.0.45
+      '@types/node': 22.19.19
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -10279,7 +10521,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.19.19
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -10287,7 +10529,7 @@ packages:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.19.19
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -10309,6 +10551,10 @@ packages:
       '@sideway/address': 4.1.5
       '@sideway/formula': 3.0.1
       '@sideway/pinpoint': 2.0.0
+
+  /jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+    dev: false
 
   /joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -10389,6 +10635,10 @@ packages:
 
   /json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  /json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+    dev: false
 
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -10976,6 +11226,11 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
+  /media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
@@ -11003,6 +11258,11 @@ packages:
 
   /merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+    dev: false
+
+  /merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
     dev: false
 
   /merge-stream@2.0.0:
@@ -11400,6 +11660,13 @@ packages:
     dependencies:
       mime-db: 1.52.0
 
+  /mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+    dependencies:
+      mime-db: 1.54.0
+    dev: false
+
   /mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
@@ -11538,6 +11805,11 @@ packages:
 
   /negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
     dev: false
 
@@ -12014,6 +12286,10 @@ packages:
     resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
     dev: false
 
+  /path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+    dev: false
+
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -12057,6 +12333,11 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
     dev: true
+
+  /pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+    dev: false
 
   /pkg-dir@7.0.0:
     resolution: {integrity: sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==}
@@ -13044,6 +13325,13 @@ packages:
       side-channel: 1.1.0
     dev: false
 
+  /qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.1.0
+    dev: false
+
   /quansync@0.2.10:
     resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
     dev: true
@@ -13093,6 +13381,16 @@ packages:
       bytes: 3.1.2
       http-errors: 2.0.0
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+    dev: false
+
+  /raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
       unpipe: 1.0.0
     dev: false
 
@@ -13713,6 +14011,19 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      debug: 4.4.1
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /rrweb-cssom@0.7.1:
     resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
     dev: true
@@ -13892,6 +14203,25 @@ packages:
       - supports-color
     dev: false
 
+  /send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
     dependencies:
@@ -13932,6 +14262,18 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -14138,6 +14480,7 @@ packages:
   /source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
     dependencies:
       whatwg-url: 7.1.0
     dev: true
@@ -14219,6 +14562,11 @@ packages:
 
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
     dev: false
 
@@ -14820,6 +15168,15 @@ packages:
       mime-types: 2.1.35
     dev: false
 
+  /type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+    dev: false
+
   /typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -14895,6 +15252,9 @@ packages:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
     dev: true
+
+  /undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   /undici@7.13.0:
     resolution: {integrity: sha512-l+zSMssRqrzDcb3fjMkjjLGmuiiK2pMIcV++mJaAc9vhjSGpvM7h43QgP+OAMb1GImHmbPyG2tBXeuyG5iY4gA==}
@@ -15668,6 +16028,14 @@ packages:
   /yocto-queue@1.2.1:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
     engines: {node: '>=12.20'}
+    dev: false
+
+  /zod-to-json-schema@3.25.2(zod@4.0.17):
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+    dependencies:
+      zod: 4.0.17
     dev: false
 
   /zod@3.25.76:


### PR DESCRIPTION
## Why

Investigating a late-May 2026 npm download spike (~3k/day on **May 16** across all four `el-form-*` packages, then back to ~10/day) showed it was **automated, whole-dependency-tree installs** — not human adoption. Tells: near-identical counts across packages, **0 new GitHub stars/forks**, only 7 repo views / 5 clones in the following 14 days, no HN/newsletter/Reddit footprint, and no npm publish since Feb to trigger a scanner. Plausibly an AI-agent/eval fleet (unprovable from npm's public data).

The exact source can't be recovered retroactively — elform.dev has no analytics, GitHub Pages keeps no logs, and GitHub's Traffic API only retains 14 days. So this PR is **forward-looking**: lean into agent-discoverability and add the instrumentation to diagnose the next spike.

## What's in here

- **`packages/el-form-mcp`** — new stdio MCP server (`npx el-form-mcp`) exposing El Form to agents. Tools: `el_form_overview`, `el_form_list_topics`, `el_form_get_topic`, `el_form_search`, `el_form_scaffold_form` (generates AutoForm/useForm code + a matching Zod schema from a field list). Builds, type-checks, and smoke-tested clean.
- **`docs/static/llms.txt` + `llms-full.txt`** — [llmstxt.org](https://llmstxt.org) format; deploy to elform.dev/llms.txt and /llms-full.txt. Verified copied into the Docusaurus `build/` output.
- **README** — new "🤖 For AI Agents & LLMs" quickstart section.
- **GA4** — added via Docusaurus `gtag`, **env-gated on `GA_TRACKING_ID`** so it's inert unless the secret is set; wired into `deploy-docs.yml`.
- **`launch/`** — Show HN, r/reactjs, and dev.to relaunch drafts (angle: "still here, here's what it does" — no new release).

## Verification

- `pnpm build:packages` → all packages build (exit 0)
- `pnpm --filter el-form-mcp build` + `type-check` → clean
- `el-form-mcp` smoke test → all 5 tools respond, both scaffold modes correct, search ranks, error path returns `isError`
- `pnpm docs:build` → `[SUCCESS]`, with both `llms*.txt` present in `build/`

## Follow-ups (not in this PR)

- [ ] Create a GA4 property and set repo secret `GA_TRACKING_ID` to activate analytics
- [ ] `pnpm changeset:add` before publishing `el-form-mcp` (no version bumps here)
- [ ] Post the `launch/` drafts

> ⚠️ Note: GA4 is client-side, so it measures **humans** — its value is the install-vs-pageview *divergence* that flags bots, not capturing agent user-agents (that would need edge logs, e.g. Cloudflare Pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
