### PR TITLE
test: comprehensive useForm suite + pre-launch sweep skill (fixes 2 validation bugs)

### DIFF
--- a/.changeset/fix-onchange-submit-gate.md
+++ b/.changeset/fix-onchange-submit-gate.md
@@ -1,0 +1,5 @@
+---
+"el-form-react-hooks": patch
+---
+
+fix: `handleSubmit` now blocks submission when a configured `validators.onChange` (or `onBlur`) validator fails. Previously only `validators.onSubmit` gated submit, so forms validating on change could submit invalid data.

--- a/.changeset/fix-trigger-writes-errors.md
+++ b/.changeset/fix-trigger-writes-errors.md
@@ -1,0 +1,5 @@
+---
+"el-form-react-hooks": patch
+---
+
+fix: `trigger()` now writes validation errors into `formState.errors` (and updates `isValid`) so the UI reflects them, matching React Hook Form. Previously it returned the correct boolean but left `formState` untouched.

--- a/.claude/skills/sweep-form-app/SKILL.md
+++ b/.claude/skills/sweep-form-app/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: sweep-form-app
+description: Use before promoting/releasing el-form to verify the example app works end-to-end. Boots the example app and drives all 15 form demos in a real browser with Playwright, asserting behavior, capturing screenshots, and writing a pass/fail report. Manual pre-launch gate — not run in CI.
+---
+
+# Sweep the El Form example app
+
+Drives every demo in `examples/react` (port 3001) in a real browser and writes a
+report you skim before promoting the library.
+
+## When to use
+
+Before sending el-form to blogs/communities, or before a release — to confirm the
+whole app actually works, not just the unit suite.
+
+## Steps
+
+1. **Install Playwright + Chromium** (skill-local; not a repo dependency):
+   ```bash
+   npm exec --yes playwright@latest install chromium
+   ```
+   If `playwright` isn't resolvable as a module for the runner, install it
+   without saving to package.json: `npm install --no-save playwright` at the repo
+   root (node_modules is git-ignored). State the ~download cost to the user.
+
+2. **Boot the dev server** (background) and wait for port 3001:
+   ```bash
+   pnpm --filter el-form-testing-app dev
+   ```
+   Wait until http://localhost:3001 responds (poll, ~10s). If the port is busy,
+   assume the app is already running and continue.
+
+3. **Run the sweep**:
+   ```bash
+   node .claude/skills/sweep-form-app/run-sweep.mjs
+   ```
+
+4. **Read the report**: `.sweep-results/REPORT.md` — a table of PASS/FAIL per
+   demo, console-error counts, and screenshots. Summarize it for the user:
+   how many passed, which failed and why. Do NOT claim "all good" unless the
+   report shows it.
+
+5. **Stop the dev server** you started.
+
+## Output
+
+- `.sweep-results/REPORT.md` — pass/fail table + console errors
+- `.sweep-results/<demo>.png` — one screenshot per demo
+
+Both are git-ignored.
+
+## Notes
+
+- The runner exits non-zero if any demo fails — surface that to the user.
+- One broken demo does not abort the sweep; each is isolated.
+- The assertions are intentionally conservative (does it render, do validation
+  errors appear, do arrays grow). For deeper per-feature checks, extend `DEMOS`
+  in `run-sweep.mjs` — the committed vitest suite is the source of truth for what
+  each feature should do.

--- a/.claude/skills/sweep-form-app/run-sweep.mjs
+++ b/.claude/skills/sweep-form-app/run-sweep.mjs
@@ -1,0 +1,131 @@
+// .claude/skills/sweep-form-app/run-sweep.mjs
+// Pre-launch sweep of the el-form example app. Run AFTER the dev server is up on :3001.
+import { chromium } from "playwright";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const BASE = "http://localhost:3001";
+const OUT = ".sweep-results";
+mkdirSync(OUT, { recursive: true });
+
+// id -> { label (sidebar button text), check(page) -> {pass, note} }
+const DEMOS = [
+  { id: "basic-validation", label: "Basic Validation", check: assertValidationErrors },
+  { id: "onblur-validation", label: "OnBlur Validation", check: assertRenders },
+  { id: "async-validation", label: "Async Validation", check: assertRenders },
+  { id: "file-upload", label: "Basic File Upload", check: assertRenders },
+  { id: "advanced-file", label: "Advanced File Validation", check: assertRenders },
+  { id: "zod-file", label: "Zod File Validation", check: assertRenders },
+  { id: "complex-arrays", label: "Complex Arrays", check: assertArrayAddRemove },
+  { id: "form-history", label: "Form History", check: assertRenders },
+  { id: "discriminated-union", label: "Manual Discriminated", check: assertRenders },
+  { id: "auto-discriminated", label: "Auto Discriminated", check: assertRenders },
+  { id: "general-autoform", label: "General AutoForm", check: assertRenders },
+  { id: "form-switch-field", label: "Field Example", check: assertRenders },
+  { id: "form-switch-select", label: "Select Example", check: assertRenders },
+  { id: "form-switch-compat", label: "Back Compat", check: assertRenders },
+  { id: "use-field-rerender", label: "useField Rerender", check: assertRenders },
+];
+
+// --- assertions (anchored to suite behaviors) ---
+
+// Baseline: the demo mounted and shows at least one input or button.
+async function assertRenders(page) {
+  const controls = await page.locator("input, select, textarea, button").count();
+  return controls > 1
+    ? { pass: true, note: `rendered (${controls} controls)` }
+    : { pass: false, note: "no interactive controls found" };
+}
+
+// Submit empty -> expect at least one validation error to appear.
+async function assertValidationErrors(page) {
+  const submit = page.getByRole("button", { name: /submit/i }).first();
+  if (!(await submit.count())) return { pass: false, note: "no submit button" };
+  await submit.click();
+  const err = page.locator("text=/required|invalid|must|valid/i").first();
+  const appeared = await err
+    .waitFor({ state: "visible", timeout: 3000 })
+    .then(() => true)
+    .catch(() => false);
+  return appeared
+    ? { pass: true, note: "validation error shown on empty submit" }
+    : { pass: false, note: "no validation error after empty submit" };
+}
+
+// Array demo: count rows, click an Add button, expect the count to grow.
+async function assertArrayAddRemove(page) {
+  const add = page.getByRole("button", { name: /add/i }).first();
+  if (!(await add.count())) return { pass: false, note: "no add button" };
+  const before = await page.locator("input").count();
+  await add.click();
+  await page.waitForTimeout(200);
+  const after = await page.locator("input").count();
+  return after > before
+    ? { pass: true, note: `inputs ${before} -> ${after} after add` }
+    : { pass: false, note: `add did not increase inputs (${before} -> ${after})` };
+}
+
+// --- driver ---
+
+async function run() {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  const consoleErrors = [];
+  page.on("console", (m) => {
+    if (m.type() === "error") consoleErrors.push(m.text());
+  });
+
+  await page.goto(BASE, { waitUntil: "networkidle" });
+  const results = [];
+
+  for (const demo of DEMOS) {
+    const before = consoleErrors.length;
+    let row = { id: demo.id, label: demo.label, pass: false, note: "", shot: `${demo.id}.png` };
+    try {
+      await page.getByRole("button", { name: demo.label, exact: true }).first().click();
+      await page.waitForTimeout(300); // allow the demo to mount
+      const r = await demo.check(page);
+      row.pass = r.pass;
+      row.note = r.note;
+    } catch (e) {
+      row.note = `threw: ${e.message}`;
+    }
+    await page.screenshot({ path: join(OUT, row.shot) }).catch(() => {});
+    row.consoleErrors = consoleErrors.length - before;
+    results.push(row);
+    console.log(`${row.pass ? "PASS" : "FAIL"}  ${demo.label}  — ${row.note}`);
+  }
+
+  await browser.close();
+  writeReport(results, consoleErrors);
+  const failed = results.filter((r) => !r.pass).length;
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+function writeReport(results, consoleErrors) {
+  const pass = results.filter((r) => r.pass).length;
+  const fail = results.length - pass;
+  const warn = consoleErrors.length;
+  const lines = [
+    `# El Form Sweep`,
+    ``,
+    `✅ ${pass} / ${results.length} passed   ❌ ${fail} failed   ⚠️ ${warn} console errors`,
+    ``,
+    `| Feature | Result | Notes | Console | Screenshot |`,
+    `|---------|--------|-------|---------|------------|`,
+    ...results.map(
+      (r) =>
+        `| ${r.label} | ${r.pass ? "✅" : "❌"} | ${r.note} | ${r.consoleErrors || 0} | ![](${r.shot}) |`
+    ),
+  ];
+  if (consoleErrors.length) {
+    lines.push(``, `## Console errors`, ``, ...consoleErrors.slice(0, 50).map((e) => `- ${e}`));
+  }
+  writeFileSync(join(OUT, "REPORT.md"), lines.join("\n") + "\n");
+  console.log(`\nReport: ${join(OUT, "REPORT.md")}  (${pass}/${results.length} passed)`);
+}
+
+run().catch((e) => {
+  console.error("Sweep crashed:", e);
+  process.exit(2);
+});

--- a/.claude/skills/sweep-form-app/run-sweep.mjs
+++ b/.claude/skills/sweep-form-app/run-sweep.mjs
@@ -54,7 +54,9 @@ async function assertValidationErrors(page) {
   }
 
   await submit.click().catch(() => {});
-  const err = main(page).locator("text=/required|invalid|must|valid/i").first();
+  // Match clearly error-indicating words. Don't include a bare "valid" — it is a
+  // substring of "invalid" and would also match success text like "looks valid".
+  const err = main(page).locator("text=/required|invalid|must be|too short|too long|enter a/i").first();
   const appeared = await err
     .waitFor({ state: "visible", timeout: 3000 })
     .then(() => true)
@@ -91,10 +93,16 @@ async function assertArrayAddRemove(page) {
       ? { pass: true, note: `item count ${before} -> ${after} after add` }
       : { pass: false, note: `add did not increment count (${before} -> ${after})` };
   }
-  // Fallback: no counter found — just confirm Add is present and enabled.
-  return (await add.isEnabled())
-    ? { pass: true, note: "add button present and enabled (no counter to verify)" }
-    : { pass: false, note: "add button disabled" };
+  // Fallback: no "(N)" counter to read. Verify Add actually changes the DOM by
+  // comparing the demo's full text before/after the click — a no-op Add (broken
+  // handler) leaves the text identical and must FAIL, not pass on "button enabled".
+  const beforeText = (await main(page).textContent()) ?? "";
+  await add.click().catch(() => {});
+  await page.waitForTimeout(400);
+  const afterText = (await main(page).textContent()) ?? "";
+  return afterText !== beforeText
+    ? { pass: true, note: "add changed the view (no numeric counter to verify)" }
+    : { pass: false, note: "add produced no visible change" };
 }
 
 // --- driver ---

--- a/.claude/skills/sweep-form-app/run-sweep.mjs
+++ b/.claude/skills/sweep-form-app/run-sweep.mjs
@@ -28,41 +28,73 @@ const DEMOS = [
 ];
 
 // --- assertions (anchored to suite behaviors) ---
+//
+// All assertions scope to the <main> content region so the persistent sidebar
+// nav (which renders ~24 buttons on every demo) is never counted or clicked.
 
-// Baseline: the demo mounted and shows at least one input or button.
+const main = (page) => page.locator("main");
+
+// Baseline: the demo mounted and shows at least one form control.
 async function assertRenders(page) {
-  const controls = await page.locator("input, select, textarea, button").count();
-  return controls > 1
-    ? { pass: true, note: `rendered (${controls} controls)` }
-    : { pass: false, note: "no interactive controls found" };
+  const controls = await main(page).locator("input, select, textarea").count();
+  return controls >= 1
+    ? { pass: true, note: `rendered (${controls} fields)` }
+    : { pass: false, note: "no form fields found in <main>" };
 }
 
-// Submit empty -> expect at least one validation error to appear.
+// Validation: try to submit invalid. The submit button may be disabled while
+// the form is invalid (that is correct canSubmit behavior) — treat a disabled
+// submit as a PASS. Otherwise click it and expect a validation message.
 async function assertValidationErrors(page) {
-  const submit = page.getByRole("button", { name: /submit/i }).first();
+  const submit = main(page).getByRole("button", { name: /submit/i }).first();
   if (!(await submit.count())) return { pass: false, note: "no submit button" };
-  await submit.click();
-  const err = page.locator("text=/required|invalid|must|valid/i").first();
+
+  if (await submit.isDisabled()) {
+    return { pass: true, note: "submit disabled while form invalid (canSubmit gate)" };
+  }
+
+  await submit.click().catch(() => {});
+  const err = main(page).locator("text=/required|invalid|must|valid/i").first();
   const appeared = await err
     .waitFor({ state: "visible", timeout: 3000 })
     .then(() => true)
     .catch(() => false);
   return appeared
-    ? { pass: true, note: "validation error shown on empty submit" }
-    : { pass: false, note: "no validation error after empty submit" };
+    ? { pass: true, note: "validation error shown on invalid submit" }
+    : { pass: false, note: "submit enabled but no validation error appeared" };
 }
 
-// Array demo: count rows, click an Add button, expect the count to grow.
+// Array demo: click an "Add" button inside <main> and confirm the demo's own
+// item counter (e.g. "Team Members (2)") increments. Counting raw inputs is
+// unreliable for nested/collapsible arrays, and the committed
+// array-ops.runtime.test.tsx is the authoritative proof of add/remove — this
+// sweep check just confirms the demo wires Add to a visible state change.
 async function assertArrayAddRemove(page) {
-  const add = page.getByRole("button", { name: /add/i }).first();
-  if (!(await add.count())) return { pass: false, note: "no add button" };
-  const before = await page.locator("input").count();
-  await add.click();
-  await page.waitForTimeout(200);
-  const after = await page.locator("input").count();
-  return after > before
-    ? { pass: true, note: `inputs ${before} -> ${after} after add` }
-    : { pass: false, note: `add did not increase inputs (${before} -> ${after})` };
+  const add = main(page).getByRole("button", { name: /add/i }).first();
+  if (!(await add.count())) return { pass: false, note: "no add button in <main>" };
+
+  // Capture a numeric "(N)" counter near the top of the demo before/after.
+  const counter = main(page).locator("text=/\\(\\d+\\)/").first();
+  const readN = async () => {
+    if (!(await counter.count())) return null;
+    const m = (await counter.textContent())?.match(/\((\d+)\)/);
+    return m ? Number(m[1]) : null;
+  };
+
+  const before = await readN();
+  await add.click().catch(() => {});
+  await page.waitForTimeout(400);
+  const after = await readN();
+
+  if (before !== null && after !== null) {
+    return after > before
+      ? { pass: true, note: `item count ${before} -> ${after} after add` }
+      : { pass: false, note: `add did not increment count (${before} -> ${after})` };
+  }
+  // Fallback: no counter found — just confirm Add is present and enabled.
+  return (await add.isEnabled())
+    ? { pass: true, note: "add button present and enabled (no counter to verify)" }
+    : { pass: false, note: "add button disabled" };
 }
 
 // --- driver ---
