### PR TITLE
fix(ci): repair release pipeline (tailwind dlx + core watch-mode)

### DIFF
--- a/.changeset/fix-release-pipeline.md
+++ b/.changeset/fix-release-pipeline.md
@@ -1,0 +1,6 @@
+---
+"el-form-react-components": patch
+"el-form-core": patch
+---
+
+fix(ci): repair the release pipeline. `build:css` now runs the installed `@tailwindcss/cli` via `pnpm exec tailwindcss` instead of `pnpm dlx`, which fetched an ephemeral copy that failed to load the native `@tailwindcss/oxide` binary on CI. `el-form-core`'s `test` script now uses `vitest run` instead of bare `vitest` (watch mode), which hung the recursive release test step in non-interactive CI.

--- a/packages/el-form-core/package.json
+++ b/packages/el-form-core/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "dependencies": {},
   "peerDependencies": {

--- a/packages/el-form-react-components/package.json
+++ b/packages/el-form-react-components/package.json
@@ -48,9 +48,9 @@
   ],
   "scripts": {
     "build": "tsup && pnpm run build:css",
-    "build:css": "pnpm dlx @tailwindcss/cli -i ./src/styles.css -o ./dist/styles.css -c ./tailwind.config.ts --minify",
+    "build:css": "pnpm exec tailwindcss -i ./src/styles.css -o ./dist/styles.css -c ./tailwind.config.ts --minify",
     "dev": "tsup --watch",
-    "dev:css": "pnpm dlx @tailwindcss/cli -i ./src/styles.css -o ./dist/styles.css -c ./tailwind.config.ts --watch",
+    "dev:css": "pnpm exec tailwindcss -i ./src/styles.css -o ./dist/styles.css -c ./tailwind.config.ts --watch",
     "test": "pnpm -w -r build && vitest --environment jsdom --run"
   },
   "dependencies": {


### PR DESCRIPTION
## Why

The **Release** workflow has been failing on every merge to `main` (the last 3, including before this work) — so no "Version Packages" PR ever opens and nothing publishes to npm. Two independent, pre-existing bugs in the release path:

### 1. `build:css` used `pnpm dlx` for a native-binary CLI
`el-form-react-components`'s `build:css` ran `pnpm dlx @tailwindcss/cli …`. `dlx` fetches an **ephemeral** copy into a temp sandbox, and on the CI Linux runner that copy fails to load the platform-native `@tailwindcss/oxide` binary:
```
Cannot find module './tailwindcss-oxide.linux-x64-gnu.node'
```
`@tailwindcss/cli` is **already a devDependency** (`^4.1.8`), so the fix is to run it via `pnpm exec tailwindcss` — uses the installed, correctly-built binary. Bonus: `dlx` was silently pulling `4.3.0` while the package pins `^4.1.8` (version drift), now also fixed.

### 2. `el-form-core` test script was bare `vitest` (watch mode)
The release workflow runs `pnpm run test` (= `pnpm -r run test`). `el-form-core`'s `test` was bare `vitest`, which enters **watch mode** and hangs/fails in the non-interactive CI runner (`ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL`). Changed to `vitest run`, matching the other packages. (Regular `ci.yml` dodged this by passing `-- --run` explicitly.)

## Verification

Ran the exact two steps the release workflow runs:
- `pnpm run test` → **exit 0** (core 11, mcp 23, hooks 33, components 23 = 90 tests, all green; CSS builds via `pnpm exec tailwindcss`)
- `pnpm run build:packages` → **exit 0** (all packages build, CSS minified)

## Impact

Unblocks the release pipeline. Once merged, the changesets action should finally open the **Version Packages** PR carrying the queued bumps (`el-form-react-hooks` ×2 bug-fix patches, `el-form-mcp` initial release, and these patches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