@@ -88,7 +120,9 @@ async function run() {
       row.pass = r.pass;
       row.note = r.note;
     } catch (e) {
-      row.note = `threw: ${e.message}`;
+      // Keep only the first line of the error; Playwright timeouts dump a long
+      // multi-line call log that would otherwise shatter the report table.
+      row.note = `threw: ${String(e.message).split("\n")[0]}`;
     }
     await page.screenshot({ path: join(OUT, row.shot) }).catch(() => {});
     row.consoleErrors = consoleErrors.length - before;
@@ -100,6 +134,12 @@ async function run() {
   writeReport(results, consoleErrors);
   const failed = results.filter((r) => !r.pass).length;
   process.exit(failed > 0 ? 1 : 0);
+}
+
+// Make a string safe for a single markdown table cell: no newlines, no raw
+// pipes, and bounded length.
+function cell(s) {
+  return String(s).replace(/\s*\n\s*/g, " ").replace(/\|/g, "\\|").slice(0, 160);
 }
 
 function writeReport(results, consoleErrors) {
@@ -115,7 +155,7 @@ function writeReport(results, consoleErrors) {
     `|---------|--------|-------|---------|------------|`,
     ...results.map(
       (r) =>
-        `| ${r.label} | ${r.pass ? "✅" : "❌"} | ${r.note} | ${r.consoleErrors || 0} | ![](${r.shot}) |`
+        `| ${r.label} | ${r.pass ? "✅" : "❌"} | ${cell(r.note)} | ${r.consoleErrors || 0} | ![](${r.shot}) |`
     ),
   ];
   if (consoleErrors.length) {

--- a/.claude/skills/test-my-change/SKILL.md
+++ b/.claude/skills/test-my-change/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: test-my-change
+description: Use after editing el-form package source to run the relevant package tests for what you changed, before pushing or opening a PR. Detects changed packages via git and runs their vitest (and tsd for hooks) suites.
+---
+
+# Test my change
+
+Runs the test suites for the el-form package(s) you've modified.
+
+## Steps
+
+1. **Find changed packages**:
+   ```bash
+   git diff --name-only $(git merge-base HEAD main)...HEAD
+   git diff --name-only            # unstaged too
+   ```
+   Map changed paths to packages:
+   - `packages/el-form-core/**` → `el-form-core`
+   - `packages/el-form-react-hooks/**` → `el-form-react-hooks`
+   - `packages/el-form-react-components/**` → `el-form-react-components`
+   - `packages/el-form-mcp/**` → `el-form-mcp`
+   - `packages/el-form-react/**` → has no tests; run hooks + components instead
+     (it re-exports them).
+
+2. **Run the matching suites** (only the affected ones):
+   ```bash
+   pnpm --filter el-form-core exec vitest --run
+   pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run
+   pnpm --filter el-form-react-hooks exec tsd --files tsd.test-d.ts
+   pnpm --filter el-form-react-components exec vitest --environment jsdom --run
+   pnpm --filter el-form-mcp test
+   ```
+
+3. **Report** pass/fail per package. If anything fails, show the failing test
+   names and output — do not summarize as "some failures".
+
+## Notes
+
+- If you can't determine the changed package, run the full suite: `pnpm -r test`.
+- This mirrors what CI runs, so green here means CI should be green.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Test react-hooks (runtime + tsd)
         run: pnpm --filter el-form-react-hooks test
 
+      - name: Test el-form-react-components (vitest)
+        run: pnpm --filter el-form-react-components exec vitest --environment jsdom --run
+
       - name: Type-check el-form-mcp
         run: pnpm --filter el-form-mcp type-check
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ examples/tests/
 # Development tracking
 FEATURE_CHECKLIST.md
 agent-actions/
+
+# Pre-launch sweep skill artifacts
+.sweep-results/

--- a/docs/superpowers/plans/2026-06-01-form-testing-and-sweep-skill.md
+++ b/docs/superpowers/plans/2026-06-01-form-testing-and-sweep-skill.md
@@ -624,12 +624,15 @@ git commit -m "test(hooks): cover getSnapshot/restoreSnapshot/hasChanges"
 
 - [ ] **Step 1: Append type-error assertions**
 
-Add inside a new block at the end of the existing file (keep the existing block intact):
+The existing file already has `import { expectType } from "tsd";` and
+`import { useForm } from "./src";` at the top. **Do NOT re-import those** (it
+causes `TS2300: Duplicate identifier`). Instead: (a) change the existing top
+import to `import { expectType, expectError } from "tsd";`, and (b) append ONLY
+the new block below (no new import lines) at the end of the file, keeping the
+existing block intact:
 
 ```tsx
-import { expectType, expectError } from "tsd";
-import { useForm } from "./src";
-
+// (no imports here — reuse the top-of-file expectType/expectError/useForm)
 {
   const form = useForm<{ email: string; age: number; user: { name: string } }>({
     defaultValues: { email: "", age: 0, user: { name: "" } },
@@ -690,7 +693,7 @@ const schema = z.object({
 describe("AutoForm submit", () => {
   it("calls onSubmit with typed data when valid", async () => {
     const onSubmit = vi.fn();
-    render(<AutoForm schema={schema} onSubmit={onSubmit} />);
+    render(<AutoForm schema={schema} initialValues={{ email: "", name: "" }} onSubmit={onSubmit} />);
     const inputs = document.querySelectorAll("input");
     fireEvent.change(inputs[0], { target: { value: "a@b.com" } });
     fireEvent.change(inputs[1], { target: { value: "Ada" } });
@@ -702,7 +705,7 @@ describe("AutoForm submit", () => {
   it("calls onError on invalid submit", async () => {
     const onSubmit = vi.fn();
     const onError = vi.fn();
-    render(<AutoForm schema={schema} onSubmit={onSubmit} onError={onError} />);
+    render(<AutoForm schema={schema} initialValues={{ email: "", name: "" }} onSubmit={onSubmit} onError={onError} />);
     fireEvent.click(screen.getByRole("button", { name: /submit/i }));
     await waitFor(() => expect(onError).toHaveBeenCalled());
     expect(onSubmit).not.toHaveBeenCalled();
@@ -773,7 +776,7 @@ Append to `.gitignore`:
 - [ ] **Step 2: Run the entire workspace test suite**
 
 Run: `pnpm -r test`
-Expected: all packages green (core, hooks incl. tsd, components, mcp). Capture the real summary output.
+Expected: all packages green (core, hooks incl. tsd, components, mcp). Capture the real summary output. Note: the `el-form-react-hooks` and `el-form-react-components` `test` scripts each begin with `pnpm -w -r build`, so this full-suite run rebuilds the workspace twice — expect extra time; that's intended for the full-suite tasks (unlike the lean CI step in Task 11 which uses `exec vitest` directly).
 
 - [ ] **Step 3: Commit**
 

--- a/docs/superpowers/plans/2026-06-01-form-testing-and-sweep-skill.md
+++ b/docs/superpowers/plans/2026-06-01-form-testing-and-sweep-skill.md
@@ -1,0 +1,1156 @@
+# El Form Test Suite & Pre-Launch Sweep Skill — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a committed vitest + Testing Library + tsd suite covering `useForm` runtime behavior and user-facing type errors, wire the components package into CI, and ship two Claude skills — a manual Playwright pre-launch sweep of the example app and a contributor "test my change" helper.
+
+**Architecture:** All artifacts are organized around a shared feature spine (submit, setValue, reset, validation modes, state tracking, errors, array ops, snapshots, type errors). The committed suite extends the EXISTING test infra in `el-form-react-hooks` (`@testing-library/react` ^14, `vitest` ^2, `tsd` ^0.31, jsdom) using the driver-component pattern already in `register.runtime.test.tsx`. The sweep skill drives the real example app (`examples/react`, port 3001) in a browser; it is never run in CI. Tests are written TDD-style; because the library already exists, most tests are characterization tests that pass on first write — where a test reveals a real discrepancy, STOP and surface it as a finding rather than silently editing library code.
+
+**Tech Stack:** TypeScript, React 18, Vitest 2, @testing-library/react 14, jsdom, tsd, Zod 4, Playwright (skill-local, self-installed), pnpm workspaces.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-form-testing-and-sweep-design.md`
+
+**Branch:** `feat/test-suite-and-sweep-skill`
+
+---
+
+## Conventions for every test task
+
+- Each runtime test file lives in `packages/el-form-react-hooks/src/__tests__/` and follows the **driver-component pattern**: define a small React component that calls `useForm`, render it with `@testing-library/react`, and assert via `screen` + `fireEvent`. Expose hook methods you need to assert on by wiring them to buttons/handlers or by rendering state into the DOM.
+- Run a single file with: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__/<file>`
+- `formState.errors[field]` is a **string** (not an object) — assert on the string directly.
+- After each task: run the file (green), then commit. Commit messages use `test(scope): ...`.
+- **TDD finding rule:** if a test you wrote to describe intended behavior FAILS because the library misbehaves, do not change library source. Record it under "## Findings" at the bottom of this plan and report to the maintainer.
+
+---
+
+## File Structure
+
+**Created — committed suite:**
+- `packages/el-form-react-hooks/src/__tests__/submit.runtime.test.tsx`
+- `packages/el-form-react-hooks/src/__tests__/setValue.runtime.test.tsx`
+- `packages/el-form-react-hooks/src/__tests__/reset.runtime.test.tsx`
+- `packages/el-form-react-hooks/src/__tests__/validation-modes.test.tsx`
+- `packages/el-form-react-hooks/src/__tests__/state-tracking.test.tsx`
+- `packages/el-form-react-hooks/src/__tests__/errors.runtime.test.tsx`
+- `packages/el-form-react-hooks/src/__tests__/array-ops.runtime.test.tsx`
+- `packages/el-form-react-hooks/src/__tests__/snapshots.runtime.test.tsx`
+- `packages/el-form-react-components/src/__tests__/AutoForm.submit.test.tsx`
+
+**Modified:**
+- `packages/el-form-react-hooks/tsd.test-d.ts` (expand type-error assertions)
+- `.github/workflows/ci.yml` (add `el-form-react-components` test step)
+- `.gitignore` (ignore sweep artifacts)
+
+**Created — skills:**
+- `.claude/skills/sweep-form-app/SKILL.md`
+- `.claude/skills/sweep-form-app/run-sweep.mjs`
+- `.claude/skills/test-my-change/SKILL.md`
+
+---
+
+## Task 1: Submit behavior tests
+
+**Files:**
+- Create: `packages/el-form-react-hooks/src/__tests__/submit.runtime.test.tsx`
+
+- [ ] **Step 1: Write the failing test file**
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { z } from "zod";
+import { useForm } from "..";
+
+const schema = z.object({
+  email: z.string().email("Invalid email"),
+  age: z.number().min(18, "Must be 18+"),
+});
+
+function SubmitDemo({ onValid, onInvalid }: { onValid: (d: any) => void; onInvalid?: (e: any) => void }) {
+  const { register, handleSubmit, formState } = useForm<{ email: string; age: number }>({
+    validators: { onChange: schema },
+    defaultValues: { email: "", age: 0 },
+  });
+  return (
+    <form onSubmit={handleSubmit(onValid, onInvalid)}>
+      <input aria-label="email" {...register("email")} />
+      <input aria-label="age" type="number" {...register("age")} />
+      <button type="submit">Submit</button>
+      <span data-testid="submitting">{String(formState.isSubmitting)}</span>
+    </form>
+  );
+}
+
+describe("handleSubmit", () => {
+  it("calls onValid with typed data when valid", async () => {
+    const onValid = vi.fn();
+    render(<SubmitDemo onValid={onValid} />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "a@b.com" } });
+    fireEvent.change(screen.getByLabelText("age"), { target: { value: "21" } });
+    fireEvent.click(screen.getByText("Submit"));
+    await waitFor(() => expect(onValid).toHaveBeenCalledTimes(1));
+    expect(onValid.mock.calls[0][0]).toEqual({ email: "a@b.com", age: 21 });
+  });
+
+  it("does not call onValid when invalid", async () => {
+    const onValid = vi.fn();
+    const onInvalid = vi.fn();
+    render(<SubmitDemo onValid={onValid} onInvalid={onInvalid} />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "not-an-email" } });
+    fireEvent.click(screen.getByText("Submit"));
+    await waitFor(() => expect(onInvalid).toHaveBeenCalled());
+    expect(onValid).not.toHaveBeenCalled();
+  });
+
+  it("awaits an async onSubmit and toggles isSubmitting", async () => {
+    let resolve!: () => void;
+    const pending = new Promise<void>((r) => (resolve = r));
+    const onValid = vi.fn(() => pending);
+    render(<SubmitDemo onValid={onValid} />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "a@b.com" } });
+    fireEvent.change(screen.getByLabelText("age"), { target: { value: "30" } });
+    fireEvent.click(screen.getByText("Submit"));
+    await waitFor(() => expect(screen.getByTestId("submitting").textContent).toBe("true"));
+    resolve();
+    await waitFor(() => expect(screen.getByTestId("submitting").textContent).toBe("false"));
+  });
+});
+```
+
+- [ ] **Step 2: Run and verify behavior**
+
+Run: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__/submit.runtime.test.tsx`
+Expected: PASS (characterization). If any case FAILS, do NOT edit library source — record under "## Findings" and continue.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/el-form-react-hooks/src/__tests__/submit.runtime.test.tsx
+git commit -m "test(hooks): cover handleSubmit valid/invalid/async behavior"
+```
+
+---
+
+## Task 2: setValue / setValues tests
+
+**Files:**
+- Create: `packages/el-form-react-hooks/src/__tests__/setValue.runtime.test.tsx`
+
+- [ ] **Step 1: Write the test file**
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useForm } from "..";
+
+function SetValueDemo() {
+  const { register, setValue, setValues, watch } = useForm<{
+    name: string;
+    age: number;
+    profile: { city: string };
+  }>({ defaultValues: { name: "", age: 0, profile: { city: "" } } });
+  const v = watch();
+  return (
+    <div>
+      <input aria-label="name" {...register("name")} />
+      <input aria-label="city" {...register("profile.city")} />
+      <button onClick={() => setValue("name", "Ada")}>setName</button>
+      <button onClick={() => setValue("profile.city", "Paris")}>setCity</button>
+      <button onClick={() => setValues({ age: 42 })}>mergeAge</button>
+      <span data-testid="snapshot">{JSON.stringify(v)}</span>
+    </div>
+  );
+}
+
+describe("setValue / setValues", () => {
+  it("sets a top-level field", () => {
+    render(<SetValueDemo />);
+    fireEvent.click(screen.getByText("setName"));
+    expect(JSON.parse(screen.getByTestId("snapshot").textContent!).name).toBe("Ada");
+  });
+
+  it("sets a nested dot-path field", () => {
+    render(<SetValueDemo />);
+    fireEvent.click(screen.getByText("setCity"));
+    expect(JSON.parse(screen.getByTestId("snapshot").textContent!).profile.city).toBe("Paris");
+  });
+
+  it("merges via setValues without clobbering other fields", () => {
+    render(<SetValueDemo />);
+    fireEvent.change(screen.getByLabelText("name"), { target: { value: "Grace" } });
+    fireEvent.click(screen.getByText("mergeAge"));
+    const snap = JSON.parse(screen.getByTestId("snapshot").textContent!);
+    expect(snap.age).toBe(42);
+    expect(snap.name).toBe("Grace");
+  });
+
+  it("coerces number inputs to numbers on change", () => {
+    render(<SetValueDemo />);
+    // number coercion is exercised via register; assert watch returns a number
+    const before = JSON.parse(screen.getByTestId("snapshot").textContent!);
+    expect(typeof before.age).toBe("number");
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__/setValue.runtime.test.tsx`
+Expected: PASS. Record any failure under Findings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/el-form-react-hooks/src/__tests__/setValue.runtime.test.tsx
+git commit -m "test(hooks): cover setValue nested paths and setValues merge"
+```
+
+---
+
+## Task 3: reset / resetField tests
+
+**Files:**
+- Create: `packages/el-form-react-hooks/src/__tests__/reset.runtime.test.tsx`
+
+- [ ] **Step 1: Write the test file**
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useForm } from "..";
+
+function ResetDemo() {
+  const { register, reset, resetField, formState } = useForm<{ name: string; email: string }>({
+    defaultValues: { name: "default", email: "" },
+  });
+  return (
+    <div>
+      <input aria-label="name" {...register("name")} />
+      <input aria-label="email" {...register("email")} />
+      <button onClick={() => reset()}>reset</button>
+      <button onClick={() => reset({ values: { name: "seed", email: "seed@x.com" } })}>resetTo</button>
+      <button onClick={() => resetField("name")}>resetName</button>
+      <span data-testid="dirty">{String(formState.isDirty)}</span>
+    </div>
+  );
+}
+
+describe("reset / resetField", () => {
+  it("resets all fields to defaults", () => {
+    render(<ResetDemo />);
+    const name = screen.getByLabelText("name") as HTMLInputElement;
+    fireEvent.change(name, { target: { value: "changed" } });
+    expect(name.value).toBe("changed");
+    fireEvent.click(screen.getByText("reset"));
+    expect((screen.getByLabelText("name") as HTMLInputElement).value).toBe("default");
+  });
+
+  it("resets to explicit values", () => {
+    render(<ResetDemo />);
+    fireEvent.click(screen.getByText("resetTo"));
+    expect((screen.getByLabelText("name") as HTMLInputElement).value).toBe("seed");
+    expect((screen.getByLabelText("email") as HTMLInputElement).value).toBe("seed@x.com");
+  });
+
+  it("clears isDirty after reset", () => {
+    render(<ResetDemo />);
+    fireEvent.change(screen.getByLabelText("name"), { target: { value: "x" } });
+    expect(screen.getByTestId("dirty").textContent).toBe("true");
+    fireEvent.click(screen.getByText("reset"));
+    expect(screen.getByTestId("dirty").textContent).toBe("false");
+  });
+
+  it("resets a single field via resetField", () => {
+    render(<ResetDemo />);
+    fireEvent.change(screen.getByLabelText("name"), { target: { value: "x" } });
+    fireEvent.click(screen.getByText("resetName"));
+    expect((screen.getByLabelText("name") as HTMLInputElement).value).toBe("default");
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__/reset.runtime.test.tsx`
+Expected: PASS. Record any failure under Findings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/el-form-react-hooks/src/__tests__/reset.runtime.test.tsx
+git commit -m "test(hooks): cover reset to defaults/values and resetField"
+```
+
+---
+
+## Task 4: Validation modes (onChange / onBlur / onSubmit)
+
+**Files:**
+- Create: `packages/el-form-react-hooks/src/__tests__/validation-modes.test.tsx`
+
+- [ ] **Step 1: Write the test file**
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { z } from "zod";
+import { useForm } from "..";
+
+const schema = z.object({ email: z.string().email("Invalid email") });
+
+function ModeDemo({ mode }: { mode: "onChange" | "onBlur" | "onSubmit" }) {
+  const { register, handleSubmit, formState } = useForm<{ email: string }>({
+    validators: { [mode]: schema } as any,
+    defaultValues: { email: "" },
+  });
+  return (
+    <form onSubmit={handleSubmit(() => {})}>
+      <input aria-label="email" {...register("email")} />
+      <button type="submit">Submit</button>
+      <span data-testid="err">{formState.errors.email ?? ""}</span>
+    </form>
+  );
+}
+
+describe("validation modes", () => {
+  it("onChange surfaces the error as the user types", async () => {
+    render(<ModeDemo mode="onChange" />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "bad" } });
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid email"));
+  });
+
+  it("onChange clears the error when corrected", async () => {
+    render(<ModeDemo mode="onChange" />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "bad" } });
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid email"));
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "a@b.com" } });
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe(""));
+  });
+
+  it("onBlur surfaces the error only after blur", async () => {
+    render(<ModeDemo mode="onBlur" />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "bad" } });
+    expect(screen.getByTestId("err").textContent).toBe("");
+    fireEvent.blur(screen.getByLabelText("email"));
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid email"));
+  });
+
+  it("onSubmit surfaces the error only on submit", async () => {
+    render(<ModeDemo mode="onSubmit" />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "bad" } });
+    expect(screen.getByTestId("err").textContent).toBe("");
+    fireEvent.click(screen.getByText("Submit"));
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid email"));
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__/validation-modes.test.tsx`
+Expected: PASS. **This is the most likely place to find a real timing discrepancy** — if a mode fires at the wrong time, record under Findings (do not change library source).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/el-form-react-hooks/src/__tests__/validation-modes.test.tsx
+git commit -m "test(hooks): cover onChange/onBlur/onSubmit validation timing"
+```
+
+---
+
+## Task 5: State tracking (dirty / touched / valid / canSubmit)
+
+**Files:**
+- Create: `packages/el-form-react-hooks/src/__tests__/state-tracking.test.tsx`
+
+- [ ] **Step 1: Write the test file**
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { z } from "zod";
+import { useForm } from "..";
+
+const schema = z.object({ email: z.string().email() });
+
+function StateDemo() {
+  const form = useForm<{ email: string }>({
+    validators: { onChange: schema },
+    defaultValues: { email: "" },
+  });
+  const { register, formState } = form;
+  return (
+    <div>
+      <input aria-label="email" {...register("email")} />
+      <span data-testid="dirty">{String(formState.isDirty)}</span>
+      <span data-testid="touched">{String(form.isFieldTouched("email"))}</span>
+      <span data-testid="valid">{String(formState.isValid)}</span>
+      <span data-testid="cansubmit">{String(form.canSubmit)}</span>
+      <span data-testid="hasErrors">{String(form.hasErrors())}</span>
+    </div>
+  );
+}
+
+describe("state tracking", () => {
+  it("isDirty flips when a value changes from default", () => {
+    render(<StateDemo />);
+    expect(screen.getByTestId("dirty").textContent).toBe("false");
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "x" } });
+    expect(screen.getByTestId("dirty").textContent).toBe("true");
+  });
+
+  it("touched flips on blur", () => {
+    render(<StateDemo />);
+    expect(screen.getByTestId("touched").textContent).toBe("false");
+    fireEvent.blur(screen.getByLabelText("email"));
+    expect(screen.getByTestId("touched").textContent).toBe("true");
+  });
+
+  it("isValid / hasErrors reflect validation", async () => {
+    render(<StateDemo />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "bad" } });
+    await waitFor(() => expect(screen.getByTestId("hasErrors").textContent).toBe("true"));
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "a@b.com" } });
+    await waitFor(() => expect(screen.getByTestId("valid").textContent).toBe("true"));
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__/state-tracking.test.tsx`
+Expected: PASS. Record failures under Findings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/el-form-react-hooks/src/__tests__/state-tracking.test.tsx
+git commit -m "test(hooks): cover dirty/touched/valid/canSubmit tracking"
+```
+
+---
+
+## Task 6: Manual errors & trigger
+
+**Files:**
+- Create: `packages/el-form-react-hooks/src/__tests__/errors.runtime.test.tsx`
+
+- [ ] **Step 1: Write the test file**
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { z } from "zod";
+import { useForm } from "..";
+
+const schema = z.object({ email: z.string().email("Invalid email") });
+
+function ErrorsDemo() {
+  const form = useForm<{ email: string }>({
+    validators: { onSubmit: schema },
+    defaultValues: { email: "" },
+  });
+  const { register, formState } = form;
+  return (
+    <div>
+      <input aria-label="email" {...register("email")} />
+      <button onClick={() => form.setError("email", "Taken")}>setErr</button>
+      <button onClick={() => form.clearErrors("email")}>clearErr</button>
+      <button onClick={() => form.trigger("email")}>trigger</button>
+      <span data-testid="err">{formState.errors.email ?? ""}</span>
+    </div>
+  );
+}
+
+describe("setError / clearErrors / trigger", () => {
+  it("setError sets a field error", () => {
+    render(<ErrorsDemo />);
+    fireEvent.click(screen.getByText("setErr"));
+    expect(screen.getByTestId("err").textContent).toBe("Taken");
+  });
+
+  it("clearErrors clears a field error", () => {
+    render(<ErrorsDemo />);
+    fireEvent.click(screen.getByText("setErr"));
+    fireEvent.click(screen.getByText("clearErr"));
+    expect(screen.getByTestId("err").textContent).toBe("");
+  });
+
+  it("trigger validates a field on demand", async () => {
+    render(<ErrorsDemo />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "bad" } });
+    fireEvent.click(screen.getByText("trigger"));
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid email"));
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__/errors.runtime.test.tsx`
+Expected: PASS. Record failures under Findings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/el-form-react-hooks/src/__tests__/errors.runtime.test.tsx
+git commit -m "test(hooks): cover setError/clearErrors/trigger"
+```
+
+---
+
+## Task 7: Array operations
+
+**Files:**
+- Create: `packages/el-form-react-hooks/src/__tests__/array-ops.runtime.test.tsx`
+
+- [ ] **Step 1: Write the test file**
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useForm } from "..";
+
+function ArrayDemo() {
+  const { watch, addArrayItem, removeArrayItem } = useForm<{ tags: string[] }>({
+    defaultValues: { tags: ["a"] },
+  });
+  const tags = watch("tags") || [];
+  return (
+    <div>
+      <span data-testid="count">{tags.length}</span>
+      <span data-testid="tags">{JSON.stringify(tags)}</span>
+      <button onClick={() => addArrayItem("tags", "")}>add</button>
+      <button onClick={() => removeArrayItem("tags", 0)}>removeFirst</button>
+    </div>
+  );
+}
+
+describe("array operations", () => {
+  it("addArrayItem appends an item", () => {
+    render(<ArrayDemo />);
+    expect(screen.getByTestId("count").textContent).toBe("1");
+    fireEvent.click(screen.getByText("add"));
+    expect(screen.getByTestId("count").textContent).toBe("2");
+  });
+
+  it("removeArrayItem removes by index", () => {
+    render(<ArrayDemo />);
+    fireEvent.click(screen.getByText("add"));
+    fireEvent.click(screen.getByText("removeFirst"));
+    expect(screen.getByTestId("count").textContent).toBe("1");
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__/array-ops.runtime.test.tsx`
+Expected: PASS. Record failures under Findings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/el-form-react-hooks/src/__tests__/array-ops.runtime.test.tsx
+git commit -m "test(hooks): cover addArrayItem/removeArrayItem"
+```
+
+---
+
+## Task 8: Snapshots & change tracking
+
+**Files:**
+- Create: `packages/el-form-react-hooks/src/__tests__/snapshots.runtime.test.tsx`
+
+- [ ] **Step 1: Write the test file**
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useForm } from "..";
+
+function SnapshotDemo() {
+  const form = useForm<{ name: string }>({ defaultValues: { name: "start" } });
+  const { register } = form;
+  return (
+    <div>
+      <input aria-label="name" {...register("name")} />
+      <button onClick={() => ((window as any).__snap = form.getSnapshot())}>snap</button>
+      <button onClick={() => form.restoreSnapshot((window as any).__snap)}>restore</button>
+      <span data-testid="changes">{String(form.hasChanges())}</span>
+    </div>
+  );
+}
+
+describe("snapshots & change tracking", () => {
+  it("captures and restores a snapshot", () => {
+    render(<SnapshotDemo />);
+    fireEvent.click(screen.getByText("snap")); // capture { name: "start" }
+    fireEvent.change(screen.getByLabelText("name"), { target: { value: "edited" } });
+    expect((screen.getByLabelText("name") as HTMLInputElement).value).toBe("edited");
+    fireEvent.click(screen.getByText("restore"));
+    expect((screen.getByLabelText("name") as HTMLInputElement).value).toBe("start");
+  });
+
+  it("hasChanges reflects edits vs defaults", () => {
+    render(<SnapshotDemo />);
+    expect(screen.getByTestId("changes").textContent).toBe("false");
+    fireEvent.change(screen.getByLabelText("name"), { target: { value: "x" } });
+    expect(screen.getByTestId("changes").textContent).toBe("true");
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__/snapshots.runtime.test.tsx`
+Expected: PASS. Record failures under Findings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/el-form-react-hooks/src/__tests__/snapshots.runtime.test.tsx
+git commit -m "test(hooks): cover getSnapshot/restoreSnapshot/hasChanges"
+```
+
+---
+
+## Task 9: Expand tsd type-error tests
+
+**Files:**
+- Modify: `packages/el-form-react-hooks/tsd.test-d.ts`
+
+- [ ] **Step 1: Append type-error assertions**
+
+Add inside a new block at the end of the existing file (keep the existing block intact):
+
+```tsx
+import { expectType, expectError } from "tsd";
+import { useForm } from "./src";
+
+{
+  const form = useForm<{ email: string; age: number; user: { name: string } }>({
+    defaultValues: { email: "", age: 0, user: { name: "" } },
+  });
+
+  // valid paths typed correctly
+  expectType<string>(form.register("email").value);
+  expectType<string>(form.register("user.name").value);
+
+  // setValue rejects unknown path
+  expectError(form.setValue("nope", "x"));
+
+  // setValue rejects wrong value type for a known path
+  expectError(form.setValue("age", "not-a-number"));
+
+  // watch rejects unknown path
+  expectError(form.watch("nope"));
+
+  // handleSubmit data is exactly T
+  form.handleSubmit((data) => {
+    expectType<{ email: string; age: number; user: { name: string } }>(data);
+  });
+}
+```
+
+- [ ] **Step 2: Run tsd**
+
+Run: `pnpm --filter el-form-react-hooks exec tsd --files tsd.test-d.ts`
+Expected: PASS (no tsd errors). If `expectError` cases do NOT error (i.e. the library is too loosely typed), that is a **type-safety finding** — record under Findings; relax the specific assertion to keep the suite green ONLY after noting it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/el-form-react-hooks/tsd.test-d.ts
+git commit -m "test(hooks): expand tsd type-error coverage for setValue/watch/handleSubmit"
+```
+
+---
+
+## Task 10: AutoForm submit tests
+
+**Files:**
+- Create: `packages/el-form-react-components/src/__tests__/AutoForm.submit.test.tsx`
+
+- [ ] **Step 1: Write the test file**
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { z } from "zod";
+import { AutoForm } from "..";
+
+const schema = z.object({
+  email: z.string().email("Invalid email"),
+  name: z.string().min(1, "Name is required"),
+});
+
+describe("AutoForm submit", () => {
+  it("calls onSubmit with typed data when valid", async () => {
+    const onSubmit = vi.fn();
+    render(<AutoForm schema={schema} onSubmit={onSubmit} />);
+    const inputs = document.querySelectorAll("input");
+    fireEvent.change(inputs[0], { target: { value: "a@b.com" } });
+    fireEvent.change(inputs[1], { target: { value: "Ada" } });
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({ email: "a@b.com", name: "Ada" });
+  });
+
+  it("calls onError on invalid submit", async () => {
+    const onSubmit = vi.fn();
+    const onError = vi.fn();
+    render(<AutoForm schema={schema} onSubmit={onSubmit} onError={onError} />);
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+    await waitFor(() => expect(onError).toHaveBeenCalled());
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});
+```
+
+Note: AutoForm's default submit button label/role — if `getByRole("button", { name: /submit/i })` doesn't match, inspect the rendered button text in `FieldComponents.tsx`/`AutoForm.tsx` and adjust the matcher. This is a test-wiring fix, not a library finding.
+
+- [ ] **Step 2: Run**
+
+Run: `pnpm --filter el-form-react-components exec vitest --environment jsdom --run src/__tests__/AutoForm.submit.test.tsx`
+Expected: PASS. Record true behavioral failures under Findings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/el-form-react-components/src/__tests__/AutoForm.submit.test.tsx
+git commit -m "test(components): cover AutoForm onSubmit/onError"
+```
+
+---
+
+## Task 11: Add components test step to CI
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add the step after the react-hooks test step**
+
+Insert after the existing `Test react-hooks (runtime + tsd)` step:
+
+```yaml
+      - name: Test el-form-react-components (vitest)
+        run: pnpm --filter el-form-react-components exec vitest --environment jsdom --run
+```
+
+(Use `exec vitest` directly, NOT `pnpm --filter el-form-react-components test`, because that script runs `pnpm -w -r build` first — redundant since the `Build workspace` step already ran, and it would rebuild on every Zod matrix leg.)
+
+- [ ] **Step 2: Validate the YAML locally**
+
+Run: `pnpm --filter el-form-react-components exec vitest --environment jsdom --run`
+Expected: all component tests pass (existing ~21 + new AutoForm submit tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: run el-form-react-components tests on every push"
+```
+
+---
+
+## Task 12: Full suite green + gitignore sweep artifacts
+
+**Files:**
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Add sweep artifact ignores**
+
+Append to `.gitignore`:
+
+```
+# Pre-launch sweep skill artifacts
+.sweep-results/
+```
+
+- [ ] **Step 2: Run the entire workspace test suite**
+
+Run: `pnpm -r test`
+Expected: all packages green (core, hooks incl. tsd, components, mcp). Capture the real summary output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .gitignore
+git commit -m "chore: ignore pre-launch sweep artifacts"
+```
+
+---
+
+## Task 13: Sweep skill — runner script
+
+The sweep is a self-contained Node ESM script the skill invokes. It self-installs
+Chromium, assumes the dev server is already running on port 3001 (the SKILL.md
+boots it), drives each demo, asserts, screenshots, and writes a report.
+
+**Files:**
+- Create: `.claude/skills/sweep-form-app/run-sweep.mjs`
+
+**Key facts (verified against the example app):**
+- Dev server: `pnpm --filter el-form-testing-app dev` → http://localhost:3001
+- Sidebar items are `<button>` elements whose text is the human label; all
+  categories are expanded by default, so buttons are clickable without expanding.
+- Demo label map (id → exact button text), from `Sidebar.tsx`:
+  `basic-validation`="Basic Validation", `onblur-validation`="OnBlur Validation",
+  `async-validation`="Async Validation", `file-upload`="Basic File Upload",
+  `advanced-file`="Advanced File Validation", `zod-file`="Zod File Validation",
+  `complex-arrays`="Complex Arrays", `form-history`="Form History",
+  `discriminated-union`="Manual Discriminated", `auto-discriminated`="Auto Discriminated",
+  `general-autoform`="General AutoForm", `form-switch-field`="Field Example",
+  `form-switch-select`="Select Example", `form-switch-compat`="Back Compat",
+  `use-field-rerender`="useField Rerender".
+
+- [ ] **Step 1: Write the runner script**
+
+```js
+// .claude/skills/sweep-form-app/run-sweep.mjs
+// Pre-launch sweep of the el-form example app. Run AFTER the dev server is up on :3001.
+import { chromium } from "playwright";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const BASE = "http://localhost:3001";
+const OUT = ".sweep-results";
+mkdirSync(OUT, { recursive: true });
+
+// id -> { label (sidebar button text), check(page) -> {pass, note} }
+const DEMOS = [
+  { id: "basic-validation", label: "Basic Validation", check: assertValidationErrors },
+  { id: "onblur-validation", label: "OnBlur Validation", check: assertRenders },
+  { id: "async-validation", label: "Async Validation", check: assertRenders },
+  { id: "file-upload", label: "Basic File Upload", check: assertRenders },
+  { id: "advanced-file", label: "Advanced File Validation", check: assertRenders },
+  { id: "zod-file", label: "Zod File Validation", check: assertRenders },
+  { id: "complex-arrays", label: "Complex Arrays", check: assertArrayAddRemove },
+  { id: "form-history", label: "Form History", check: assertRenders },
+  { id: "discriminated-union", label: "Manual Discriminated", check: assertRenders },
+  { id: "auto-discriminated", label: "Auto Discriminated", check: assertRenders },
+  { id: "general-autoform", label: "General AutoForm", check: assertRenders },
+  { id: "form-switch-field", label: "Field Example", check: assertRenders },
+  { id: "form-switch-select", label: "Select Example", check: assertRenders },
+  { id: "form-switch-compat", label: "Back Compat", check: assertRenders },
+  { id: "use-field-rerender", label: "useField Rerender", check: assertRenders },
+];
+
+// --- assertions (anchored to suite behaviors) ---
+
+// Baseline: the demo mounted and shows at least one input or button.
+async function assertRenders(page) {
+  const controls = await page.locator("input, select, textarea, button").count();
+  return controls > 1
+    ? { pass: true, note: `rendered (${controls} controls)` }
+    : { pass: false, note: "no interactive controls found" };
+}
+
+// Submit empty → expect at least one validation error to appear.
+async function assertValidationErrors(page) {
+  const submit = page.getByRole("button", { name: /submit/i }).first();
+  if (!(await submit.count())) return { pass: false, note: "no submit button" };
+  await submit.click();
+  // errors render as text in red spans/paragraphs; look for any new text node
+  // matching common validation phrasing.
+  const err = page.locator("text=/required|invalid|must|valid/i").first();
+  const appeared = await err
+    .waitFor({ state: "visible", timeout: 3000 })
+    .then(() => true)
+    .catch(() => false);
+  return appeared
+    ? { pass: true, note: "validation error shown on empty submit" }
+    : { pass: false, note: "no validation error after empty submit" };
+}
+
+// Array demo: count rows, click an Add button, expect the count to grow.
+async function assertArrayAddRemove(page) {
+  const add = page.getByRole("button", { name: /add/i }).first();
+  if (!(await add.count())) return { pass: false, note: "no add button" };
+  const before = await page.locator("input").count();
+  await add.click();
+  await page.waitForTimeout(200);
+  const after = await page.locator("input").count();
+  return after > before
+    ? { pass: true, note: `inputs ${before} -> ${after} after add` }
+    : { pass: false, note: `add did not increase inputs (${before} -> ${after})` };
+}
+
+// --- driver ---
+
+async function run() {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  const consoleErrors = [];
+  page.on("console", (m) => {
+    if (m.type() === "error") consoleErrors.push(m.text());
+  });
+
+  await page.goto(BASE, { waitUntil: "networkidle" });
+  const results = [];
+
+  for (const demo of DEMOS) {
+    const before = consoleErrors.length;
+    let row = { id: demo.id, label: demo.label, pass: false, note: "", shot: `${demo.id}.png` };
+    try {
+      await page.getByRole("button", { name: demo.label, exact: true }).first().click();
+      await page.waitForTimeout(300); // allow the demo to mount
+      const r = await demo.check(page);
+      row.pass = r.pass;
+      row.note = r.note;
+    } catch (e) {
+      row.note = `threw: ${e.message}`;
+    }
+    await page.screenshot({ path: join(OUT, row.shot) }).catch(() => {});
+    row.consoleErrors = consoleErrors.length - before;
+    results.push(row);
+    console.log(`${row.pass ? "PASS" : "FAIL"}  ${demo.label}  — ${row.note}`);
+  }
+
+  await browser.close();
+  writeReport(results, consoleErrors);
+  const failed = results.filter((r) => !r.pass).length;
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+function writeReport(results, consoleErrors) {
+  const pass = results.filter((r) => r.pass).length;
+  const fail = results.length - pass;
+  const warn = consoleErrors.length;
+  const lines = [
+    `# El Form Sweep`,
+    ``,
+    `✅ ${pass} / ${results.length} passed   ❌ ${fail} failed   ⚠️ ${warn} console errors`,
+    ``,
+    `| Feature | Result | Notes | Console | Screenshot |`,
+    `|---------|--------|-------|---------|------------|`,
+    ...results.map(
+      (r) =>
+        `| ${r.label} | ${r.pass ? "✅" : "❌"} | ${r.note} | ${r.consoleErrors || 0} | ![](${r.shot}) |`
+    ),
+  ];
+  if (consoleErrors.length) {
+    lines.push(``, `## Console errors`, ``, ...consoleErrors.slice(0, 50).map((e) => `- ${e}`));
+  }
+  writeFileSync(join(OUT, "REPORT.md"), lines.join("\n") + "\n");
+  console.log(`\nReport: ${join(OUT, "REPORT.md")}  (${pass}/${results.length} passed)`);
+}
+
+run().catch((e) => {
+  console.error("Sweep crashed:", e);
+  process.exit(2);
+});
+```
+
+- [ ] **Step 2: Commit (script only; verified end-to-end in Task 15)**
+
+```bash
+git add .claude/skills/sweep-form-app/run-sweep.mjs
+git commit -m "feat(skill): add el-form example-app sweep runner script"
+```
+
+---
+
+## Task 14: Sweep skill — SKILL.md
+
+**Files:**
+- Create: `.claude/skills/sweep-form-app/SKILL.md`
+
+- [ ] **Step 1: Write the skill file**
+
+````markdown
+---
+name: sweep-form-app
+description: Use before promoting/releasing el-form to verify the example app works end-to-end. Boots the example app and drives all 15 form demos in a real browser with Playwright, asserting behavior, capturing screenshots, and writing a pass/fail report. Manual pre-launch gate — not run in CI.
+---
+
+# Sweep the El Form example app
+
+Drives every demo in `examples/react` (port 3001) in a real browser and writes a
+report you skim before promoting the library.
+
+## When to use
+
+Before sending el-form to blogs/communities, or before a release — to confirm the
+whole app actually works, not just the unit suite.
+
+## Steps
+
+1. **Install Playwright + Chromium** (skill-local; not a repo dependency):
+   ```bash
+   npm exec --yes playwright@latest install chromium
+   ```
+   If `playwright` isn't resolvable as a module for the runner, install it in a
+   temp scope: `npm install --no-save playwright` at the repo root is acceptable
+   (it is git-ignored via node_modules). State the ~download cost to the user.
+
+2. **Boot the dev server** (background) and wait for port 3001:
+   ```bash
+   pnpm --filter el-form-testing-app dev
+   ```
+   Wait until http://localhost:3001 responds (poll, ~10s). If the port is busy,
+   assume the app is already running and continue.
+
+3. **Run the sweep**:
+   ```bash
+   node .claude/skills/sweep-form-app/run-sweep.mjs
+   ```
+
+4. **Read the report**: `.sweep-results/REPORT.md` — a table of PASS/FAIL per
+   demo, console-error counts, and screenshots. Summarize it for the user:
+   how many passed, which failed and why. Do NOT claim "all good" unless the
+   report shows it.
+
+5. **Stop the dev server** you started.
+
+## Output
+
+- `.sweep-results/REPORT.md` — pass/fail table + console errors
+- `.sweep-results/<demo>.png` — one screenshot per demo
+
+Both are git-ignored.
+
+## Notes
+
+- The runner exits non-zero if any demo fails — surface that to the user.
+- One broken demo does not abort the sweep; each is isolated.
+- The assertions are intentionally conservative (does it render, do validation
+  errors appear, do arrays grow). For deeper per-feature checks, extend `DEMOS`
+  in `run-sweep.mjs` — the committed vitest suite is the source of truth for what
+  each feature *should* do.
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/sweep-form-app/SKILL.md
+git commit -m "feat(skill): add sweep-form-app SKILL.md"
+```
+
+---
+
+## Task 15: Verify the sweep skill end-to-end (testing the test)
+
+**No new files — this task PROVES the sweep works, including catching a failure.**
+
+- [ ] **Step 1: Install Playwright + Chromium**
+
+Run: `npm exec --yes playwright@latest install chromium` (and `npm install --no-save playwright` if the runner can't resolve the module).
+Expected: Chromium downloads successfully.
+
+- [ ] **Step 2: Boot the dev server in the background**
+
+Run: `pnpm --filter el-form-testing-app dev` (background), then poll `http://localhost:3001` until it responds.
+
+- [ ] **Step 3: Run the sweep against the real app**
+
+Run: `node .claude/skills/sweep-form-app/run-sweep.mjs`
+Expected: console prints PASS/FAIL per demo; `.sweep-results/REPORT.md` and 15 PNGs exist. Capture the real pass count.
+
+- [ ] **Step 4: Prove it CATCHES a failure**
+
+Temporarily point one demo's label at a non-existent button (edit `run-sweep.mjs`: change one `label` to `"Does Not Exist"`), re-run, and confirm that demo shows **FAIL** in the report. Then revert the edit.
+Expected: exactly one FAIL row for the broken demo; revert restores all-pass (modulo any genuine Findings).
+
+- [ ] **Step 5: Record findings & stop the server**
+
+If real demos failed (not the injected one), record them under "## Findings" and report to the maintainer. Stop the dev server. No commit (verification only; any `run-sweep.mjs` edits were reverted).
+
+---
+
+## Task 16: Contributor test-my-change skill
+
+**Files:**
+- Create: `.claude/skills/test-my-change/SKILL.md`
+
+- [ ] **Step 1: Write the skill file**
+
+````markdown
+---
+name: test-my-change
+description: Use after editing el-form package source to run the relevant package tests for what you changed, before pushing or opening a PR. Detects changed packages via git and runs their vitest (and tsd for hooks) suites.
+---
+
+# Test my change
+
+Runs the test suites for the el-form package(s) you've modified.
+
+## Steps
+
+1. **Find changed packages**:
+   ```bash
+   git diff --name-only $(git merge-base HEAD main)...HEAD
+   git diff --name-only            # unstaged too
+   ```
+   Map changed paths to packages:
+   - `packages/el-form-core/**` → `el-form-core`
+   - `packages/el-form-react-hooks/**` → `el-form-react-hooks`
+   - `packages/el-form-react-components/**` → `el-form-react-components`
+   - `packages/el-form-mcp/**` → `el-form-mcp`
+   - `packages/el-form-react/**` → has no tests; run hooks + components instead
+     (it re-exports them).
+
+2. **Run the matching suites** (only the affected ones):
+   ```bash
+   pnpm --filter el-form-core exec vitest --run
+   pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run
+   pnpm --filter el-form-react-hooks exec tsd --files tsd.test-d.ts
+   pnpm --filter el-form-react-components exec vitest --environment jsdom --run
+   pnpm --filter el-form-mcp test
+   ```
+
+3. **Report** pass/fail per package. If anything fails, show the failing test
+   names and output — do not summarize as "some failures".
+
+## Notes
+
+- If you can't determine the changed package, run the full suite: `pnpm -r test`.
+- This mirrors what CI runs, so green here means CI should be green.
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/test-my-change/SKILL.md
+git commit -m "feat(skill): add test-my-change contributor skill"
+```
+
+---
+
+## Task 17: Final verification & push
+
+- [ ] **Step 1: Full suite green**
+
+Run: `pnpm -r test`
+Expected: all packages pass. Capture the summary.
+
+- [ ] **Step 2: Confirm sweep artifacts are ignored, not committed**
+
+Run: `git status --porcelain | grep sweep-results || echo "clean"`
+Expected: `clean` (artifacts ignored).
+
+- [ ] **Step 3: Push the branch and open a PR**
+
+```bash
+git push -u origin feat/test-suite-and-sweep-skill
+gh pr create --base main --title "test: comprehensive useForm suite + pre-launch sweep skill" --body "<summary + Findings>"
+```
+
+- [ ] **Step 4: Report Findings**
+
+Paste the "## Findings" section (any real discrepancies surfaced by TDD or the
+sweep) into the PR body and to the maintainer. If empty, state "no library
+discrepancies found — suite is characterization-green."
+
+---
+
+## Findings
+
+_(Record any real library discrepancies discovered while writing tests or running
+the sweep. Do NOT silently edit library source to make a test pass — surface here.)_
+
+- _(none yet)_
+

--- a/docs/superpowers/plans/2026-06-01-form-testing-and-sweep-skill.md
+++ b/docs/superpowers/plans/2026-06-01-form-testing-and-sweep-skill.md
@@ -602,6 +602,118 @@ git commit -m "test(hooks): cover setError/clearErrors/trigger"
 
 ---
 
+## Task 6.5: LIBRARY FIX — `trigger()` writes errors to state (resolves FINDING 2)
+
+Maintainer chose to fix now. `trigger` must merge computed validation errors into
+`formState` (and update `isValid`) so the UI shows them, like React Hook Form's
+`trigger`. Currently it only returns the boolean.
+
+**Root cause (verified):** `packages/el-form-react-hooks/src/utils/errorManagement.ts`
+→ `trigger` (lines 55–87). All three branches call the validation manager and
+`return` validity, but never `setFormState`.
+
+**Design (mirror `handleSubmit`'s proven pattern):** `errorManagement` receives
+`formState` + `setFormState` (NOT a ref) — same as `submitOperations`. Managers are
+recreated each render so `formState.values` is current at call time. For each
+branch, after computing results, call `setFormState` to merge the field error(s)
+in (or clear them when a field is now valid), and set `isValid` accordingly. Keep
+returning the same boolean.
+
+**Files:**
+- Modify: `packages/el-form-react-hooks/src/utils/errorManagement.ts` (`trigger` only)
+- Test: existing `packages/el-form-react-hooks/src/__tests__/errors.runtime.test.tsx` (3rd case turns green)
+
+- [ ] **Step 1: Confirm red**
+
+Run: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__/errors.runtime.test.tsx`
+Expected: `"trigger validates a field on demand"` FAILS (1 failed | 2 passed).
+
+- [ ] **Step 2: Implement**
+
+Rewrite `trigger` so each branch updates state. Reference implementation:
+
+```ts
+trigger: (async (nameOrNames?: keyof T | (keyof T)[]) => {
+  // Validate all fields
+  if (!nameOrNames) {
+    const { isValid, errors } = await validationManager.validateForm(
+      formState.values
+    );
+    setFormState((prev) => ({ ...prev, errors, isValid }));
+    return isValid;
+  }
+
+  // Validate multiple fields: merge each field's errors, clearing ones now valid
+  if (Array.isArray(nameOrNames)) {
+    const results = await Promise.all(
+      nameOrNames.map((name) =>
+        validationManager
+          .validateField(name, formState.values[name], formState.values, "onSubmit")
+          .then((r) => ({ name, r }))
+      )
+    );
+    setFormState((prev) => {
+      const errors = { ...prev.errors };
+      for (const { name, r } of results) {
+        if (!r.isValid) Object.assign(errors, r.errors);
+        else delete errors[name];
+      }
+      return { ...prev, errors, isValid: Object.keys(errors).length === 0 };
+    });
+    return results.every(({ r }) => r.isValid);
+  }
+
+  // Validate single field
+  const result = await validationManager.validateField(
+    nameOrNames,
+    formState.values[nameOrNames],
+    formState.values,
+    "onSubmit"
+  );
+  setFormState((prev) => {
+    const errors = { ...prev.errors };
+    if (!result.isValid) Object.assign(errors, result.errors);
+    else delete errors[nameOrNames];
+    return { ...prev, errors, isValid: Object.keys(errors).length === 0 };
+  });
+  return result.isValid;
+}) as UseFormReturn<T>["trigger"],
+```
+
+Note: `isValid: Object.keys(errors).length === 0` is a per-call approximation
+sufficient for single/array triggers; the all-fields branch uses the authoritative
+`isValid` from `validateForm`. Do not change `setError`/`clearErrors`.
+
+- [ ] **Step 3: Green + full regression**
+
+Run: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__/errors.runtime.test.tsx` → 3/3 PASS.
+Run the full hooks + core + components suites; all must stay green:
+`pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run` /
+`pnpm --filter el-form-core exec vitest --run` /
+`pnpm --filter el-form-react-components exec vitest --environment jsdom --run`.
+
+- [ ] **Step 4: Commit + changeset**
+
+```bash
+git add packages/el-form-react-hooks/src/utils/errorManagement.ts
+git commit -m "fix(hooks): trigger() writes validation errors to formState
+
+trigger() validated but never surfaced errors to the UI. It now merges
+computed errors into formState (and updates isValid) across all branches,
+matching React Hook Form semantics. Fixes FINDING 2."
+cat > .changeset/fix-trigger-writes-errors.md <<'EOF'
+---
+"el-form-react-hooks": patch
+---
+
+fix: `trigger()` now writes validation errors into `formState.errors` (and updates `isValid`) so the UI reflects them, matching React Hook Form. Previously it returned the correct boolean but left `formState` untouched.
+EOF
+git add .changeset/fix-trigger-writes-errors.md
+git commit -m "chore: changeset for trigger error-surfacing fix"
+```
+
+---
+
 ## Task 7: Array operations
 
 **Files:**

--- a/docs/superpowers/plans/2026-06-01-form-testing-and-sweep-skill.md
+++ b/docs/superpowers/plans/2026-06-01-form-testing-and-sweep-skill.md
@@ -132,6 +132,107 @@ git commit -m "test(hooks): cover handleSubmit valid/invalid/async behavior"
 
 ---
 
+## Task 1.5: LIBRARY FIX — make submit respect configured validators (resolves FINDING 1)
+
+Maintainer chose the **library fix**: at submit time, `handleSubmit` must validate
+against whatever validators are configured (`onChange`/`onBlur`/`onSubmit`), not
+just a literal `onSubmit` key. This makes `validators: { onChange: schema }` block
+invalid submits, matching the docs and user expectation.
+
+**Root cause (verified):** `packages/el-form-react-hooks/src/utils/validation.ts`
+→ `validateForm()` (the form-level path, ~lines 167–230) builds
+`event = { type: "onSubmit" }` and passes it to the core engine's
+`validateForm`/`validateField`. The engine
+(`el-form-core/src/validators/engine.ts:54`) reads `config["onSubmit"]`; a config
+with only `onChange` has no `onSubmit` key, so it returns valid. The core engine is
+shared and must NOT change. The fix is in the hooks-layer `validateForm` only.
+
+**Design:** When `validateForm` is called with `eventType === "onSubmit"` (the
+default, used by `handleSubmit`/`submit`/`submitAsync`), run the configured
+validators across their actual keys instead of only `onSubmit`. Concretely: for
+the top-level `validators` object and each `fieldValidators` entry, validate once
+per *configured sync key* present among `onChange`/`onBlur`/`onSubmit`; the form is
+invalid if ANY of them reports invalid. For non-submit eventTypes, keep current
+behavior (validate only that event). This mirrors the existing "smart validation"
+in `shouldValidate` (line 69) and leaves the discriminated-union `schema` fallback
+(already unconditional) untouched.
+
+**Files:**
+- Modify: `packages/el-form-react-hooks/src/utils/validation.ts` (the `validateForm` method only)
+- Test: the existing `packages/el-form-react-hooks/src/__tests__/submit.runtime.test.tsx` (its 3rd case, currently failing, becomes the regression test)
+
+- [ ] **Step 1: Confirm the failing test (red)**
+
+Run: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__/submit.runtime.test.tsx`
+Expected: `"does not call onValid when invalid"` FAILS (1 failed | 2 passed). This is the red state the fix turns green.
+
+- [ ] **Step 2: Implement the fix in `validateForm`**
+
+In `validation.ts`, locate the `validateForm` method. For the form-level
+`validators` block and the per-field `fieldValidators` loop, when
+`eventType === "onSubmit"`, iterate the configured sync keys and OR-combine
+results. Helper sketch (adapt to the existing code structure — do not rewrite
+unrelated logic):
+
+```ts
+const SYNC_KEYS = ["onChange", "onBlur", "onSubmit"] as const;
+
+// keys actually present on a given validator config
+const configuredKeys = (cfg: any) =>
+  SYNC_KEYS.filter((k) => cfg && typeof cfg[k] !== "undefined");
+
+// at submit, validate against every configured key; else just the event
+const keysToRun =
+  eventType === "onSubmit" ? configuredKeys(validators) : [eventType];
+```
+
+For each key in `keysToRun`, build `event = { type: key, isAsync: false }`, call
+`validationEngine.current.validateForm(values, validators, event)` (and the field
+equivalent for each `fieldValidators` entry), and merge errors / AND the validity.
+If `keysToRun` is empty (no validators configured), preserve current behavior
+(valid). Keep the existing top-level `schema`-prop fallback intact.
+
+- [ ] **Step 3: Run the submit tests (green)**
+
+Run: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__/submit.runtime.test.tsx`
+Expected: 3/3 PASS.
+
+- [ ] **Step 4: Run the FULL hooks suite + core suite (no regressions)**
+
+Run: `pnpm --filter el-form-core exec vitest --run`
+Run: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run`
+Run: `pnpm --filter el-form-react-components exec vitest --environment jsdom --run`
+Expected: all green. The existing `asyncValidation.test.tsx` and AutoForm tests
+must still pass — this is the critical regression gate, since validateForm is
+shared by all submit paths.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/el-form-react-hooks/src/utils/validation.ts
+git commit -m "fix(hooks): submit validates against configured validators, not just onSubmit
+
+Previously useForm({ validators: { onChange: schema } }) did not block
+submit — invalid data reached onValid. validateForm now runs whichever
+validators are configured at submit time. Fixes FINDING 1."
+```
+
+- [ ] **Step 6: Add a changeset**
+
+```bash
+cat > .changeset/fix-onchange-submit-gate.md <<'EOF'
+---
+"el-form-react-hooks": patch
+---
+
+fix: `handleSubmit` now blocks submission when a configured `validators.onChange` (or `onBlur`) validator fails. Previously only `validators.onSubmit` gated submit, so forms validating on change could submit invalid data.
+EOF
+git add .changeset/fix-onchange-submit-gate.md
+git commit -m "chore: changeset for onChange submit-gate fix"
+```
+
+---
+
 ## Task 2: setValue / setValues tests
 
 **Files:**
@@ -1155,5 +1256,41 @@ discrepancies found — suite is characterization-green."
 _(Record any real library discrepancies discovered while writing tests or running
 the sweep. Do NOT silently edit library source to make a test pass — surface here.)_
 
-- _(none yet)_
+### FINDING 1 (Task 1) — `validators.onChange` does NOT block submit ⚠️ HIGH
+
+**Severity:** High — affects correctness of forms following the documented quick-start.
+
+**Symptom:** With `useForm({ validators: { onChange: schema } })`, submitting an
+invalid form calls `onValid` (the success handler) with the invalid data instead
+of calling `onError`/blocking. Independently reproduced (controller ran a separate
+repro, not just the task test):
+- `validators: { onChange: schema }` + invalid submit → `onValid` called with `{email:"bad"}` ❌
+- `validators: { onSubmit: schema }` + invalid submit → `onValid` NOT called ✅
+
+**Root cause:** `packages/el-form-react-hooks/src/utils/validation.ts` →
+`validateForm()` builds `event = { type: "onSubmit" }` and calls the core engine's
+`validateForm(values, validators, event)`. The engine
+(`el-form-core/src/validators/engine.ts`) looks up `config["onSubmit"]`; a config
+with only an `onChange` key has no `onSubmit`, so the engine returns
+`{ isValid: true }`. The top-level `schema`-prop fallback (validation.ts:211) only
+runs when a separate `schema` prop is passed, not for `validators.onChange`.
+
+**Why it matters:** The docs, quick-start, README, and the dev.to draft all use
+`validators: { onChange: schema }` and assume submit is protected. Under this bug,
+those forms can submit invalid data.
+
+**Decision needed from maintainer (do NOT fix unilaterally):**
+- (a) **Library fix** — at submit time, also run whichever validators are
+  configured (onChange/onBlur) as a final gate, OR
+- (b) **Docs fix** — declare that submit only respects `validators.onSubmit` (or
+  `mode: "all"`), and update every doc/example to configure onSubmit.
+
+Option (a) matches user expectations and what the docs already imply; (b) is a
+smaller change but means the current docs are teaching an unsafe pattern.
+
+**Test status:** `submit.runtime.test.tsx` currently has 1 failing case
+(`"does not call onValid when invalid"`) committed at `f5a8c20`. **This failing
+test must be resolved before the branch is mergeable** — either by the library fix
+(a, test then passes) or by rewriting the test to use `validators: { onSubmit }`
+and documenting the constraint (b). Pending maintainer decision.
 

--- a/docs/superpowers/plans/2026-06-01-form-testing-and-sweep-skill.md
+++ b/docs/superpowers/plans/2026-06-01-form-testing-and-sweep-skill.md
@@ -1256,7 +1256,52 @@ discrepancies found — suite is characterization-green."
 _(Record any real library discrepancies discovered while writing tests or running
 the sweep. Do NOT silently edit library source to make a test pass — surface here.)_
 
-### FINDING 1 (Task 1) — `validators.onChange` does NOT block submit ⚠️ HIGH
+### FINDING 2 (Task 6) — `trigger()` validates but never writes errors to state ⚠️ MEDIUM
+
+**Severity:** Medium — `trigger` returns the correct boolean, but the imperative
+"validate and show errors" use case is broken.
+
+**Symptom:** Calling `form.trigger("email")` with an invalid value returns `false`
+(correct) but does NOT populate `formState.errors.email`, so the UI shows no error.
+Test `errors.runtime.test.tsx` → `"trigger validates a field on demand"` fails
+(`expected '' to be 'Invalid email'`), committed red at `23ce453`.
+
+**Root cause (verified at source):**
+`packages/el-form-react-hooks/src/utils/errorManagement.ts` → `trigger` (lines
+55–87). All three branches (no-arg, array, single) call
+`validationManager.validateField/validateForm`, compute the result, and `return`
+the validity boolean — but **never call `setFormState`** to merge the errors into
+state. Contrast `setError`/`clearErrors` directly above (lines 31–52), which both
+do call `setFormState`.
+
+**Conventional contract:** React Hook Form's `trigger()` (which el-form's API
+mirrors) populates `formState.errors` as a side effect. So the test's expectation
+matches the expected contract — this is a real bug.
+
+**Fix caveat (why it needs care, not a quick patch):** `trigger` closes over
+`formState.values` directly. Other managers (e.g. the register onChange path) read
+from a `formStateRef.current` to avoid stale-closure reads. A correct fix must
+(a) merge the computed errors into state via `setFormState`, and (b) verify it
+reads current values, not a stale closure — likely mirroring how `handleSubmit`
+threads validation results back into state. Single + array + all-fields branches
+all need it.
+
+**Decision needed from maintainer:** fix now (new plan task, TDD, turns the parked
+test green) or defer (rewrite the test to assert only the return value and log the
+UI-error gap as a known issue). Recommended: fix now, same as Finding 1 — it's a
+small, contained manager.
+
+**Test status:** `errors.runtime.test.tsx` has 1 failing case parked at `23ce453`;
+must be resolved (fix or test-rewrite) before the branch is mergeable.
+
+---
+
+### FINDING 1 (Task 1) — `validators.onChange` does NOT block submit ⚠️ HIGH — ✅ FIXED
+
+**Status:** RESOLVED via library fix (Task 1.5, commit `c627209`, changeset
+`74efd69`). `validateForm` now runs all configured sync validators at submit time.
+The submit-test 3rd case passes; full suite regression-green. Details retained
+below for the record.
 
 **Severity:** High — affects correctness of forms following the documented quick-start.
 

--- a/docs/superpowers/specs/2026-06-01-form-testing-and-sweep-design.md
+++ b/docs/superpowers/specs/2026-06-01-form-testing-and-sweep-design.md
@@ -47,6 +47,7 @@ FEATURE SPINE:
   array ops · snapshots · validation modes · type errors
 
   ├─ 1. COMMITTED SUITE  (vitest + Testing Library + tsd)  → CI, fast, deterministic
+  │      (+ one new ci.yml step for el-form-react-components)
   ├─ 2. SWEEP SKILL      (Playwright vs example app)        → manual, pre-launch
   └─ 3. CONTRIBUTOR PATH (CI step + test-my-change skill)
 ```
@@ -54,6 +55,15 @@ FEATURE SPINE:
 **Invariant:** every feature in the spine has both a committed suite test and a
 sweep checklist item. "Is the sweep complete?" reduces to "does it cover the
 spine?"
+
+The suite↔sweep mapping is **many-to-many, not 1:1 per demo.** Most demos anchor
+to one of the new hooks/AutoForm suite files. Three groups anchor to **existing**
+tests rather than new suite files: the file-upload demos (`file-upload`,
+`advanced-file`, `zod-file`) exercise the file methods, and the `form-switch-*`
+demos map to the existing `FormSwitch.runtime.test.tsx` / `AutoForm.*` component
+tests. For those, the sweep's expected behavior anchors to the existing test (or,
+where none exists, to inline expectations stated in the sweep checklist) — the
+invariant does **not** require minting a new suite file per demo.
 
 The example app (`examples/react`, Vite dev server on **port 3001**) routes
 between 15 demos via `useState<TestId>` in `App.tsx` (a sidebar `Layout`
@@ -91,8 +101,20 @@ Expand with assertions that:
 
 ### AutoForm (`packages/el-form-react-components/src/__tests__/`)
 
-Fill the submit gap: `onSubmit` receives correct data, `onError` fires,
-`customErrorComponent` and `componentMap` render. (~5 tests.)
+New file `AutoForm.submit.test.tsx` (the existing `AutoForm.validation.test.tsx`
+covers validation/error display; this fills the **submit** gap, which none of the
+existing files cover): `onSubmit` receives correct typed data, `onError` fires on
+invalid submit, and `customErrorComponent` / `componentMap` overrides render.
+(~5 tests.)
+
+**CI gap to close:** `el-form-react-components` tests are **not** currently run by
+`ci.yml` (CI runs only `el-form-core`, `el-form-react-hooks`, `el-form-mcp`). So
+this component requires a one-line CI addition — a `Test el-form-react-components`
+step mirroring the existing per-package steps (the package already has a `test`
+script: `vitest --environment jsdom --run`). Without it, the new AutoForm tests
+plus the **existing** ~21 component tests would never run in CI. This is the only
+CI change required; the hooks runtime files and `tsd` land in the
+already-covered `el-form-react-hooks` path.
 
 **Total:** ~55 new runtime tests + ~10 tsd assertions.
 
@@ -165,11 +187,18 @@ the spine.
 
 ## Component 3 — Contributor Path
 
-- The committed suite already runs in CI per-package on every push; the new test
-  files land in directories CI already covers. **No new CI workflow needed.**
+- The hooks runtime files and `tsd` land in the `el-form-react-hooks` path CI
+  already runs every push — no workflow change for those. The **one** CI change
+  required is adding a `Test el-form-react-components` step to `ci.yml` (see the
+  AutoForm section above), so the component tests are gated too. No new *workflow
+  file* is needed — just one step in the existing `ci.yml`.
 - Add `.claude/skills/test-my-change/SKILL.md`: detects which package(s) the
-  contributor changed (via `git diff`) and runs the matching
-  `pnpm --filter <pkg> test` (plus `tsd` for hooks), reporting pass/fail.
+  contributor changed (via `git diff --name-only` against the merge base) and
+  runs the matching `pnpm --filter <pkg> test` (plus `tsd` for hooks), reporting
+  pass/fail. Package-detection map covers all five workspace packages
+  (`el-form-core`, `el-form-react-hooks`, `el-form-react-components`,
+  `el-form-react`, `el-form-mcp`); `el-form-react` has no `test` script, so a
+  change touching only it runs the dependent packages' tests instead.
 
 ## Testing Strategy (testing the tests)
 
@@ -191,7 +220,8 @@ the spine.
 
 ## Rollout
 
-1. Build committed suite (Component 1), run green in CI.
+1. Build committed suite (Component 1) and add the `el-form-react-components` CI
+   step; run green in CI.
 2. Build sweep skill (Component 2), verify end-to-end incl. a deliberate
    failure.
 3. Add contributor skill (Component 3).

--- a/docs/superpowers/specs/2026-06-01-form-testing-and-sweep-design.md
+++ b/docs/superpowers/specs/2026-06-01-form-testing-and-sweep-design.md
@@ -1,0 +1,198 @@
+# El Form — Test Suite & Pre-Launch Sweep Skill
+
+**Date:** 2026-06-01
+**Status:** Approved design, pending spec review
+**Branch:** `feat/test-suite-and-sweep-skill`
+
+## Problem
+
+El Form's automated tests are uneven. The most-used, least-tested surface is
+`el-form-react-hooks`: `useForm` exposes ~117 members but only 8 runtime test
+cases exist (async validation, register, selector). User-facing type errors are
+only covered for the hooks `register` path via one `tsd` file. There is **zero**
+browser/end-to-end coverage — the README literally instructs maintainers to run
+`pnpm dev` and click through 15 demos by hand.
+
+The maintainer wants to promote the library to blogs/communities and needs:
+
+1. **Concrete knowledge** of what works — a committed, authoritative test suite.
+2. **A way to verify changes** — CI coverage plus a contributor skill.
+3. **A pre-launch confidence gate** — a skill that sweeps the whole example app
+   in a real browser so the app is verified working before promotion.
+
+## Goals
+
+- Comprehensively test `useForm` runtime behavior and user-facing type errors.
+- Keep CI fast and deterministic (no browser in CI).
+- Provide a manual, human-triggered browser sweep of all example-app features
+  that asserts behavior and produces a skimmable report.
+- Keep the committed suite and the sweep in sync by construction.
+
+## Non-Goals (YAGNI)
+
+- Committing Playwright to CI (browser stays in the manual sweep skill only).
+- Visual-snapshot diffing as a correctness oracle.
+- Auto-filing GitHub issues from sweep failures.
+- Performance/load testing, cross-browser matrix.
+
+## Architecture
+
+Three artifacts organized around **one shared feature list ("the spine")** so
+the committed suite and the sweep skill stay in sync:
+
+```
+FEATURE SPINE:
+  submit · setValue/setValues · reset(+keep) · watch ·
+  setError/clearErrors · trigger · dirty/touched ·
+  array ops · snapshots · validation modes · type errors
+
+  ├─ 1. COMMITTED SUITE  (vitest + Testing Library + tsd)  → CI, fast, deterministic
+  ├─ 2. SWEEP SKILL      (Playwright vs example app)        → manual, pre-launch
+  └─ 3. CONTRIBUTOR PATH (CI step + test-my-change skill)
+```
+
+**Invariant:** every feature in the spine has both a committed suite test and a
+sweep checklist item. "Is the sweep complete?" reduces to "does it cover the
+spine?"
+
+The example app (`examples/react`, Vite dev server on **port 3001**) routes
+between 15 demos via `useState<TestId>` in `App.tsx` (a sidebar `Layout`
+calls `onSelectTest`). This app is the sweep target.
+
+## Component 1 — Committed Test Suite
+
+Extends the **existing** test infrastructure in `el-form-react-hooks`
+(`@testing-library/react` ^14, `vitest` ^2, `tsd` ^0.31, jsdom). No new test
+framework. Each runtime file uses a small driver component that exposes the hook
+through the DOM and asserts via `screen` + `fireEvent`, matching the existing
+`register.runtime.test.tsx` pattern.
+
+### Runtime files (`packages/el-form-react-hooks/src/__tests__/`)
+
+| File | Covers | ~tests |
+|------|--------|--------|
+| `submit.runtime.test.tsx` | `handleSubmit` calls `onValid` with correct typed data on valid input; calls `onError` and blocks on invalid; `isSubmitting` toggles; async `onSubmit` awaited | 7 |
+| `setValue.runtime.test.tsx` | `setValue` (incl. nested dot-path), `setValues` merge, number/checkbox coercion | 6 |
+| `reset.runtime.test.tsx` | `reset` to defaults and to explicit values; `keepErrors`/`keepDirty`/`keepTouched`; `resetField` | 6 |
+| `validation-modes.test.tsx` | `onChange`/`onBlur`/`onSubmit` trigger timing; error appears and clears per mode | 6 |
+| `state-tracking.test.tsx` | `isDirty`/`getDirtyFields`, `touched`/`markFieldTouched`, `isValid`, `hasErrors`/`getErrorCount`, `canSubmit` | 7 |
+| `errors.runtime.test.tsx` | `setError`/`clearErrors` (field + all), `trigger` (single/all/multi) | 5 |
+| `array-ops.runtime.test.tsx` | `addArrayItem`/`removeArrayItem` incl. nested paths and scalar arrays | 5 |
+| `snapshots.runtime.test.tsx` | `getSnapshot`/`restoreSnapshot`, `hasChanges`/`getChanges` | 4 |
+
+### Type-error coverage (`packages/el-form-react-hooks/tsd.test-d.ts`)
+
+Expand with assertions that:
+- invalid field paths error,
+- `setValue`/`watch`/`trigger` reject wrong paths and wrong value types,
+- `handleSubmit` `onValid` data is exactly `T`.
+
+(~10 assertions.)
+
+### AutoForm (`packages/el-form-react-components/src/__tests__/`)
+
+Fill the submit gap: `onSubmit` receives correct data, `onError` fires,
+`customErrorComponent` and `componentMap` render. (~5 tests.)
+
+**Total:** ~55 new runtime tests + ~10 tsd assertions.
+
+### TDD discipline & finding handling
+
+Tests are written test-first. Because the library already exists, tests for
+already-correct behavior pass immediately (characterization tests). **Where a
+test reveals a real discrepancy (e.g. an API that misbehaves), STOP and surface
+it to the maintainer as a finding — do not silently change library code.** The
+maintainer decides bug vs. intended.
+
+## Component 2 — Pre-Launch Sweep Skill
+
+Location: `.claude/skills/sweep-form-app/SKILL.md`.
+
+Playwright is **self-installed on first run** (e.g. `npx playwright install
+chromium`), NOT added to repo dependencies — keeps CI and `pnpm install` clean.
+
+### Flow
+
+1. Verify/boot the `examples/react` dev server on port 3001 (check port; start
+   `pnpm --filter el-form-testing-app dev` if needed; wait for ready).
+2. For each of the 15 demos:
+   1. Navigate (click the sidebar item → `setCurrentTest`).
+   2. Interact (type, blur, submit, add/remove rows, toggle, set files).
+   3. **Assert** concrete expectations (error text appears/clears; submit
+      payload correct; dirty/touched flips; array rows change).
+   4. Screenshot → `.sweep-results/<demo>.png`.
+   5. Capture console errors/warnings for that demo.
+   6. Record PASS / FAIL + reason.
+3. Write `.sweep-results/REPORT.md`.
+
+### The 15 demo targets (from `App.tsx`)
+
+`basic-validation`, `onblur-validation`, `async-validation`, `file-upload`,
+`advanced-file`, `zod-file`, `complex-arrays`, `form-history`,
+`discriminated-union`, `auto-discriminated`, `general-autoform`,
+`form-switch-field`, `form-switch-select`, `form-switch-compat`,
+`use-field-rerender`.
+
+### Report format (`.sweep-results/REPORT.md`)
+
+```
+# El Form Sweep — <date>
+✅ N / 15 passed   ❌ M failed   ⚠️ K console warnings
+
+| Feature | Result | Notes | Screenshot |
+|---------|--------|-------|------------|
+| basic-validation | ✅ | errors show on submit, payload correct | basic.png |
+| async-validation | ❌ | "checking…" never resolves            | async.png |
+…
+```
+
+### Assertion source of truth
+
+Each demo's expected behavior is anchored to the **committed suite test for that
+feature**, so the sweep's "what should happen" is not re-invented — it mirrors
+the spine.
+
+### Constraints
+
+- `.sweep-results/` and Playwright browser cache are git-ignored (artifacts not
+  committed).
+- First run downloads a browser (time/disk); the skill states this up front.
+- File-upload demos use Playwright `setInputFiles` with a tiny fixture the skill
+  creates.
+- Async/debounced demos use `waitFor`-style waits, never fixed sleeps.
+- Per-demo try/catch: one broken demo records FAIL and the sweep continues.
+- Clear messages for dev-server-won't-boot and Playwright-install-failure.
+
+## Component 3 — Contributor Path
+
+- The committed suite already runs in CI per-package on every push; the new test
+  files land in directories CI already covers. **No new CI workflow needed.**
+- Add `.claude/skills/test-my-change/SKILL.md`: detects which package(s) the
+  contributor changed (via `git diff`) and runs the matching
+  `pnpm --filter <pkg> test` (plus `tsd` for hooks), reporting pass/fail.
+
+## Testing Strategy (testing the tests)
+
+- **Suite:** run full `pnpm -r test` and show real output; green before claiming
+  done.
+- **Sweep skill:** verified end-to-end — actually run it against the live app,
+  confirm the report generates with real PASS/FAIL, and confirm it **catches a
+  failure** by temporarily breaking one demo and seeing a FAIL row. Evidence,
+  not assertion.
+
+## Risks & Mitigations
+
+- **Sweep flakiness** → explicit waits, per-demo isolation, console-error
+  capture.
+- **TDD reveals library bugs** → surface as findings, do not silent-fix.
+- **Playwright weight** → self-install on demand, never in CI, artifacts
+  git-ignored.
+- **Suite/sweep drift** → the spine invariant; both enumerate the same features.
+
+## Rollout
+
+1. Build committed suite (Component 1), run green in CI.
+2. Build sweep skill (Component 2), verify end-to-end incl. a deliberate
+   failure.
+3. Add contributor skill (Component 3).
+4. Run the initial sweep; report findings to maintainer.

--- a/docs/superpowers/specs/2026-06-01-form-testing-and-sweep-design.md
+++ b/docs/superpowers/specs/2026-06-01-form-testing-and-sweep-design.md
@@ -110,8 +110,13 @@ invalid submit, and `customErrorComponent` / `componentMap` overrides render.
 **CI gap to close:** `el-form-react-components` tests are **not** currently run by
 `ci.yml` (CI runs only `el-form-core`, `el-form-react-hooks`, `el-form-mcp`). So
 this component requires a one-line CI addition — a `Test el-form-react-components`
-step mirroring the existing per-package steps (the package already has a `test`
-script: `vitest --environment jsdom --run`). Without it, the new AutoForm tests
+step. Note the package's `test` script is `pnpm -w -r build && vitest
+--environment jsdom --run` (it rebuilds the whole workspace first). Since `ci.yml`
+already has a `Build workspace` step before the test steps, the new CI step should
+invoke **vitest directly against the already-built tree**
+(`pnpm --filter el-form-react-components exec vitest --environment jsdom --run`)
+rather than `pnpm --filter el-form-react-components test`, to avoid a redundant
+full rebuild on each Zod matrix leg. Without this step, the new AutoForm tests
 plus the **existing** ~21 component tests would never run in CI. This is the only
 CI change required; the hooks runtime files and `tsd` land in the
 already-covered `el-form-react-hooks` path.

--- a/packages/el-form-react-components/src/__tests__/AutoForm.submit.test.tsx
+++ b/packages/el-form-react-components/src/__tests__/AutoForm.submit.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { z } from "zod";
+import { AutoForm } from "../AutoForm";
+
+beforeEach(() => {
+  cleanup();
+});
+
+const schema = z.object({
+  email: z.string().email("Invalid email"),
+  name: z.string().min(1, "Name is required"),
+});
+
+describe("AutoForm submit", () => {
+  it("calls onSubmit with typed data when valid", async () => {
+    const onSubmit = vi.fn();
+    render(<AutoForm schema={schema} initialValues={{ email: "", name: "" }} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByLabelText("Email"), { target: { value: "a@b.com" } });
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Ada" } });
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({ email: "a@b.com", name: "Ada" });
+  });
+
+  it("calls onError on invalid submit", async () => {
+    const onSubmit = vi.fn();
+    const onError = vi.fn();
+    render(<AutoForm schema={schema} initialValues={{ email: "", name: "" }} onSubmit={onSubmit} onError={onError} />);
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+    await waitFor(() => expect(onError).toHaveBeenCalled());
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/el-form-react-hooks/src/__tests__/array-ops.runtime.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/array-ops.runtime.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+function ArrayDemo() {
+  const { watch, addArrayItem, removeArrayItem } = useForm<{ tags: string[] }>({
+    defaultValues: { tags: ["a"] },
+  });
+  const tags = watch("tags") || [];
+  return (
+    <div>
+      <span data-testid="count">{tags.length}</span>
+      <span data-testid="tags">{JSON.stringify(tags)}</span>
+      <button onClick={() => addArrayItem("tags", "")}>add</button>
+      <button onClick={() => removeArrayItem("tags", 0)}>removeFirst</button>
+    </div>
+  );
+}
+
+describe("array operations", () => {
+  it("addArrayItem appends an item", () => {
+    render(<ArrayDemo />);
+    expect(screen.getByTestId("count").textContent).toBe("1");
+    fireEvent.click(screen.getByText("add"));
+    expect(screen.getByTestId("count").textContent).toBe("2");
+  });
+
+  it("removeArrayItem removes by index", () => {
+    render(<ArrayDemo />);
+    fireEvent.click(screen.getByText("add"));
+    fireEvent.click(screen.getByText("removeFirst"));
+    expect(screen.getByTestId("count").textContent).toBe("1");
+  });
+});

--- a/packages/el-form-react-hooks/src/__tests__/errors.runtime.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/errors.runtime.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { z } from "zod";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+const schema = z.object({ email: z.string().email("Invalid email") });
+
+function ErrorsDemo() {
+  const form = useForm<{ email: string }>({
+    validators: { onSubmit: schema },
+    defaultValues: { email: "" },
+  });
+  const { register, formState } = form;
+  return (
+    <div>
+      <input aria-label="email" {...register("email")} />
+      <button onClick={() => form.setError("email", "Taken")}>setErr</button>
+      <button onClick={() => form.clearErrors("email")}>clearErr</button>
+      <button onClick={() => form.trigger("email")}>trigger</button>
+      <span data-testid="err">{formState.errors.email ?? ""}</span>
+    </div>
+  );
+}
+
+describe("setError / clearErrors / trigger", () => {
+  it("setError sets a field error", () => {
+    render(<ErrorsDemo />);
+    fireEvent.click(screen.getByText("setErr"));
+    expect(screen.getByTestId("err").textContent).toBe("Taken");
+  });
+
+  it("clearErrors clears a field error", () => {
+    render(<ErrorsDemo />);
+    fireEvent.click(screen.getByText("setErr"));
+    fireEvent.click(screen.getByText("clearErr"));
+    expect(screen.getByTestId("err").textContent).toBe("");
+  });
+
+  it("trigger validates a field on demand", async () => {
+    render(<ErrorsDemo />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "bad" } });
+    fireEvent.click(screen.getByText("trigger"));
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid email"));
+  });
+});

--- a/packages/el-form-react-hooks/src/__tests__/reset.runtime.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/reset.runtime.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+function ResetDemo() {
+  const { register, reset, resetField, formState } = useForm<{ name: string; email: string }>({
+    defaultValues: { name: "default", email: "" },
+  });
+  return (
+    <div>
+      <input aria-label="name" {...register("name")} />
+      <input aria-label="email" {...register("email")} />
+      <button onClick={() => reset()}>reset</button>
+      <button onClick={() => reset({ values: { name: "seed", email: "seed@x.com" } })}>resetTo</button>
+      <button onClick={() => resetField("name")}>resetName</button>
+      <span data-testid="dirty">{String(formState.isDirty)}</span>
+    </div>
+  );
+}
+
+describe("reset / resetField", () => {
+  it("resets all fields to defaults", () => {
+    render(<ResetDemo />);
+    const name = screen.getByLabelText("name") as HTMLInputElement;
+    fireEvent.change(name, { target: { value: "changed" } });
+    expect(name.value).toBe("changed");
+    fireEvent.click(screen.getByText("reset"));
+    expect((screen.getByLabelText("name") as HTMLInputElement).value).toBe("default");
+  });
+
+  it("resets to explicit values", () => {
+    render(<ResetDemo />);
+    fireEvent.click(screen.getByText("resetTo"));
+    expect((screen.getByLabelText("name") as HTMLInputElement).value).toBe("seed");
+    expect((screen.getByLabelText("email") as HTMLInputElement).value).toBe("seed@x.com");
+  });
+
+  it("clears isDirty after reset", () => {
+    render(<ResetDemo />);
+    fireEvent.change(screen.getByLabelText("name"), { target: { value: "x" } });
+    expect(screen.getByTestId("dirty").textContent).toBe("true");
+    fireEvent.click(screen.getByText("reset"));
+    expect(screen.getByTestId("dirty").textContent).toBe("false");
+  });
+
+  it("resets a single field via resetField", () => {
+    render(<ResetDemo />);
+    fireEvent.change(screen.getByLabelText("name"), { target: { value: "x" } });
+    fireEvent.click(screen.getByText("resetName"));
+    expect((screen.getByLabelText("name") as HTMLInputElement).value).toBe("default");
+  });
+});

--- a/packages/el-form-react-hooks/src/__tests__/setValue.runtime.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/setValue.runtime.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+function SetValueDemo() {
+  const { register, setValue, setValues, watch } = useForm<{
+    name: string;
+    age: number;
+    profile: { city: string };
+  }>({ defaultValues: { name: "", age: 0, profile: { city: "" } } });
+  const v = watch();
+  return (
+    <div>
+      <input aria-label="name" {...register("name")} />
+      <input aria-label="city" {...register("profile.city")} />
+      <button onClick={() => setValue("name", "Ada")}>setName</button>
+      <button onClick={() => setValue("profile.city", "Paris")}>setCity</button>
+      <button onClick={() => setValues({ age: 42 })}>mergeAge</button>
+      <span data-testid="snapshot">{JSON.stringify(v)}</span>
+    </div>
+  );
+}
+
+describe("setValue / setValues", () => {
+  it("sets a top-level field", () => {
+    render(<SetValueDemo />);
+    fireEvent.click(screen.getByText("setName"));
+    expect(JSON.parse(screen.getByTestId("snapshot").textContent!).name).toBe("Ada");
+  });
+
+  it("sets a nested dot-path field", () => {
+    render(<SetValueDemo />);
+    fireEvent.click(screen.getByText("setCity"));
+    expect(JSON.parse(screen.getByTestId("snapshot").textContent!).profile.city).toBe("Paris");
+  });
+
+  it("merges via setValues without clobbering other fields", () => {
+    render(<SetValueDemo />);
+    fireEvent.change(screen.getByLabelText("name"), { target: { value: "Grace" } });
+    fireEvent.click(screen.getByText("mergeAge"));
+    const snap = JSON.parse(screen.getByTestId("snapshot").textContent!);
+    expect(snap.age).toBe(42);
+    expect(snap.name).toBe("Grace");
+  });
+
+  it("coerces number inputs to numbers on change", () => {
+    render(<SetValueDemo />);
+    const before = JSON.parse(screen.getByTestId("snapshot").textContent!);
+    expect(typeof before.age).toBe("number");
+  });
+});

--- a/packages/el-form-react-hooks/src/__tests__/snapshots.runtime.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/snapshots.runtime.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+function SnapshotDemo() {
+  const form = useForm<{ name: string }>({ defaultValues: { name: "start" } });
+  const { register } = form;
+  return (
+    <div>
+      <input aria-label="name" {...register("name")} />
+      <button onClick={() => ((window as any).__snap = form.getSnapshot())}>snap</button>
+      <button onClick={() => form.restoreSnapshot((window as any).__snap)}>restore</button>
+      <span data-testid="changes">{String(form.hasChanges())}</span>
+    </div>
+  );
+}
+
+describe("snapshots & change tracking", () => {
+  it("captures and restores a snapshot", () => {
+    render(<SnapshotDemo />);
+    fireEvent.click(screen.getByText("snap")); // capture { name: "start" }
+    fireEvent.change(screen.getByLabelText("name"), { target: { value: "edited" } });
+    expect((screen.getByLabelText("name") as HTMLInputElement).value).toBe("edited");
+    fireEvent.click(screen.getByText("restore"));
+    expect((screen.getByLabelText("name") as HTMLInputElement).value).toBe("start");
+  });
+
+  it("hasChanges reflects edits vs defaults", () => {
+    render(<SnapshotDemo />);
+    expect(screen.getByTestId("changes").textContent).toBe("false");
+    fireEvent.change(screen.getByLabelText("name"), { target: { value: "x" } });
+    expect(screen.getByTestId("changes").textContent).toBe("true");
+  });
+});

--- a/packages/el-form-react-hooks/src/__tests__/state-tracking.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/state-tracking.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { z } from "zod";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+const schema = z.object({ email: z.string().email() });
+
+function StateDemo() {
+  const form = useForm<{ email: string }>({
+    validators: { onChange: schema },
+    defaultValues: { email: "" },
+  });
+  const { register, formState } = form;
+  return (
+    <div>
+      <input aria-label="email" {...register("email")} />
+      <span data-testid="dirty">{String(formState.isDirty)}</span>
+      <span data-testid="touched">{String(form.isFieldTouched("email"))}</span>
+      <span data-testid="valid">{String(formState.isValid)}</span>
+      <span data-testid="cansubmit">{String(form.canSubmit)}</span>
+      <span data-testid="hasErrors">{String(form.hasErrors())}</span>
+    </div>
+  );
+}
+
+describe("state tracking", () => {
+  it("isDirty flips when a value changes from default", () => {
+    render(<StateDemo />);
+    expect(screen.getByTestId("dirty").textContent).toBe("false");
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "x" } });
+    expect(screen.getByTestId("dirty").textContent).toBe("true");
+  });
+
+  it("touched flips on blur", () => {
+    render(<StateDemo />);
+    expect(screen.getByTestId("touched").textContent).toBe("false");
+    fireEvent.blur(screen.getByLabelText("email"));
+    expect(screen.getByTestId("touched").textContent).toBe("true");
+  });
+
+  it("isValid / hasErrors reflect validation", async () => {
+    render(<StateDemo />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "bad" } });
+    await waitFor(() => expect(screen.getByTestId("hasErrors").textContent).toBe("true"));
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "a@b.com" } });
+    await waitFor(() => expect(screen.getByTestId("valid").textContent).toBe("true"));
+  });
+});

--- a/packages/el-form-react-hooks/src/__tests__/submit.runtime.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/submit.runtime.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+
+beforeEach(() => {
+  cleanup();
+});
+import { z } from "zod";
+import { useForm } from "..";
+
+const schema = z.object({
+  email: z.string().email("Invalid email"),
+  age: z.number().min(18, "Must be 18+"),
+});
+
+function SubmitDemo({ onValid, onInvalid }: { onValid: (d: any) => void; onInvalid?: (e: any) => void }) {
+  const { register, handleSubmit, formState } = useForm<{ email: string; age: number }>({
+    validators: { onChange: schema },
+    defaultValues: { email: "", age: 0 },
+  });
+  return (
+    <form onSubmit={handleSubmit(onValid, onInvalid)}>
+      <input aria-label="email" {...register("email")} />
+      <input aria-label="age" type="number" {...register("age")} />
+      <button type="submit">Submit</button>
+      <span data-testid="submitting">{String(formState.isSubmitting)}</span>
+    </form>
+  );
+}
+
+describe("handleSubmit", () => {
+  it("calls onValid with typed data when valid", async () => {
+    const onValid = vi.fn();
+    render(<SubmitDemo onValid={onValid} />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "a@b.com" } });
+    fireEvent.change(screen.getByLabelText("age"), { target: { value: "21" } });
+    fireEvent.click(screen.getByText("Submit"));
+    await waitFor(() => expect(onValid).toHaveBeenCalledTimes(1));
+    expect(onValid.mock.calls[0][0]).toEqual({ email: "a@b.com", age: 21 });
+  });
+
+  it("does not call onValid when invalid", async () => {
+    const onValid = vi.fn();
+    const onInvalid = vi.fn();
+    render(<SubmitDemo onValid={onValid} onInvalid={onInvalid} />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "not-an-email" } });
+    fireEvent.click(screen.getByText("Submit"));
+    await waitFor(() => expect(onInvalid).toHaveBeenCalled());
+    expect(onValid).not.toHaveBeenCalled();
+  });
+
+  it("awaits an async onSubmit and toggles isSubmitting", async () => {
+    let resolve!: () => void;
+    const pending = new Promise<void>((r) => (resolve = r));
+    const onValid = vi.fn(() => pending);
+    render(<SubmitDemo onValid={onValid} />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "a@b.com" } });
+    fireEvent.change(screen.getByLabelText("age"), { target: { value: "30" } });
+    fireEvent.click(screen.getByText("Submit"));
+    await waitFor(() => expect(screen.getByTestId("submitting").textContent).toBe("true"));
+    resolve();
+    await waitFor(() => expect(screen.getByTestId("submitting").textContent).toBe("false"));
+  });
+});

--- a/packages/el-form-react-hooks/src/__tests__/validation-modes.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/validation-modes.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { z } from "zod";
+import { useForm } from "..";
+
+beforeEach(() => {
+  cleanup();
+});
+
+const schema = z.object({ email: z.string().email("Invalid email") });
+
+function ModeDemo({ mode }: { mode: "onChange" | "onBlur" | "onSubmit" }) {
+  const { register, handleSubmit, formState } = useForm<{ email: string }>({
+    validators: { [mode]: schema } as any,
+    defaultValues: { email: "" },
+  });
+  return (
+    <form onSubmit={handleSubmit(() => {})}>
+      <input aria-label="email" {...register("email")} />
+      <button type="submit">Submit</button>
+      <span data-testid="err">{formState.errors.email ?? ""}</span>
+    </form>
+  );
+}
+
+describe("validation modes", () => {
+  it("onChange surfaces the error as the user types", async () => {
+    render(<ModeDemo mode="onChange" />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "bad" } });
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid email"));
+  });
+
+  it("onChange clears the error when corrected", async () => {
+    render(<ModeDemo mode="onChange" />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "bad" } });
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid email"));
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "a@b.com" } });
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe(""));
+  });
+
+  it("onBlur surfaces the error only after blur", async () => {
+    render(<ModeDemo mode="onBlur" />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "bad" } });
+    expect(screen.getByTestId("err").textContent).toBe("");
+    fireEvent.blur(screen.getByLabelText("email"));
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid email"));
+  });
+
+  it("onSubmit surfaces the error only on submit", async () => {
+    render(<ModeDemo mode="onSubmit" />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "bad" } });
+    expect(screen.getByTestId("err").textContent).toBe("");
+    fireEvent.click(screen.getByText("Submit"));
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid email"));
+  });
+});

--- a/packages/el-form-react-hooks/src/utils/errorManagement.ts
+++ b/packages/el-form-react-hooks/src/utils/errorManagement.ts
@@ -53,27 +53,42 @@ export function createErrorManagementManager<T extends Record<string, any>>(
 
     // Manual validation trigger
     trigger: (async (nameOrNames?: keyof T | (keyof T)[]) => {
+      // Validate all fields
       if (!nameOrNames) {
-        // Validate all fields
-        const { isValid } = await validationManager.validateForm(
+        const { isValid, errors } = await validationManager.validateForm(
           formState.values
         );
+        setFormState((prev) => ({ ...prev, errors, isValid }));
         return isValid;
       }
 
+      // Validate multiple fields: merge each field's errors, clearing ones now valid
       if (Array.isArray(nameOrNames)) {
-        // Validate multiple fields
         const results = await Promise.all(
           nameOrNames.map((name) =>
-            validationManager.validateField(
-              name,
-              formState.values[name],
-              formState.values,
-              "onSubmit"
-            )
+            validationManager
+              .validateField(
+                name,
+                formState.values[name],
+                formState.values,
+                "onSubmit"
+              )
+              .then((r) => ({ name, r }))
           )
         );
-        return results.every((result) => result.isValid);
+        setFormState((prev) => {
+          const errors: Record<string, string | undefined> = { ...prev.errors };
+          for (const { name, r } of results) {
+            if (!r.isValid) Object.assign(errors, r.errors);
+            else delete errors[String(name)];
+          }
+          return {
+            ...prev,
+            errors: errors as FormState<T>["errors"],
+            isValid: Object.keys(errors).length === 0,
+          };
+        });
+        return results.every(({ r }) => r.isValid);
       }
 
       // Validate single field
@@ -83,6 +98,16 @@ export function createErrorManagementManager<T extends Record<string, any>>(
         formState.values,
         "onSubmit"
       );
+      setFormState((prev) => {
+        const errors: Record<string, string | undefined> = { ...prev.errors };
+        if (!result.isValid) Object.assign(errors, result.errors);
+        else delete errors[String(nameOrNames)];
+        return {
+          ...prev,
+          errors: errors as FormState<T>["errors"],
+          isValid: Object.keys(errors).length === 0,
+        };
+      });
       return result.isValid;
     }) as UseFormReturn<T>["trigger"],
   };

--- a/packages/el-form-react-hooks/src/utils/validation.ts
+++ b/packages/el-form-react-hooks/src/utils/validation.ts
@@ -169,41 +169,62 @@ export function createValidationManager<T extends Record<string, any>>(
       values: Partial<T>,
       eventType: "onChange" | "onBlur" | "onSubmit" = "onSubmit"
     ): Promise<{ isValid: boolean; errors: Record<keyof T, string> }> => {
-      const event: ValidatorEvent = {
-        type: eventType,
-        isAsync: false,
-      };
+      // The sync validator keys the core engine understands.
+      const SYNC_KEYS = ["onChange", "onBlur", "onSubmit"] as const;
+      // Which of those keys are actually configured on a given validator config.
+      const configuredKeys = (cfg: ValidatorConfig | undefined) =>
+        SYNC_KEYS.filter((k) => cfg && typeof (cfg as any)[k] !== "undefined");
 
       let allErrors: Record<string, string> = {};
       let isValid = true;
 
       // Validate all fields with field-level validators
       for (const [fieldName, fieldConfig] of Object.entries(fieldValidators)) {
-        const fieldResult = await validationEngine.current.validateField(
-          fieldName,
-          values[fieldName as keyof T],
-          values,
-          fieldConfig as ValidatorConfig,
-          event
-        );
+        // On submit, validate against every configured sync validator (not just
+        // onSubmit) so that e.g. an onChange-only validator still gates submit.
+        // For other events, only run the single requested event.
+        const keysToRun =
+          eventType === "onSubmit"
+            ? configuredKeys(fieldConfig as ValidatorConfig)
+            : [eventType];
 
-        if (!fieldResult.isValid) {
-          isValid = false;
-          Object.assign(allErrors, fieldResult.errors);
+        for (const key of keysToRun) {
+          const event: ValidatorEvent = { type: key, isAsync: false };
+          const fieldResult = await validationEngine.current.validateField(
+            fieldName,
+            values[fieldName as keyof T],
+            values,
+            fieldConfig as ValidatorConfig,
+            event
+          );
+
+          if (!fieldResult.isValid) {
+            isValid = false;
+            Object.assign(allErrors, fieldResult.errors);
+          }
         }
       }
 
       // Run form-level validation
       if (validators) {
-        const formResult = await validationEngine.current.validateForm(
-          values,
-          validators,
-          event
-        );
+        // Same logic as above: on submit, run all configured sync validators.
+        const keysToRun =
+          eventType === "onSubmit"
+            ? configuredKeys(validators)
+            : [eventType];
 
-        if (!formResult.isValid) {
-          isValid = false;
-          Object.assign(allErrors, formResult.errors);
+        for (const key of keysToRun) {
+          const event: ValidatorEvent = { type: key, isAsync: false };
+          const formResult = await validationEngine.current.validateForm(
+            values,
+            validators,
+            event
+          );
+
+          if (!formResult.isValid) {
+            isValid = false;
+            Object.assign(allErrors, formResult.errors);
+          }
         }
       }
 

--- a/packages/el-form-react-hooks/tsd.test-d.ts
+++ b/packages/el-form-react-hooks/tsd.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType } from "tsd";
+import { expectType, expectError } from "tsd";
 import { useForm } from "./src";
 
 // Compile-time assertions for Path and register typings
@@ -40,4 +40,28 @@ import { useForm } from "./src";
 
   // invalid path should error (which it does)
   // form.register("user.nonexistent");
+}
+
+{
+  const form = useForm<{ email: string; age: number; user: { name: string } }>({
+    defaultValues: { email: "", age: 0, user: { name: "" } },
+  });
+
+  // valid paths typed correctly
+  expectType<string>(form.register("email").value);
+  expectType<string>(form.register("user.name").value);
+
+  // setValue rejects unknown path
+  expectError(form.setValue("nope", "x"));
+
+  // setValue rejects wrong value type for a known path
+  expectError(form.setValue("age", "not-a-number"));
+
+  // watch rejects unknown path
+  expectError(form.watch("nope"));
+
+  // handleSubmit data is exactly T
+  form.handleSubmit((data) => {
+    expectType<{ email: string; age: number; user: { name: string } }>(data);
+  });
 }


### PR DESCRIPTION
## Summary

Builds the committed test suite for `useForm` runtime behavior + user-facing type errors, wires the components package into CI, and ships two Claude skills — a manual Playwright **pre-launch sweep** of the example app and a contributor **test-my-change** helper. Built TDD via subagent-driven development against a written + reviewed spec and plan (`docs/superpowers/`).

**The suite immediately earned its keep: it found and fixed two real bugs the docs were teaching users to hit.**

## 🐞 Findings — two real library bugs, both fixed in this PR

### FINDING 1 (HIGH) — `validators.onChange` did not block submit
`useForm({ validators: { onChange: schema } })` let an **invalid** form submit — `handleSubmit` called the success handler with bad data. Every doc/quick-start/example uses `onChange`, so forms built from the docs could submit invalid data.
- **Fix** (`c627209`): `validateForm` now runs all *configured* sync validators at submit time, not just a literal `onSubmit` key. Core engine untouched.
- Changeset: `el-form-react-hooks` patch.

### FINDING 2 (MEDIUM) — `trigger()` validated but never surfaced errors
`form.trigger("email")` returned the correct boolean but never wrote errors into `formState`, so the UI showed nothing (React Hook Form's `trigger` does surface them).
- **Fix** (`88784d0`): `trigger` now merges computed errors into `formState` (and updates `isValid`) across all branches.
- Changeset: `el-form-react-hooks` patch.

## What's added

**Committed suite (90 tests + tsd, all green):**
- 8 new `el-form-react-hooks` runtime files: submit, setValue/setValues, reset/resetField, validation-modes, state-tracking, errors/trigger, array-ops, snapshots
- Expanded `tsd.test-d.ts` — type-error coverage (setValue/watch reject bad paths & value types; handleSubmit data is exactly `T`)
- `AutoForm.submit.test.tsx` — onSubmit/onError
- **New CI step** running `el-form-react-components` tests (they were never run in CI before)

**Skills (`.claude/skills/`):**
- `sweep-form-app` — boots the example app, drives all **15 demos** in a real browser (Playwright), asserts behavior, screenshots, writes `.sweep-results/REPORT.md`. Manual pre-launch gate, never in CI. **Verified end-to-end: 15/15 against the live app, and proven to catch an injected failure (exit 1).**
- `test-my-change` — runs the relevant package tests for whatever a contributor changed.

## Verification

- core 11 · hooks 33 (+tsd) · components 23 · mcp 23 = **90 tests + tsd, all passing**, both fixes integrated, zero regressions
- Sweep dry-run hardened from the real DOM (scoped to `<main>`, disabled-submit handled, counter-based array check) → 15/15

## Notes for the maintainer

- Two `el-form-react-hooks` patch changesets are included — these ship the bug fixes. (There's also the pre-existing `el-form-mcp` initial-release changeset.)
- Design + plan + findings are under `docs/superpowers/specs/` and `docs/superpowers/plans/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
