### PR TITLE
feat: accessibility pass + validation debounce + focus-on-error

### DIFF
--- a/.changeset/a11y-debounce.md
+++ b/.changeset/a11y-debounce.md
@@ -1,0 +1,14 @@
+---
+"el-form-react-hooks": minor
+"el-form-react-components": minor
+"el-form-core": minor
+---
+
+Accessibility pass + validation debounce.
+
+- **Accessibility:** AutoForm-generated inputs and the standalone `TextField` / `TextareaField` / `SelectField` now wire `aria-invalid`, `aria-describedby` (linked to the error element), `aria-required`, and render field errors with `role="alert"` for screen-reader announcement.
+- **Focus-on-error:** `useForm` gains `shouldFocusError` (default `true`); after a failed submit, focus moves to the first invalid field. `register` now returns a `ref` (this is what makes `setFocus` work).
+- **Sync validation debounce:** new `validationDebounceMs` config debounces synchronous validation at both field and form level (default `0` = unchanged), symmetric with the existing `asyncDebounceMs`. The async debounce now has test coverage.
+- **Fix:** standalone field components (`TextField` etc.) now reflect validation errors on the first blur — previously they could lag one render behind because they read form state through the context getter; they now subscribe via `useField`.
+
+All additive and backward-compatible.

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -26,6 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`updateValue(path, updater)`**: apply a functional update to a field against the latest state (e.g. `updateValue("items", (prev) => [...prev, item])`). Avoids the stale-snapshot "lost update" pitfall when several updates run in one event handler. `useFieldArray` uses this internally so multiple synchronous operations all apply correctly.
 
+### ♿ Accessibility
+
+- **AutoForm and the standalone `TextField` / `TextareaField` / `SelectField` are now accessible by default.** Inputs wire `aria-invalid`, `aria-describedby` (pointing at the error element), and `aria-required`; field errors render with `role="alert"` so screen readers announce them. No markup changes required in your code.
+- **Focus-on-error:** `useForm` gains `shouldFocusError` (default `true`). After a failed submit, focus moves to the first invalid field. To opt out: `useForm({ shouldFocusError: false })`. (`register` now also returns a `ref`, which is what makes `setFocus`/focus-on-error work.)
+- **Fix:** the standalone field components now show validation errors on the first blur. They previously could lag one render behind because they read form state through the context getter; they now subscribe via `useField`.
+
+### ⏱️ Validation debounce
+
+- **`validationDebounceMs`**: new config to debounce *synchronous* validation, at both form and field level (default `0` = validate every change, unchanged). Mirrors the existing `asyncDebounceMs`. Example: `useForm({ validators: { onChange: schema, validationDebounceMs: 200 } })`.
+
 ## 2026-06-01
 
 ### 🐞 Bug Fixes — `el-form-react-hooks@3.10.2`

--- a/docs/docs/guides/async-validation.md
+++ b/docs/docs/guides/async-validation.md
@@ -73,6 +73,26 @@ You can scope the debounce to a specific event with
 `onChangeAsyncDebounceMs` / `onBlurAsyncDebounceMs`, or set `asyncDebounceMs`
 to cover all async validators on that field.
 
+### Debouncing synchronous validation
+
+`asyncDebounceMs` only affects async validators. To debounce **synchronous**
+validation (e.g. an expensive schema, or just to reduce error flicker while the
+user types), use `validationDebounceMs`. It works at both the form and field
+level and defaults to `0` (validate on every change, unchanged):
+
+```typescript
+const form = useForm({
+  validators: {
+    onChange: schema,
+    validationDebounceMs: 200, // coalesce sync validation while typing
+  },
+});
+```
+
+Error *clearing* stays immediate — only the setting of a new error is delayed —
+so a field that becomes valid is never left showing a stale error during the
+quiet period.
+
 ## Validate on blur instead of change
 
 To check only when the user leaves the field, use `onBlurAsync`:

--- a/docs/docs/guides/auto-form.md
+++ b/docs/docs/guides/auto-form.md
@@ -513,6 +513,32 @@ function SignupForm() {
 }
 ```
 
+## Accessibility
+
+AutoForm generates accessible markup out of the box — you don't need to wire any
+ARIA attributes yourself:
+
+- Each input sets **`aria-invalid`** when it has a visible error.
+- Each input links to its error message via **`aria-describedby`**, and the error
+  element carries a matching `id` and **`role="alert"`** so screen readers announce
+  it as soon as it appears.
+- Fields whose schema type is not optional/nullable get **`aria-required`**.
+- Labels are associated with their controls via `htmlFor` / `id`.
+
+### Focus-on-error
+
+After a failed submit, focus automatically moves to the first invalid field, so
+keyboard and screen-reader users land directly on what needs fixing. This is on by
+default. To turn it off, pass `shouldFocusError: false` to the underlying form (via
+the `useForm` hook when you build a custom form, or it is on by default for AutoForm).
+
+The standalone `TextField` / `TextareaField` / `SelectField` components carry the
+same ARIA wiring. Pass `required` to a field component to advertise `aria-required`:
+
+```tsx
+<TextField name="email" label="Email" required />
+```
+
 ## Render Props Pattern
 
 Access form state and methods for advanced customization:

--- a/docs/superpowers/plans/2026-06-02-a11y-and-debounce.md
+++ b/docs/superpowers/plans/2026-06-02-a11y-and-debounce.md
@@ -1,0 +1,527 @@
+# Accessibility + Validation Debounce Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax. Get a second-opinion subagent review after each task (spec-compliance then code-quality), per the user's standing preference.
+
+**Goal:** Make el-form forms accessible (ARIA wiring + focus-on-error) and add sync-validation debounce, all additive and backward-compatible.
+
+**Architecture:** Three workstreams. (1) A shared `fieldAriaProps` helper in the components package wires `aria-invalid`/`aria-describedby`/`role="alert"`/`aria-required` into both AutoForm's `DefaultField` and the standalone FieldComponents. (2) Focus-on-error requires NEW ref plumbing: add a `ref` to `register`'s return, populate the existing-but-empty `fieldRefs` map, forward the ref through all four component render sites, then wire `handleSubmit` to focus the first errored field when `shouldFocusError` (default true). (3) A new debounced branch for SYNC validation in the core engine (`validationDebounceMs`), reusing the existing timer-map helpers; plus characterization tests for the already-shipped async debounce.
+
+**Tech Stack:** TypeScript 5, React 18, Vitest + @testing-library/react (jsdom), `vi.useFakeTimers` for debounce, tsd, tsup, changesets.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-a11y-and-debounce-design.md`
+**Working location:** `.worktrees/el-form-a11y-debounce` (branch `el-form-a11y-debounce`, off `main` @ `1dc8bbe`). Paths relative to repo root.
+
+---
+
+## Resolved decisions (spec's open questions — pinned)
+
+1. **First-errored-field ordering:** use the order of keys in `formState.errors` as produced by `validateForm` (schema field order for AutoForm; this is deterministic). Resolve each errored name to its `fieldRefs` element; focus the first that resolves and is focusable; skip missing ones. Test asserts first-in-error-order is focused.
+2. **AutoForm `required`:** derive in the schema walker — a field is required if its raw Zod type is NOT `ZodOptional`/`ZodDefault`/`ZodNullable`. Thread a `required: boolean` onto the field config passed to `DefaultField`. FieldComponents use their existing `required?: boolean` prop.
+3. **Clear-vs-debounce:** error CLEARING stays immediate (the onChange handler already optimistically deletes the field error before validating — `useForm.ts:264-274`); only the SETTING of a new error via sync validation is debounced.
+
+---
+
+## Conventions
+
+- Runtime tests import from `..` (package index); `render/screen/fireEvent/cleanup` from `@testing-library/react`; `beforeEach(cleanup)`. For focus tests use `document.activeElement`.
+- Debounce tests: `vi.useFakeTimers()` in `beforeEach`, `vi.useRealTimers()` in `afterEach`, advance with `await vi.advanceTimersByTimeAsync(ms)`.
+- Run one hooks test file: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/<path>`
+- Run one components test file: `pnpm --filter el-form-react-components exec vitest --environment jsdom --run src/<path>`
+- Run one core test file: `pnpm --filter el-form-core exec vitest --run src/<path>`
+- tsd: `pnpm --filter el-form-react-hooks exec tsd --files tsd.test-d.ts`
+- Build a package: `pnpm --filter <pkg> build` ; whole workspace: `pnpm build:packages`
+- DO NOT reference `process`/`@types/node` in any package source (browser DTS build fails — prior CI lesson).
+
+---
+
+## File structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `packages/el-form-react-hooks/src/types/path.ts` | add `ref` to `RegisterReturn` | Modify |
+| `packages/el-form-react-hooks/src/useForm.ts` | `register` returns a `ref` that populates `fieldRefs`; thread `shouldFocusError` | Modify |
+| `packages/el-form-react-hooks/src/types.ts` | `UseFormOptions.shouldFocusError` | Modify |
+| `packages/el-form-react-hooks/src/utils/submitOperations.ts` | focus first error on failed submit | Modify |
+| `packages/el-form-react-hooks/src/utils/focusError.ts` | pure helper: pick first errored field name | Create |
+| `packages/el-form-react-hooks/src/__tests__/setFocus.runtime.test.tsx` | proves ref plumbing + setFocus | Create |
+| `packages/el-form-react-hooks/src/__tests__/focusError.runtime.test.tsx` | focus-on-error behavior | Create |
+| `packages/el-form-core/src/validators/types.ts` | `validationDebounceMs` key | Modify |
+| `packages/el-form-core/src/validators/engine.ts` | sync debounce branch | Modify |
+| `packages/el-form-core/src/validators/__tests__/debounce.test.ts` | async (characterization) + sync debounce | Create |
+| `packages/el-form-react-components/src/fieldAria.ts` | `fieldAriaProps` helper | Create |
+| `packages/el-form-react-components/src/FieldComponents.tsx` | aria + ref forward | Modify |
+| `packages/el-form-react-components/src/AutoForm.tsx` | aria + ref forward + required derive | Modify |
+| `packages/el-form-react-components/src/types.ts` | `AutoFormFieldProps.ref`/`required` | Modify |
+| `packages/el-form-react-components/src/__tests__/a11y.runtime.test.tsx` | aria assertions both paths | Create |
+| `.changeset/a11y-debounce.md` | minor: hooks, components, core | Create |
+| docs | a11y + debounce docs | Modify |
+
+---
+
+## Task 1: Ref plumbing — `register` populates `fieldRefs` (makes setFocus work)
+
+**Files:** Modify `types/path.ts`, `useForm.ts`; Create `__tests__/setFocus.runtime.test.tsx`
+
+- [ ] **Step 1: Failing test proving setFocus is a no-op today**
+
+```tsx
+// packages/el-form-react-hooks/src/__tests__/setFocus.runtime.test.tsx
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import React from "react";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+function Demo() {
+  const { register, setFocus } = useForm<{ a: string; b: string }>({
+    defaultValues: { a: "", b: "" },
+  });
+  return (
+    <div>
+      <input aria-label="a" {...register("a")} />
+      <input aria-label="b" {...register("b")} />
+      <button onClick={() => setFocus("b")}>focus-b</button>
+    </div>
+  );
+}
+
+describe("setFocus", () => {
+  it("moves focus to the named field", () => {
+    render(<Demo />);
+    const b = screen.getByLabelText("b");
+    screen.getByText("focus-b").click();
+    expect(document.activeElement).toBe(b);
+  });
+});
+```
+
+Run: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__/setFocus.runtime.test.tsx`
+Expected: FAIL (activeElement is body, not the input — fieldRefs is empty today).
+
+- [ ] **Step 2: Add `ref` to `RegisterReturn`**
+
+In `types/path.ts`, add `ref` to the base of `RegisterReturn`:
+
+```ts
+export type RegisterReturn<Value> = {
+  name: string;
+  ref: (el: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | null) => void;
+  onChange: (e: React.ChangeEvent<any>) => void;
+  onBlur: (e: React.FocusEvent<any>) => void;
+} & (Value extends boolean
+  ? { checked: boolean; value?: never; files?: never }
+  : Value extends File | FileList | (File | null)[] | File[] | null | undefined
+  ? { files: FileList | File | File[] | null; value?: never; checked?: never }
+  : { value: Value; checked?: never; files?: never });
+```
+
+- [ ] **Step 3: Populate `fieldRefs` from `register`**
+
+In `useForm.ts` `registerImpl`, add a `ref` callback to `baseProps` (alongside `name`/`onChange`/`onBlur`). `fieldRefs` is already declared (`useRef<Map<keyof T, HTMLInputElement|HTMLTextAreaElement|HTMLSelectElement>>`):
+
+```ts
+const baseProps = {
+  name,
+  ref: (el: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | null) => {
+    if (el) fieldRefs.current.set(name as keyof T, el);
+    else fieldRefs.current.delete(name as keyof T);
+  },
+  onChange: async (e: React.ChangeEvent<any>) => { /* unchanged */ },
+  onBlur: async (_e) => { /* unchanged */ },
+};
+```
+
+(Leave the rest of `baseProps`/return shape unchanged.)
+
+- [ ] **Step 4: Run the test — now passes**
+
+Run the same command. Expected: PASS (focus moves to input b).
+
+- [ ] **Step 5: Regression — full hooks runtime suite + tsd + build**
+
+Run: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__` (all pass), then `pnpm --filter el-form-react-hooks exec tsd --files tsd.test-d.ts` (the `ref` addition must not break existing register type tests — if it does, the existing tsd `register` assertions may need a `ref` acknowledgment; only adjust tsd, never weaken types), then `pnpm --filter el-form-react-hooks build` (DTS clean).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/el-form-react-hooks/src/types/path.ts packages/el-form-react-hooks/src/useForm.ts packages/el-form-react-hooks/src/__tests__/setFocus.runtime.test.tsx
+git commit -m "feat(hooks): register returns a ref that populates fieldRefs (setFocus now works)"
+```
+
+---
+
+## Task 2: Focus-on-error helper + handleSubmit wiring
+
+**Files:** Create `utils/focusError.ts`, `__tests__/focusError.runtime.test.tsx`; Modify `types.ts`, `useForm.ts`, `utils/submitOperations.ts`
+
+- [ ] **Step 1: Failing test (focus first error on invalid submit; opt-out; not on valid)**
+
+```tsx
+// packages/el-form-react-hooks/src/__tests__/focusError.runtime.test.tsx
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import React from "react";
+import { z } from "zod";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+const schema = z.object({
+  a: z.string().min(1, "a required"),
+  b: z.string().min(1, "b required"),
+});
+
+function makeForm(opts?: { shouldFocusError?: boolean }) {
+  return function Demo() {
+    const { register, handleSubmit } = useForm({
+      validators: { onSubmit: schema },
+      defaultValues: { a: "", b: "" },
+      ...opts,
+    });
+    return (
+      <form onSubmit={handleSubmit(() => {})}>
+        <input aria-label="a" {...register("a")} />
+        <input aria-label="b" {...register("b")} />
+        <button type="submit">submit</button>
+      </form>
+    );
+  };
+}
+
+describe("focus-on-error", () => {
+  it("focuses the first errored field on invalid submit (default on)", async () => {
+    const Demo = makeForm();
+    render(<Demo />);
+    fireEvent.click(screen.getByText("submit"));
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByLabelText("a")));
+  });
+
+  it("does not focus when shouldFocusError is false", async () => {
+    const Demo = makeForm({ shouldFocusError: false });
+    render(<Demo />);
+    const before = document.activeElement;
+    fireEvent.click(screen.getByText("submit"));
+    // give validation a tick; focus should NOT have moved to input a
+    await new Promise((r) => setTimeout(r, 50));
+    expect(document.activeElement).not.toBe(screen.getByLabelText("a"));
+  });
+});
+```
+
+Run: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__/focusError.runtime.test.tsx`
+Expected: FAIL (no focusing happens; `shouldFocusError` unknown option).
+
+- [ ] **Step 2: Pure helper to pick the first errored field**
+
+```ts
+// packages/el-form-react-hooks/src/utils/focusError.ts
+/**
+ * Given the errors object (in validateForm key order) and a resolver from field name
+ * to its DOM element, return the first errored element that exists and is focusable.
+ */
+export function findFirstErrorElement(
+  errors: Record<string, any>,
+  resolve: (name: string) => HTMLElement | undefined
+): HTMLElement | undefined {
+  for (const name of Object.keys(errors)) {
+    if (!errors[name]) continue;
+    const el = resolve(name);
+    if (el && typeof el.focus === "function") return el;
+  }
+  return undefined;
+}
+```
+
+- [ ] **Step 3: Add the option type**
+
+In `types.ts` `UseFormOptions`, add:
+```ts
+/** Focus the first invalid field after a failed submit. Default true. */
+shouldFocusError?: boolean;
+```
+
+- [ ] **Step 4: Wire into handleSubmit**
+
+`submitOperations.ts` `createSubmitManager` needs access to `shouldFocusError` and `fieldRefs`. Thread them through the options the manager is constructed with (in `useForm.ts` where `createSubmitManager`/handleSubmit is built — check how it currently receives deps; pass `fieldRefs` and `shouldFocusError`). In the failure branch (`!isValid`, after setting errors+touched, around `submitOperations.ts:64-67`), add:
+
+```ts
+if (shouldFocusError !== false) {
+  const el = findFirstErrorElement(
+    errors as Record<string, any>,
+    (name) => fieldRefs.current.get(name as keyof T)
+  );
+  el?.focus();
+}
+```
+
+If `submitOperations.ts` doesn't currently receive `fieldRefs`/options, the cleanest wiring is to do the focus in `useForm.ts` itself right after `handleSubmit`'s validation result is known — implementer: pick whichever keeps `handleSubmit` cohesive; prefer passing deps into the submit manager. Document the choice in the commit.
+
+- [ ] **Step 5: Run tests — pass**
+
+Run the focusError test (both cases pass). Then full hooks suite for regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/el-form-react-hooks/src/utils/focusError.ts packages/el-form-react-hooks/src/types.ts packages/el-form-react-hooks/src/useForm.ts packages/el-form-react-hooks/src/utils/submitOperations.ts packages/el-form-react-hooks/src/__tests__/focusError.runtime.test.tsx
+git commit -m "feat(hooks): shouldFocusError (default true) focuses first invalid field on failed submit"
+```
+
+---
+
+## Task 3: Sync-validation debounce in the engine
+
+**Files:** Modify `el-form-core/src/validators/types.ts`, `engine.ts`; Create `engine __tests__/debounce.test.ts`
+
+- [ ] **Step 1: Characterization tests for EXISTING async debounce (no code change yet)**
+
+```ts
+// packages/el-form-core/src/validators/__tests__/debounce.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ValidationEngine } from "../engine"; // confirm the exported class name
+// (read engine.ts for the actual export + validateField signature before writing)
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+// Async: with asyncDebounceMs, N rapid validations resolve once after the delay.
+// Sync (added in step 3): with validationDebounceMs, rapid sync validations coalesce.
+```
+Implementer: FIRST read `engine.ts` to get the exact public method (`validate`/`validateField`), the `ValidatorContext`/`ValidatorEvent` shapes, and how to construct the engine, then write real tests. Write the async characterization test and run it — it should PASS against current code (proves async debounce works). If it FAILS, that's a real bug — report it before continuing.
+
+- [ ] **Step 2: Add the sync config key**
+
+In `validators/types.ts` `ValidatorConfig`, add:
+```ts
+/** Debounce SYNC validation for this event (ms). Default 0 = off (validate every change). */
+validationDebounceMs?: number;
+```
+
+- [ ] **Step 3: Failing sync-debounce test**
+
+Add a test: a sync validator wired with `validationDebounceMs: 200`, called 3x rapidly, runs the underlying validation once after advancing 200ms. Run — FAILS (no sync debounce yet).
+
+- [ ] **Step 4: Implement the sync debounce branch**
+
+In `engine.ts` `validateField`, change the sync branch (currently `else return SchemaAdapter.validate(...)`) to debounce when configured:
+
+```ts
+} else {
+  const debounceMs =
+    (config[`${event.type}ValidationDebounceMs` as keyof ValidatorConfig] as number) ||
+    config.validationDebounceMs || 0;
+  if (debounceMs > 0) {
+    return this.validateSyncWithDebounce(validator, value, context, event, debounceMs);
+  }
+  return SchemaAdapter.validate(validator, value, context);
+}
+```
+Add `validateSyncWithDebounce` mirroring `validateWithDebounce` but calling `SchemaAdapter.validate` (sync) inside the timer, reusing `this.debounceTimers` + `this.clearDebounce`. (Per-event key `onChangeValidationDebounceMs` etc. is optional symmetry — include only if trivial; otherwise just the global `validationDebounceMs`. Keep it simple: global key is enough for the spec. If you add per-event, add the keys to types.ts too.)
+
+> NOTE: keep error-CLEARING immediate. This branch only affects how the *result* is produced; the hooks `onChange` already clears the field error optimistically before calling validateField (`useForm.ts:264-274`), so a debounced result that comes back valid simply confirms the cleared state. Do not add clearing logic here.
+
+- [ ] **Step 5: Run tests — sync + async both pass**
+
+Run the debounce test file. Then `pnpm --filter el-form-core exec vitest --run` (full core suite) for regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/el-form-core/src/validators/types.ts packages/el-form-core/src/validators/engine.ts packages/el-form-core/src/validators/__tests__/debounce.test.ts
+git commit -m "feat(core): validationDebounceMs for sync validation + characterization tests for async debounce"
+```
+
+---
+
+## Task 4: A11y helper + FieldComponents wiring
+
+**Files:** Create `el-form-react-components/src/fieldAria.ts`; Modify `FieldComponents.tsx`; Create `__tests__/a11y.runtime.test.tsx`
+
+- [ ] **Step 1: The shared helper (pure, unit-testable)**
+
+```ts
+// packages/el-form-react-components/src/fieldAria.ts
+export interface FieldAriaInput {
+  fieldId: string;
+  error?: unknown;
+  touched?: unknown;
+  required?: boolean;
+}
+export interface FieldAriaResult {
+  "aria-invalid"?: true;
+  "aria-describedby"?: string;
+  "aria-required"?: true;
+  errorId: string;
+}
+/** ARIA props for an input + the id its error element should carry. */
+export function fieldAriaProps({ fieldId, error, touched, required }: FieldAriaInput): FieldAriaResult {
+  const showError = Boolean(touched && error);
+  const errorId = `${fieldId}-error`;
+  return {
+    ...(showError ? { "aria-invalid": true as const, "aria-describedby": errorId } : {}),
+    ...(required ? { "aria-required": true as const } : {}),
+    errorId,
+  };
+}
+```
+
+- [ ] **Step 2: Failing component test (FieldComponents path)**
+
+```tsx
+// packages/el-form-react-components/src/__tests__/a11y.runtime.test.tsx
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import React from "react";
+import { z } from "zod";
+import { useForm, FormProvider } from "el-form-react-hooks";
+import { TextField } from "..";
+
+beforeEach(cleanup);
+
+function Demo() {
+  const form = useForm({
+    validators: { onChange: z.object({ email: z.string().email("bad email") }) },
+    defaultValues: { email: "" },
+  });
+  return (
+    <FormProvider form={form}>
+      <TextField name="email" label="Email" required />
+      <button onClick={() => form.trigger()}>v</button>
+    </FormProvider>
+  );
+}
+
+describe("FieldComponents a11y", () => {
+  it("wires aria-required, and aria-invalid + aria-describedby + role=alert on error", async () => {
+    render(<Demo />);
+    const input = screen.getByLabelText("Email");
+    expect(input).toHaveAttribute("aria-required", "true");
+    // trigger validation to produce an error + touched
+    fireEvent.change(input, { target: { value: "x" } });
+    fireEvent.blur(input);
+    // wait for the error element
+    const err = await screen.findByRole("alert");
+    expect(err).toHaveAttribute("id", "email-error");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).toHaveAttribute("aria-describedby", "email-error");
+  });
+});
+```
+(Implementer: if `@testing-library/jest-dom` matchers like `toHaveAttribute` aren't set up, use `expect(input.getAttribute("aria-required")).toBe("true")` style instead — check existing component tests for the convention.)
+
+Run: `pnpm --filter el-form-react-components exec vitest --environment jsdom --run src/__tests__/a11y.runtime.test.tsx` — FAIL.
+
+- [ ] **Step 3: Wire FieldComponents**
+
+In each of `TextField`/`TextareaField`/`SelectField` (FieldComponents.tsx): accept `required?: boolean` (BaseFieldProps may already have it — verify), compute `const aria = fieldAriaProps({ fieldId: String(name), error, touched, required })`, spread the aria attrs + `registration.ref` onto the input/textarea/select, and put `id={aria.errorId} role="alert"` on the error `<div>`. Keep `id={String(name)}` on the control. Example for TextField's input + error:
+```tsx
+<input {...registration} {...props} id={String(name)} type={type}
+  aria-invalid={aria["aria-invalid"]} aria-describedby={aria["aria-describedby"]}
+  aria-required={aria["aria-required"]} className={inputClasses} />
+...
+{touched && error && (
+  <div id={aria.errorId} role="alert" className="text-red-500 text-xs mt-1">{error}</div>
+)}
+```
+(`registration` already includes `ref` from Task 1, so `{...registration}` forwards it — verify the ref lands on the DOM node.)
+
+- [ ] **Step 4: Run test — pass.** Then full components suite for regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/el-form-react-components/src/fieldAria.ts packages/el-form-react-components/src/FieldComponents.tsx packages/el-form-react-components/src/__tests__/a11y.runtime.test.tsx
+git commit -m "feat(components): ARIA wiring for FieldComponents (aria-invalid/describedby/required, role=alert)"
+```
+
+---
+
+## Task 5: A11y + ref + required for AutoForm
+
+**Files:** Modify `AutoForm.tsx`, `types.ts` (AutoFormFieldProps); extend `a11y.runtime.test.tsx`
+
+- [ ] **Step 1: Failing test (AutoForm path)**
+
+Add a test rendering `<AutoForm schema={z.object({ email: z.string().email("bad") })} onSubmit={()=>{}} />`, trigger invalid input, assert the generated input has `aria-invalid`/`aria-describedby` pointing at `field-email-error`, the error has `role="alert"` + that id, and a required field has `aria-required`. Note AutoForm's fieldId is `field-${name}`. Run — FAIL.
+
+- [ ] **Step 2: Thread `ref` + `required` through AutoFormFieldProps**
+
+In components `types.ts`, add to `AutoFormFieldProps`: `ref?: (el: HTMLInputElement|HTMLTextAreaElement|HTMLSelectElement|null) => void;` and `required?: boolean;`.
+
+- [ ] **Step 3: Derive `required` in the schema walker**
+
+In AutoForm's schema introspection (the walker that unwraps `ZodOptional`/`ZodDefault`/`ZodNullable` ~`AutoForm.tsx:354-367`), record `required = !(isOptional || isDefault || isNullable)` onto the field config. Pass `required` and the field's `register` ref into `DefaultField`.
+
+- [ ] **Step 4: Wire `DefaultField`**
+
+In `DefaultField`, compute `fieldAriaProps({ fieldId, error, touched, required })` and apply aria attrs + `ref` to each control branch (text/textarea/select/checkbox), and `id={aria.errorId} role="alert"` on the error element. Import `fieldAriaProps` from `./fieldAria`.
+
+- [ ] **Step 5: Run tests — pass.** Full components suite for regressions. `pnpm build:packages`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/el-form-react-components/src/AutoForm.tsx packages/el-form-react-components/src/types.ts packages/el-form-react-components/src/__tests__/a11y.runtime.test.tsx
+git commit -m "feat(components): ARIA wiring + ref forwarding + required derivation for AutoForm"
+```
+
+---
+
+## Task 6: Full gate, changeset, docs
+
+**Files:** Create `.changeset/a11y-debounce.md`; Modify docs
+
+- [ ] **Step 1: Full workspace gate**
+
+Run and confirm all green:
+- `pnpm --filter el-form-core exec vitest --run`
+- `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run` + `tsd --files tsd.test-d.ts`
+- `pnpm --filter el-form-react-components exec vitest --environment jsdom --run`
+- `pnpm build:packages`
+
+- [ ] **Step 2: Changeset**
+
+```bash
+cat > .changeset/a11y-debounce.md <<'EOF'
+---
+"el-form-react-hooks": minor
+"el-form-react-components": minor
+"el-form-core": minor
+---
+
+Accessibility pass + validation debounce.
+
+- **Accessibility:** AutoForm-generated inputs and the standalone `TextField`/`TextareaField`/`SelectField` now wire `aria-invalid`, `aria-describedby` (linked to the error element), `aria-required`, and render field errors with `role="alert"` for screen-reader announcement.
+- **Focus-on-error:** `useForm` gains `shouldFocusError` (default `true`); after a failed submit, focus moves to the first invalid field. `register` now returns a `ref` (this is what makes `setFocus` work).
+- **Sync validation debounce:** new `validationDebounceMs` config debounces synchronous validation (default `0` = unchanged). The existing async debounce (`asyncDebounceMs`) now has test coverage.
+
+All additive and backward-compatible.
+EOF
+```
+Run `pnpm changeset status` — expect hooks/components/core minor + cascade to el-form-react.
+
+- [ ] **Step 3: Docs**
+
+- Add an "Accessibility" section to the AutoForm guide + a note in the field-components/custom-components guide describing the ARIA attributes and `shouldFocusError`.
+- Document `validationDebounceMs` in the validation/async-validation docs alongside the existing `asyncDebounceMs`.
+- Add an "Unreleased" bullet group to `docs/docs/changelog.md` under the existing `## [Unreleased]` heading (created in the useFieldArray PR) — a11y + focus-on-error + validationDebounceMs.
+- Build docs: `pnpm --filter el-form-docs build` (must succeed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .changeset/a11y-debounce.md docs
+git commit -m "docs+changeset: a11y, focus-on-error, validationDebounceMs"
+```
+
+---
+
+## Done criteria
+
+- `register` returns a working `ref`; a test proves `setFocus` moves focus (fails against old code).
+- Focus-on-error focuses the first invalid field on failed submit (default-on); opt-out works.
+- Sync `validationDebounceMs` debounces sync validation (fake-timer test); async debounce has passing characterization tests.
+- Both AutoForm and FieldComponents expose `aria-invalid`/`aria-describedby`/`aria-required` + `role="alert"` errors, verified by tests.
+- All package suites + tsd green; `pnpm build:packages` clean; `pnpm changeset status` shows hooks/components/core minor.
+- Docs + changelog updated. Zero breaking changes (existing tests unchanged & green).
+- Verify scope: `git diff --stat main..HEAD` shows only intended files.

--- a/docs/superpowers/plans/2026-06-02-a11y-and-debounce.md
+++ b/docs/superpowers/plans/2026-06-02-a11y-and-debounce.md
@@ -287,7 +287,14 @@ afterEach(() => vi.useRealTimers());
 // Async: with asyncDebounceMs, N rapid validations resolve once after the delay.
 // Sync (added in step 3): with validationDebounceMs, rapid sync validations coalesce.
 ```
-Implementer: FIRST read `engine.ts` to get the exact public method (`validate`/`validateField`), the `ValidatorContext`/`ValidatorEvent` shapes, and how to construct the engine, then write real tests. Write the async characterization test and run it — it should PASS against current code (proves async debounce works). If it FAILS, that's a real bug — report it before continuing.
+Implementer: FIRST read `engine.ts`. The class is exported as **`ValidationEngine`** (named export, also re-exported from the package index). Public method: `validateField(fieldName, value, values, config, event)` — FIVE args (not the 4-arg hooks wrapper). Construct `new ValidationEngine()` directly and call it with a field-level config to hit the debounce machinery deterministically, e.g.:
+```ts
+const engine = new ValidationEngine();
+const cfg = { onChangeAsync: someAsyncValidator };
+const ev = { type: "onChange", isAsync: true, fieldName: "email" };
+// call validateField 3x rapidly with asyncDebounceMs in cfg, advance timers, assert underlying validator ran once
+```
+Write the async characterization test and run it — it should PASS against current code (proves async debounce works). If it FAILS, that's a real bug — report it before continuing. (Read the exact `ValidatorContext`/`ValidatorEvent`/`ValidatorConfig` shapes from `validators/types.ts` before finalizing.)
 
 - [ ] **Step 2: Add the sync config key**
 
@@ -297,28 +304,62 @@ In `validators/types.ts` `ValidatorConfig`, add:
 validationDebounceMs?: number;
 ```
 
-- [ ] **Step 3: Failing sync-debounce test**
+- [ ] **Step 3: Failing sync-debounce tests — BOTH field-level AND form-level**
 
-Add a test: a sync validator wired with `validationDebounceMs: 200`, called 3x rapidly, runs the underlying validation once after advancing 200ms. Run — FAILS (no sync debounce yet).
+> CRITICAL (from plan review): sync validation has TWO routes. Field-level
+> (`fieldValidators.<field>`) goes through `engine.validateField` → sync `else`. Form-level
+> (`validators.onChange` schema — the common AutoForm/quick-start case) goes through
+> `engine.validateForm` → `validateFormSync`, which currently takes NO config/event and so
+> cannot debounce. The async side is asymmetric-but-complete: `validateFormAsync` already
+> honors `asyncDebounceMs` at form level. To avoid `validationDebounceMs` being a silent
+> no-op at form level (where users will most likely put it, copying the `asyncDebounceMs`
+> pattern), debounce MUST be added to BOTH sync paths.
 
-- [ ] **Step 4: Implement the sync debounce branch**
+Add two failing tests: (a) a **field-level** sync validator with `validationDebounceMs: 200`
+called 3x rapidly runs once after 200ms; (b) a **form-level** `validators` config with
+`validationDebounceMs: 200` likewise coalesces. Run — both FAIL.
 
-In `engine.ts` `validateField`, change the sync branch (currently `else return SchemaAdapter.validate(...)`) to debounce when configured:
+- [ ] **Step 4a: Field-level sync debounce in `validateField`**
+
+In `engine.ts` `validateField`, change the sync `else` branch:
 
 ```ts
 } else {
-  const debounceMs =
-    (config[`${event.type}ValidationDebounceMs` as keyof ValidatorConfig] as number) ||
-    config.validationDebounceMs || 0;
+  const debounceMs = config.validationDebounceMs || 0;
   if (debounceMs > 0) {
     return this.validateSyncWithDebounce(validator, value, context, event, debounceMs);
   }
   return SchemaAdapter.validate(validator, value, context);
 }
 ```
-Add `validateSyncWithDebounce` mirroring `validateWithDebounce` but calling `SchemaAdapter.validate` (sync) inside the timer, reusing `this.debounceTimers` + `this.clearDebounce`. (Per-event key `onChangeValidationDebounceMs` etc. is optional symmetry — include only if trivial; otherwise just the global `validationDebounceMs`. Keep it simple: global key is enough for the spec. If you add per-event, add the keys to types.ts too.)
+Add a private `validateSyncWithDebounce(validator, value, context, event, debounceMs)`
+mirroring `validateWithDebounce` but calling `SchemaAdapter.validate` (sync) inside the
+timer, reusing `this.debounceTimers` + `this.clearDebounce` (key `${context.fieldName}-${event.type}`).
 
-> NOTE: keep error-CLEARING immediate. This branch only affects how the *result* is produced; the hooks `onChange` already clears the field error optimistically before calling validateField (`useForm.ts:264-274`), so a debounced result that comes back valid simply confirms the cleared state. Do not add clearing logic here.
+- [ ] **Step 4b: Form-level sync debounce in `validateFormSync` (symmetry with async)**
+
+`validateForm` (engine.ts:64-68) already has `config`+`event` in scope and forwards them to
+`validateFormAsync`. Forward them to the sync path too, and debounce there:
+
+```ts
+} else {
+  result = this.validateFormSync(validator, context, config, event);
+}
+```
+Change `validateFormSync` to accept `(validator, context, config, event)`. When
+`config.validationDebounceMs > 0`, wrap its final `SchemaAdapter.validate(validator, context.value)`
+return in a debounce timer (mirror `validateFormAsync`'s structure: key `form-${event.type}`,
+`clearDebounce("form", event.type)`, return a `Promise<ValidationResult>`). The function
+becomes `async` (return type `ValidationResult | Promise<ValidationResult>` → just make it
+async; `validateForm` already awaits). The function-validator branches (string/object/fn)
+stay synchronous and un-debounced — only the schema-validate path debounces, matching the
+spirit of debouncing expensive validation.
+
+> Keep it to the GLOBAL `validationDebounceMs` key (no per-event keys this round — YAGNI).
+> Keep error-CLEARING immediate: this only changes how the *result* is produced; the hooks
+> `onChange` already clears the field error optimistically before validating
+> (`useForm.ts:264-274`), so a debounced valid result just confirms the cleared state. Do
+> not add clearing logic here.
 
 - [ ] **Step 5: Run tests — sync + async both pass**
 
@@ -326,9 +367,13 @@ Run the debounce test file. Then `pnpm --filter el-form-core exec vitest --run` 
 
 - [ ] **Step 6: Commit**
 
+- [ ] **Step 7: Run both field-level AND form-level sync debounce tests — both pass**
+
+Confirm Step 3's two tests now pass (field-level via validateField, form-level via validateFormSync). Then full core suite.
+
 ```bash
 git add packages/el-form-core/src/validators/types.ts packages/el-form-core/src/validators/engine.ts packages/el-form-core/src/validators/__tests__/debounce.test.ts
-git commit -m "feat(core): validationDebounceMs for sync validation + characterization tests for async debounce"
+git commit -m "feat(core): validationDebounceMs debounces sync validation (field + form level); async debounce tests"
 ```
 
 ---
@@ -503,7 +548,7 @@ Run `pnpm changeset status` — expect hooks/components/core minor + cascade to 
 - [ ] **Step 3: Docs**
 
 - Add an "Accessibility" section to the AutoForm guide + a note in the field-components/custom-components guide describing the ARIA attributes and `shouldFocusError`.
-- Document `validationDebounceMs` in the validation/async-validation docs alongside the existing `asyncDebounceMs`.
+- Document `validationDebounceMs` in the validation/async-validation docs alongside the existing `asyncDebounceMs`. It works at BOTH levels (form `validators` and `fieldValidators`), now symmetric with `asyncDebounceMs`. Show a form-level example: `useForm({ validators: { onChange: schema, validationDebounceMs: 200 } })`.
 - Add an "Unreleased" bullet group to `docs/docs/changelog.md` under the existing `## [Unreleased]` heading (created in the useFieldArray PR) — a11y + focus-on-error + validationDebounceMs.
 - Build docs: `pnpm --filter el-form-docs build` (must succeed).
 

--- a/docs/superpowers/specs/2026-06-02-a11y-and-debounce-design.md
+++ b/docs/superpowers/specs/2026-06-02-a11y-and-debounce-design.md
@@ -20,7 +20,18 @@ Phase 4 of the El Form revival. Exploration of `main` reshaped the original fram
 - **Accessibility is genuinely thin.** Field components only set `htmlFor` on labels.
   Inputs have **no** `aria-invalid`, errors have **no** `aria-describedby` linkage,
   **no** `role="alert"`, **no** `aria-required`, and there is **no focus-on-error** on
-  failed submit (the `setFocus` infra exists in the hook but nothing wires it).
+  failed submit.
+- **`setFocus` is a no-op today (verified).** `createFocusManager` reads
+  `fieldRefs.current.get(name)`, but **nothing ever populates `fieldRefs`** —
+  `register`'s return (`RegisterReturn`) has **no `ref`**, and `registerImpl` never sets
+  the map. So `setFocus` silently does nothing for any registered field. Focus-on-error
+  therefore requires building ref plumbing first (see Workstream 2).
+- **The two paths use different field-id conventions (verified):** AutoForm's
+  `DefaultField` uses `id={`field-${name}`}`; standalone FieldComponents use
+  `id={String(name)}`. The a11y helper must take a resolved `fieldId` per path.
+- **Debounce is async-only (verified):** the engine routes `event.isAsync:false`
+  straight to `SchemaAdapter.validate` (no debounce); only `validateAsync` reaches the
+  timer machinery. Sync debounce is a **new branch**, not config-plumbing (see W3b).
 - There are **two rendering paths**: AutoForm renders its own inputs
   (`packages/el-form-react-components/src/AutoForm.tsx`) AND there are standalone
   `TextField` / `TextareaField` / `SelectField`
@@ -60,8 +71,10 @@ All work is **additive and backward-compatible**.
 
 ## Workstream 1 — Accessibility wiring
 
-Applied identically to AutoForm's generated inputs and the three standalone field
-components. For a field with `fieldId` (already `String(name)`):
+Applied to AutoForm's generated inputs and the three standalone field components. The
+`fieldId` differs per path — **AutoForm: `` `field-${name}` ``; FieldComponents:
+`String(name)`** — so the shared helper takes the resolved `fieldId` as input rather than
+assuming a convention. For a field with its `fieldId`:
 
 - Input/textarea/select gets:
   - `aria-invalid={Boolean(touched && error) || undefined}` (omit when false to keep DOM clean).
@@ -80,21 +93,41 @@ A small shared helper (e.g. `fieldAriaProps(fieldId, { error, touched, required 
 returning the aria attribute object keeps the two rendering paths DRY and individually
 testable. Lives in the components package (it's component-layer concern, not core).
 
-## Workstream 2 — Focus-on-error
+## Workstream 2 — Focus-on-error (depends on NEW ref plumbing)
+
+**Prerequisite (not optional): make `setFocus` actually work.** Today `fieldRefs` is
+never populated, so this must be built first:
+
+1. Add an optional **`ref`** callback to `RegisterReturn` (`types/path.ts`) — a
+   `(el: HTMLElement | null) => void` that is spreadable onto an input alongside the
+   existing `value`/`onChange`/`onBlur`.
+2. In `registerImpl` (`useForm.ts`), return a `ref` that populates/cleans
+   `fieldRefs.current` (set on mount with the element, delete on unmount/null). Keep it
+   backward-compatible: existing spreads `{...register("x")}` simply gain a `ref` they can
+   ignore or apply.
+3. Forward the ref through the consuming components so the DOM node is captured:
+   AutoForm's `DefaultField` and the standalone `TextField`/`TextareaField`/`SelectField`
+   must apply `registration.ref` to their `<input>/<textarea>/<select>`.
+4. Add a test that `setFocus("field")` now actually moves focus (none exists today) —
+   this is the precursor that proves the plumbing before focus-on-error is layered on.
+
+**Then focus-on-error itself:**
 
 - Add `shouldFocusError?: boolean` to `UseFormOptions` (default `true`).
 - In `submitOperations.ts`, when validation fails (`!isValid`) and `shouldFocusError` is
-  on, focus the **first errored field in registration/DOM order** using the existing
-  focus-management utility (`setFocus`).
-- "First errored field" = the first registered field name present in the `errors` object,
-  resolved to its DOM node. If the node is missing or not focusable, skip silently and try
-  the next; never throw.
+  on, focus the **first errored field** via `setFocus` (now functional).
+- "First errored field" ordering: see Open Question #1 (leaning: schema/registration order
+  for AutoForm, DOM order fallback for custom forms). If a field's ref is missing or not
+  focusable, skip to the next; never throw.
 - Applies uniformly because both AutoForm and custom forms submit through `handleSubmit`.
+  Scope is **`handleSubmit` only** this round (not the imperative `submit()`/`submitAsync()`
+  paths) — a deliberate YAGNI line.
 
 ### Boundaries / interface
-Focus selection logic is a pure-ish helper (given `errors` + a way to resolve a field's
-element) so it can be unit-tested without a full DOM submit. The wiring point is
-`handleSubmit`'s failure branch.
+Ref plumbing is additive on `RegisterReturn` + `registerImpl`. Focus-selection (given
+`errors` + an order) is a small helper, unit-testable; the wiring point is `handleSubmit`'s
+failure branch. Forwarding the ref in components is mechanical but must be done in all four
+places (AutoForm DefaultField + 3 FieldComponents).
 
 ## Workstream 3 — Validation debounce
 
@@ -106,14 +139,27 @@ element) so it can be unit-tested without a full DOM submit. The wiring point is
 - If a test reveals a real bug, fix it (record as a finding); otherwise this is
   characterization coverage for previously-untested shipped behavior.
 
-### 3b. Add sync-validation debounce (new)
+### 3b. Add sync-validation debounce (NEW branch, not config-plumbing)
+The engine currently routes sync validation (`event.isAsync:false`) straight to
+`SchemaAdapter.validate` with **no debounce** — only `validateAsync` reaches the timer
+machinery. So this is a new code path, though it can **reuse the timer-map helpers**
+(`debounceTimers`, `clearDebounce`).
+
 - New `ValidatorConfig` key **`validationDebounceMs?: number`** (default `0` = off, no
-  behavior change). When > 0, sync validation for that event is debounced using the same
-  timer machinery as async.
-- Plumbed from `useForm` config through to the engine. Default off means existing forms
-  are unaffected.
+  behavior change).
+- Add a debounced sync branch in the engine's `validateField`: when `validationDebounceMs
+  > 0`, wrap the `SchemaAdapter.validate` call in a debounce timer (mirroring
+  `validateWithDebounce`) that returns a `Promise<ValidationResult>` resolving after the
+  quiet period. The hooks `onChange` path already `await`s `validateField`, so a
+  now-sometimes-deferred resolution integrates without signature changes.
+- **Error-clearing stays immediate** (Open Question #3 leaning): only the *setting* of
+  errors is debounced; clearing an existing error on valid input is immediate, to avoid a
+  stale error lingering during the quiet period.
+- Plumbed from `useForm` config through to the engine. Default off → existing forms
+  unaffected.
 - Tests: with fake timers, rapid `onChange` with `validationDebounceMs: 200` runs sync
-  validation once after the quiet period; `0`/unset validates every change as today.
+  validation once after the quiet period; `0`/unset validates every change as today;
+  a newly-valid value clears its error immediately (not debounced).
 
 ## Data flow
 
@@ -160,7 +206,9 @@ submit → handleSubmit → validateForm → if !isValid:
 
 - Both rendering paths expose `aria-invalid` / `aria-describedby` / `role="alert"` /
   `aria-required`, verified by tests.
-- Focus moves to the first invalid field on failed submit (default-on), opt-out works.
+- `register` now returns a working `ref`; `setFocus` actually moves focus (proven by a
+  test that fails against today's no-op). Focus moves to the first invalid field on failed
+  submit (default-on), opt-out works.
 - Existing async debounce has passing characterization tests; new `validationDebounceMs`
   debounces sync validation (default off → no behavior change), tested with fake timers.
 - All existing tests stay green; docs updated (a11y notes + debounce config); changeset added.
@@ -171,8 +219,12 @@ submit → handleSubmit → validateForm → if !isValid:
 1. **"First errored field" ordering source** — registration order vs. DOM order vs.
    schema field order. Leaning: schema/registration order for AutoForm (deterministic);
    fall back to DOM query order for custom forms. Pin in plan with a test.
-2. **AutoForm `required` introspection** — confirm the existing schema introspection
-   exposes required-ness per field (Zod optional/nullable detection) or derive it. Pin in plan.
+2. **AutoForm `required` introspection** — the schema walker already unwraps
+   `ZodOptional`/`ZodNullable`/`ZodDefault` (`AutoForm.tsx`) but discards optionality;
+   required-ness IS derivable (required = raw type not Optional/Default/Nullable).
+   `AutoFormFieldConfig` doesn't yet carry a `required` flag; FieldComponents already have
+   an unused `required?: boolean` prop. Plan: derive + thread `required` into the a11y
+   helper for both paths. Pin exact mechanism in plan.
 3. **Sync debounce + immediate error clearing** — decide whether clearing an existing
    error on valid input is also debounced or immediate (leaning: clear immediately, only
    debounce the *setting* of errors, to avoid stale errors lingering). Pin in plan.

--- a/docs/superpowers/specs/2026-06-02-a11y-and-debounce-design.md
+++ b/docs/superpowers/specs/2026-06-02-a11y-and-debounce-design.md
@@ -1,0 +1,178 @@
+# Accessibility + Validation Debounce — Design Spec (Phase 4)
+
+**Date:** 2026-06-02
+**Status:** Approved (design); plan to follow
+**Owner:** Nic (colorpulse6)
+**Branch:** `el-form-a11y-debounce` (worktree, off `main` @ `1dc8bbe`)
+**Parent spec:** `2026-05-31-el-form-revival-design.md` (Phase 4)
+
+## Context
+
+Phase 4 of the El Form revival. Exploration of `main` reshaped the original framing:
+
+- **Debounced validation already partly exists.** `el-form-core`'s validator engine
+  (`packages/el-form-core/src/validators/engine.ts`) has a full **async** debounce:
+  config keys `asyncDebounceMs` and per-event `onChangeAsyncDebounceMs` /
+  `onBlurAsyncDebounceMs` / `onSubmitAsyncDebounceMs`, wired into `validateAsync` →
+  `validateWithDebounce` (timer map, clear-on-retrigger). It is **documented** in ~8 docs
+  pages but has **zero tests**. It only debounces **async** validators; **sync**
+  `onChange` validation runs every keystroke.
+- **Accessibility is genuinely thin.** Field components only set `htmlFor` on labels.
+  Inputs have **no** `aria-invalid`, errors have **no** `aria-describedby` linkage,
+  **no** `role="alert"`, **no** `aria-required`, and there is **no focus-on-error** on
+  failed submit (the `setFocus` infra exists in the hook but nothing wires it).
+- There are **two rendering paths**: AutoForm renders its own inputs
+  (`packages/el-form-react-components/src/AutoForm.tsx`) AND there are standalone
+  `TextField` / `TextareaField` / `SelectField`
+  (`packages/el-form-react-components/src/FieldComponents.tsx`). Both need the a11y work.
+
+## Goals
+
+1. **Accessibility pass** — wire ARIA into both rendering paths so forms are usable with
+   assistive tech: `aria-invalid`, `aria-describedby` (input↔error), `role="alert"` on
+   errors, `aria-required`, verified label association.
+2. **Focus-on-error** — an opt-in (default-on) behavior that focuses the first invalid
+   field on a failed submit, for both custom forms and AutoForm.
+3. **Validation debounce** — add tests proving the existing async debounce works; add a
+   new **sync**-validation debounce config so rapid typing can coalesce.
+
+All work is **additive and backward-compatible**.
+
+## Non-Goals
+
+- No visual redesign of components (markup/attributes only; existing classes unchanged).
+- No WCAG audit/certification claim — this is a targeted, high-value a11y pass, not a
+  full conformance program.
+- No change to the error-summary's behavior beyond keeping it working (no summary-focus
+  redirect this round).
+- No new validation *engine* rewrite — sync debounce reuses the existing timer machinery.
+
+## Decisions (from brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Focus-on-error location | **Opt-in `useForm` option `shouldFocusError`**, applied in `handleSubmit`. Works for custom forms AND AutoForm. |
+| `shouldFocusError` default | **`true`** (RHF-parity; best default a11y; only fires on invalid submit). Documented as a (positive, additive) behavior change. |
+| A11y coverage | **Both** AutoForm internal inputs AND standalone FieldComponents. |
+| Error announcement | **`role="alert"` per-field error** + `aria-describedby` from input + `aria-invalid` on input. |
+| Sync debounce | **New config key `validationDebounceMs`** (default `0` = off), distinct from `asyncDebounceMs`. |
+| Spec/plan structure | **One spec, one plan** (a11y + focus + debounce together; ship in the same batched `3.11.0`). |
+
+## Workstream 1 — Accessibility wiring
+
+Applied identically to AutoForm's generated inputs and the three standalone field
+components. For a field with `fieldId` (already `String(name)`):
+
+- Input/textarea/select gets:
+  - `aria-invalid={Boolean(touched && error) || undefined}` (omit when false to keep DOM clean).
+  - `aria-describedby={touched && error ? `${fieldId}-error` : undefined}`.
+  - `aria-required={required || undefined}` — `required` comes from AutoForm schema
+    introspection (it already knows required-ness) or a `required` prop on FieldComponents.
+- Error element gets `id={`${fieldId}-error`}` and `role="alert"`.
+- Labels: confirm `htmlFor={fieldId}` matches input `id={fieldId}` (already true; verify
+  for select/textarea/checkbox variants).
+
+No visual change (attributes only). No public prop removed. AutoForm's existing
+`errorClassName`/`inputClassName` customization is preserved.
+
+### Boundaries / interface
+A small shared helper (e.g. `fieldAriaProps(fieldId, { error, touched, required })`)
+returning the aria attribute object keeps the two rendering paths DRY and individually
+testable. Lives in the components package (it's component-layer concern, not core).
+
+## Workstream 2 — Focus-on-error
+
+- Add `shouldFocusError?: boolean` to `UseFormOptions` (default `true`).
+- In `submitOperations.ts`, when validation fails (`!isValid`) and `shouldFocusError` is
+  on, focus the **first errored field in registration/DOM order** using the existing
+  focus-management utility (`setFocus`).
+- "First errored field" = the first registered field name present in the `errors` object,
+  resolved to its DOM node. If the node is missing or not focusable, skip silently and try
+  the next; never throw.
+- Applies uniformly because both AutoForm and custom forms submit through `handleSubmit`.
+
+### Boundaries / interface
+Focus selection logic is a pure-ish helper (given `errors` + a way to resolve a field's
+element) so it can be unit-tested without a full DOM submit. The wiring point is
+`handleSubmit`'s failure branch.
+
+## Workstream 3 — Validation debounce
+
+### 3a. Verify existing async debounce (no new code unless broken)
+- Add core/engine tests using fake timers (`vi.useFakeTimers`) proving:
+  - `asyncDebounceMs` coalesces rapid async validations (only the last runs after the delay).
+  - Per-event `onChangeAsyncDebounceMs` overrides the global.
+  - A new trigger before the delay cancels the prior pending validation.
+- If a test reveals a real bug, fix it (record as a finding); otherwise this is
+  characterization coverage for previously-untested shipped behavior.
+
+### 3b. Add sync-validation debounce (new)
+- New `ValidatorConfig` key **`validationDebounceMs?: number`** (default `0` = off, no
+  behavior change). When > 0, sync validation for that event is debounced using the same
+  timer machinery as async.
+- Plumbed from `useForm` config through to the engine. Default off means existing forms
+  are unaffected.
+- Tests: with fake timers, rapid `onChange` with `validationDebounceMs: 200` runs sync
+  validation once after the quiet period; `0`/unset validates every change as today.
+
+## Data flow
+
+```
+keystroke → register onChange → useForm validateField (eventType onChange)
+  → engine: if validationDebounceMs>0 (sync) or asyncDebounceMs>0 (async) → debounce timer
+  → on fire: compute result → setFormState(errors) → field re-renders
+  → error <div role="alert" id="x-error"> appears; input aria-invalid + aria-describedby="x-error"
+
+submit → handleSubmit → validateForm → if !isValid:
+  → setFormState(errors, touched) ; if shouldFocusError → focus first errored field
+```
+
+## Error handling
+
+- Focus-on-error: missing/unfocusable node → skip, no throw.
+- Debounce: timers cleared on unmount / re-trigger (async path already does this; sync
+  path mirrors it). No unhandled rejections — debounced promise resolves with the result.
+- ARIA: when `error` is falsy, aria attributes are omitted (not set to empty strings).
+
+## Testing
+
+- **Components (jsdom + testing-library):** for AutoForm and each FieldComponent —
+  `aria-invalid` toggles with error state; `aria-describedby` equals the error element's
+  `id`; error element has `role="alert"`; `aria-required` reflects required-ness. No
+  visual/class regressions (existing component tests stay green).
+- **Hooks:** focus-on-error focuses the first errored field on invalid submit; respects
+  `shouldFocusError: false`; doesn't focus on valid submit. Uses real DOM via
+  testing-library.
+- **Core/engine:** async debounce characterization tests + new sync debounce tests, both
+  with fake timers.
+- **Type tests (tsd):** `shouldFocusError` and `validationDebounceMs` accepted by the
+  respective option types.
+
+## Release impact
+
+- **Minor** on `el-form-react-hooks` (`shouldFocusError`), `el-form-react-components`
+  (a11y attrs), and `el-form-core` (`validationDebounceMs`). Patch cascade to the umbrella
+  `el-form-react`. Changeset authored with the work.
+- Batched into the held `3.11.0` "Version Packages" PR (#61) per the revival's
+  single-release decision.
+
+## Success criteria
+
+- Both rendering paths expose `aria-invalid` / `aria-describedby` / `role="alert"` /
+  `aria-required`, verified by tests.
+- Focus moves to the first invalid field on failed submit (default-on), opt-out works.
+- Existing async debounce has passing characterization tests; new `validationDebounceMs`
+  debounces sync validation (default off → no behavior change), tested with fake timers.
+- All existing tests stay green; docs updated (a11y notes + debounce config); changeset added.
+- Zero breaking changes.
+
+## Open questions (resolve in the plan)
+
+1. **"First errored field" ordering source** — registration order vs. DOM order vs.
+   schema field order. Leaning: schema/registration order for AutoForm (deterministic);
+   fall back to DOM query order for custom forms. Pin in plan with a test.
+2. **AutoForm `required` introspection** — confirm the existing schema introspection
+   exposes required-ness per field (Zod optional/nullable detection) or derive it. Pin in plan.
+3. **Sync debounce + immediate error clearing** — decide whether clearing an existing
+   error on valid input is also debounced or immediate (leaning: clear immediately, only
+   debounce the *setting* of errors, to avoid stale errors lingering). Pin in plan.

--- a/packages/el-form-core/src/validators/__tests__/debounce.test.ts
+++ b/packages/el-form-core/src/validators/__tests__/debounce.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { z } from "zod";
+import { ValidationEngine } from "../engine";
+import { SchemaAdapter } from "../adapters";
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("async debounce (characterization — existing behavior)", () => {
+  it("coalesces rapid async field validations with onChangeAsyncDebounceMs", async () => {
+    const engine = new ValidationEngine();
+    // Async validator function returning undefined = valid. SchemaAdapter treats a
+    // plain function as a validator function (validateAsyncFunction awaits it).
+    const spy = vi.fn(async () => undefined);
+    const config: any = { onChangeAsync: spy, onChangeAsyncDebounceMs: 200 };
+    const ev: any = { type: "onChange", isAsync: true, fieldName: "email" };
+
+    // Fire 3 times rapidly; only the last should actually run after 200ms.
+    // NOTE: superseded calls have their timers cleared and their promises never
+    // resolve (an existing quirk of the debounce machinery), so we only await the
+    // last call's promise — which is the one whose timer survives to fire.
+    void engine.validateField("email", "a", { email: "a" }, config, ev);
+    void engine.validateField("email", "ab", { email: "ab" }, config, ev);
+    const last = engine.validateField("email", "abc", { email: "abc" }, config, ev);
+
+    await vi.advanceTimersByTimeAsync(250);
+    await last;
+
+    expect(spy).toHaveBeenCalledTimes(1); // debounced to a single run
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ value: "abc" })
+    );
+  });
+
+  it("coalesces rapid async form validations with asyncDebounceMs", async () => {
+    const engine = new ValidationEngine();
+    const spy = vi.fn(async () => undefined);
+    const config: any = { onChangeAsync: spy, asyncDebounceMs: 200 };
+    const ev: any = { type: "onChange", isAsync: true };
+
+    void engine.validateForm({ email: "a" }, config, ev);
+    void engine.validateForm({ email: "ab" }, config, ev);
+    const last = engine.validateForm({ email: "abc" }, config, ev);
+
+    await vi.advanceTimersByTimeAsync(250);
+    await last;
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("sync debounce (new — validationDebounceMs)", () => {
+  it("coalesces rapid sync FIELD validations with validationDebounceMs", async () => {
+    const engine = new ValidationEngine();
+    // Sync validator function returning undefined = valid. SchemaAdapter treats a
+    // plain function as a validator function (validateFunction).
+    const spy = vi.fn(() => undefined);
+    const config: any = { onChange: spy, validationDebounceMs: 200 };
+    const ev: any = { type: "onChange", isAsync: false, fieldName: "name" };
+
+    // Fire 3 times rapidly; only the last should actually run after 200ms.
+    void engine.validateField("name", "a", { name: "a" }, config, ev);
+    void engine.validateField("name", "ab", { name: "ab" }, config, ev);
+    const last = engine.validateField("name", "abc", { name: "abc" }, config, ev);
+
+    await vi.advanceTimersByTimeAsync(250);
+    await last;
+
+    expect(spy).toHaveBeenCalledTimes(1); // debounced to a single run
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ value: "abc" })
+    );
+  });
+
+  it("coalesces rapid sync FORM validations with validationDebounceMs", async () => {
+    const engine = new ValidationEngine();
+    // Use a real schema (NOT a function) so the form-level schema-validate path —
+    // the one that debounces — is exercised. Spy on SchemaAdapter.validate to count
+    // real schema evaluations (zod v4 resolves via the Standard Schema branch, so
+    // spying on safeParse would miss it; SchemaAdapter.validate is the choke point
+    // the debounce wraps regardless of which library branch runs).
+    const schema = z.object({ name: z.string().min(1) });
+    const validateSpy = vi.spyOn(SchemaAdapter, "validate");
+    const config: any = { onChange: schema, validationDebounceMs: 200 };
+    const ev: any = { type: "onChange", isAsync: false };
+
+    void engine.validateForm({ name: "a" }, config, ev);
+    void engine.validateForm({ name: "ab" }, config, ev);
+    const last = engine.validateForm({ name: "abc" }, config, ev);
+
+    await vi.advanceTimersByTimeAsync(250);
+    await last;
+
+    expect(validateSpy).toHaveBeenCalledTimes(1); // debounced to a single run
+    expect(validateSpy).toHaveBeenLastCalledWith(schema, { name: "abc" });
+
+    validateSpy.mockRestore();
+  });
+});

--- a/packages/el-form-core/src/validators/__tests__/debounce.test.ts
+++ b/packages/el-form-core/src/validators/__tests__/debounce.test.ts
@@ -74,6 +74,22 @@ describe("sync debounce (new — validationDebounceMs)", () => {
     );
   });
 
+  it("propagates the validation RESULT (errors) through the debounced sync path", async () => {
+    const engine = new ValidationEngine();
+    // A field-level schema that rejects empty strings; the debounced result must carry
+    // the failure, not silently resolve valid.
+    const schema = z.string().min(1, "name required");
+    const config: any = { onChange: schema, validationDebounceMs: 200 };
+    const ev: any = { type: "onChange", isAsync: false, fieldName: "name" };
+
+    const last = engine.validateField("name", "", { name: "" }, config, ev);
+    await vi.advanceTimersByTimeAsync(250);
+    const result = await last;
+
+    expect(result.isValid).toBe(false);
+    expect(Object.keys(result.errors).length).toBeGreaterThan(0);
+  });
+
   it("coalesces rapid sync FORM validations with validationDebounceMs", async () => {
     const engine = new ValidationEngine();
     // Use a real schema (NOT a function) so the form-level schema-validate path —

--- a/packages/el-form-core/src/validators/engine.ts
+++ b/packages/el-form-core/src/validators/engine.ts
@@ -39,6 +39,16 @@ export class ValidationEngine {
     if (event.isAsync) {
       return this.validateAsync(validator, context, config, event);
     } else {
+      const debounceMs = config.validationDebounceMs || 0;
+      if (debounceMs > 0) {
+        return this.validateSyncWithDebounce(
+          validator,
+          value,
+          context,
+          event,
+          debounceMs
+        );
+      }
       return SchemaAdapter.validate(validator, value, context);
     }
   }
@@ -64,7 +74,7 @@ export class ValidationEngine {
     if (event.isAsync) {
       result = await this.validateFormAsync(validator, context, config, event);
     } else {
-      result = this.validateFormSync(validator, context);
+      result = await this.validateFormSync(validator, context, config, event);
     }
 
     return result;
@@ -180,10 +190,35 @@ export class ValidationEngine {
     });
   }
 
-  private validateFormSync(
+  private async validateSyncWithDebounce(
     validator: any,
-    context: { value: Record<string, any> }
-  ): ValidationResult {
+    value: any,
+    context: ValidatorContext,
+    event: ValidatorEvent,
+    debounceMs: number
+  ): Promise<ValidationResult> {
+    const key = `${context.fieldName}-${event.type}`;
+
+    // Clear existing timer (supersede the previous pending validation)
+    this.clearDebounce(context.fieldName, event.type);
+
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        this.debounceTimers.delete(key);
+        const result = SchemaAdapter.validate(validator, value, context);
+        resolve(result);
+      }, debounceMs);
+
+      this.debounceTimers.set(key, timer);
+    });
+  }
+
+  private async validateFormSync(
+    validator: any,
+    context: { value: Record<string, any> },
+    config: ValidatorConfig,
+    event: ValidatorEvent
+  ): Promise<ValidationResult> {
     if (typeof validator === "function") {
       const result = (validator as FormLevelValidator)(context);
 
@@ -206,7 +241,24 @@ export class ValidationEngine {
       }
     }
 
-    // For schema validators at form level, validate the entire form values
+    // For schema validators at form level, validate the entire form values.
+    // Debounce this path when configured (mirrors validateFormAsync). The
+    // function-validator branches above stay synchronous and un-debounced.
+    const debounceMs = config.validationDebounceMs || 0;
+    if (debounceMs > 0) {
+      const key = `form-${event.type}`;
+      this.clearDebounce("form", event.type);
+
+      return new Promise((resolve) => {
+        const timer = setTimeout(() => {
+          this.debounceTimers.delete(key);
+          resolve(SchemaAdapter.validate(validator, context.value));
+        }, debounceMs);
+
+        this.debounceTimers.set(key, timer);
+      });
+    }
+
     return SchemaAdapter.validate(validator, context.value);
   }
 

--- a/packages/el-form-core/src/validators/types.ts
+++ b/packages/el-form-core/src/validators/types.ts
@@ -40,6 +40,9 @@ export interface ValidatorConfig {
   // Global async debounce (applies to all async validators)
   asyncDebounceMs?: number;
 
+  /** Debounce SYNC validation (ms). Default 0 = off (validate every change). Works at field and form level, like asyncDebounceMs. */
+  validationDebounceMs?: number;
+
   // Run async validators even if sync validators fail
   asyncAlways?: boolean;
 }

--- a/packages/el-form-core/src/zodHelpers.ts
+++ b/packages/el-form-core/src/zodHelpers.ts
@@ -53,6 +53,8 @@ export function getTypeName(schema: AnyZodSchema): string | undefined {
       return "ZodNullable";
     case "optional":
       return "ZodOptional";
+    case "default":
+      return "ZodDefault";
     default:
       return undefined;
   }

--- a/packages/el-form-react-components/src/AutoForm.tsx
+++ b/packages/el-form-react-components/src/AutoForm.tsx
@@ -21,6 +21,7 @@ import {
   getDef,
 } from "el-form-core";
 import { FormSwitch, FormCase } from "./Form";
+import { fieldAriaProps } from "./fieldAria";
 
 // Zod helpers now come from el-form-core (Zod 4 only)
 
@@ -60,6 +61,8 @@ const DefaultField: React.FC<AutoFormFieldProps> = ({
   value,
   onChange,
   onBlur,
+  inputRef,
+  required,
   error,
   touched,
   options,
@@ -69,6 +72,7 @@ const DefaultField: React.FC<AutoFormFieldProps> = ({
   errorClassName,
 }: AutoFormFieldProps) => {
   const fieldId = `field-${name}`;
+  const aria = fieldAriaProps({ fieldId, error, touched, required });
 
   if (type === "checkbox") {
     return (
@@ -80,6 +84,10 @@ const DefaultField: React.FC<AutoFormFieldProps> = ({
           checked={!!value}
           onChange={onChange}
           onBlur={onBlur}
+          ref={inputRef}
+          aria-invalid={aria["aria-invalid"]}
+          aria-describedby={aria["aria-describedby"]}
+          aria-required={aria["aria-required"]}
           className={inputClassName || "el-form-checkbox"}
         />
         <label
@@ -112,6 +120,10 @@ const DefaultField: React.FC<AutoFormFieldProps> = ({
           value={value || ""}
           onChange={onChange}
           onBlur={onBlur}
+          ref={inputRef}
+          aria-invalid={aria["aria-invalid"]}
+          aria-describedby={aria["aria-describedby"]}
+          aria-required={aria["aria-required"]}
           placeholder={placeholder}
           className={inputClassName || "el-form-textarea"}
           rows={4}
@@ -123,6 +135,10 @@ const DefaultField: React.FC<AutoFormFieldProps> = ({
           value={value || ""}
           onChange={onChange}
           onBlur={onBlur}
+          ref={inputRef}
+          aria-invalid={aria["aria-invalid"]}
+          aria-describedby={aria["aria-describedby"]}
+          aria-required={aria["aria-required"]}
           className={inputClassName || "el-form-select"}
         >
           <option value="">{placeholder || "Select an option"}</option>
@@ -140,13 +156,21 @@ const DefaultField: React.FC<AutoFormFieldProps> = ({
           value={value || ""}
           onChange={onChange}
           onBlur={onBlur}
+          ref={inputRef}
+          aria-invalid={aria["aria-invalid"]}
+          aria-describedby={aria["aria-describedby"]}
+          aria-required={aria["aria-required"]}
           placeholder={placeholder}
           className={inputClasses}
         />
       )}
 
       {hasError && (
-        <div className={errorClassName || "el-form-error-message"}>
+        <div
+          id={aria.errorId}
+          role="alert"
+          className={errorClassName || "el-form-error-message"}
+        >
           <span>⚠️</span>
           <span className="ml-1">{error}</span>
         </div>
@@ -416,12 +440,21 @@ function generateFieldsFromSchema<T extends z.ZodTypeAny>(
     // Unwrap optional/nullable/default wrappers to get the inner type
     const zodType = unwrapZodType(rawZodType);
     const typeName = getTypeName(zodType as any);
+    // A field is required unless the RAW (pre-unwrap) type is one of the
+    // optional/nullable/default wrappers.
+    const rawTypeName = getTypeName(rawZodType as any);
+    const required = !(
+      rawTypeName === "ZodOptional" ||
+      rawTypeName === "ZodNullable" ||
+      rawTypeName === "ZodDefault"
+    );
     const fieldConfig: AutoFormFieldConfig = {
       name: key,
       label: key
         .replace(/([A-Z])/g, " $1")
         .replace(/^./, (s) => s.toUpperCase()),
       type: "text",
+      required,
     };
 
     if (typeName === "ZodString") {
@@ -581,6 +614,8 @@ const DiscriminatedUnionField: React.FC<DiscriminatedUnionFieldProps> = ({
                           value={fieldValue}
                           onChange={fieldProps.onChange}
                           onBlur={fieldProps.onBlur}
+                          inputRef={fieldProps.ref}
+                          required={field.required}
                           error={error}
                           touched={touched}
                           options={field.options}
@@ -800,6 +835,8 @@ export function AutoForm<T extends Record<string, any>>({
           value={fieldValue}
           onChange={fieldProps.onChange}
           onBlur={fieldProps.onBlur}
+          inputRef={fieldProps.ref}
+          required={fieldConfig.required}
           error={error}
           touched={touched}
           options={fieldConfig.options}

--- a/packages/el-form-react-components/src/FieldComponents.tsx
+++ b/packages/el-form-react-components/src/FieldComponents.tsx
@@ -1,4 +1,4 @@
-import { useFormContext } from "el-form-react-hooks";
+import { useFormContext, useField } from "el-form-react-hooks";
 import { fieldAriaProps } from "./fieldAria";
 
 // Base field props that all field components should extend
@@ -45,11 +45,11 @@ export function TextField<T extends Record<string, any>, K extends keyof T>({
   type?: "text" | "email" | "password" | "url" | "tel";
 }) {
   const form = useFormContext<T>();
-  const field = createField<T, K>(name);
-
-  const error = field.getError(form.form);
-  const touched = field.getTouched(form.form);
-  const registration = field.register(form.form);
+  const { error, touched } = useField<T, any>(name as any);
+  const registration = form.form.register(String(name) as any) as Record<
+    string,
+    any
+  >;
   const aria = fieldAriaProps({ fieldId: String(name), error, touched, required });
 
   const inputClasses = `
@@ -110,11 +110,11 @@ export function TextareaField<
   rows?: number;
 }) {
   const form = useFormContext<T>();
-  const field = createField<T, K>(name);
-
-  const error = field.getError(form.form);
-  const touched = field.getTouched(form.form);
-  const registration = field.register(form.form);
+  const { error, touched } = useField<T, any>(name as any);
+  const registration = form.form.register(String(name) as any) as Record<
+    string,
+    any
+  >;
   const aria = fieldAriaProps({ fieldId: String(name), error, touched, required });
 
   const textareaClasses = `
@@ -172,11 +172,11 @@ export function SelectField<T extends Record<string, any>, K extends keyof T>({
   options: Array<{ value: string; label: string }>;
 }) {
   const form = useFormContext<T>();
-  const field = createField<T, K>(name);
-
-  const error = field.getError(form.form);
-  const touched = field.getTouched(form.form);
-  const registration = field.register(form.form);
+  const { error, touched } = useField<T, any>(name as any);
+  const registration = form.form.register(String(name) as any) as Record<
+    string,
+    any
+  >;
   const aria = fieldAriaProps({ fieldId: String(name), error, touched, required });
 
   const selectClasses = `

--- a/packages/el-form-react-components/src/FieldComponents.tsx
+++ b/packages/el-form-react-components/src/FieldComponents.tsx
@@ -1,4 +1,5 @@
 import { useFormContext } from "el-form-react-hooks";
+import { fieldAriaProps } from "./fieldAria";
 
 // Base field props that all field components should extend
 export interface BaseFieldProps<
@@ -38,6 +39,7 @@ export function TextField<T extends Record<string, any>, K extends keyof T>({
   placeholder,
   className = "",
   type = "text",
+  required,
   ...props
 }: BaseFieldProps<T, K> & {
   type?: "text" | "email" | "password" | "url" | "tel";
@@ -48,6 +50,7 @@ export function TextField<T extends Record<string, any>, K extends keyof T>({
   const error = field.getError(form.form);
   const touched = field.getTouched(form.form);
   const registration = field.register(form.form);
+  const aria = fieldAriaProps({ fieldId: String(name), error, touched, required });
 
   const inputClasses = `
     w-full px-3 py-2 border rounded-md text-sm text-gray-900 placeholder-gray-500
@@ -77,10 +80,16 @@ export function TextField<T extends Record<string, any>, K extends keyof T>({
         id={String(name)}
         type={type}
         placeholder={placeholder}
+        required={required}
+        aria-invalid={aria["aria-invalid"]}
+        aria-describedby={aria["aria-describedby"]}
+        aria-required={aria["aria-required"]}
         className={inputClasses}
       />
       {touched && error && (
-        <div className="text-red-500 text-xs mt-1">{error}</div>
+        <div id={aria.errorId} role="alert" className="text-red-500 text-xs mt-1">
+          {error}
+        </div>
       )}
     </div>
   );
@@ -95,6 +104,7 @@ export function TextareaField<
   placeholder,
   className = "",
   rows = 4,
+  required,
   ...props
 }: BaseFieldProps<T, K> & {
   rows?: number;
@@ -105,6 +115,7 @@ export function TextareaField<
   const error = field.getError(form.form);
   const touched = field.getTouched(form.form);
   const registration = field.register(form.form);
+  const aria = fieldAriaProps({ fieldId: String(name), error, touched, required });
 
   const textareaClasses = `
     w-full px-3 py-2 border rounded-md text-sm text-gray-900 placeholder-gray-500
@@ -134,10 +145,16 @@ export function TextareaField<
         id={String(name)}
         placeholder={placeholder}
         rows={rows}
+        required={required}
+        aria-invalid={aria["aria-invalid"]}
+        aria-describedby={aria["aria-describedby"]}
+        aria-required={aria["aria-required"]}
         className={textareaClasses}
       />
       {touched && error && (
-        <div className="text-red-500 text-xs mt-1">{error}</div>
+        <div id={aria.errorId} role="alert" className="text-red-500 text-xs mt-1">
+          {error}
+        </div>
       )}
     </div>
   );
@@ -149,6 +166,7 @@ export function SelectField<T extends Record<string, any>, K extends keyof T>({
   placeholder,
   className = "",
   options = [],
+  required,
   ...props
 }: BaseFieldProps<T, K> & {
   options: Array<{ value: string; label: string }>;
@@ -159,6 +177,7 @@ export function SelectField<T extends Record<string, any>, K extends keyof T>({
   const error = field.getError(form.form);
   const touched = field.getTouched(form.form);
   const registration = field.register(form.form);
+  const aria = fieldAriaProps({ fieldId: String(name), error, touched, required });
 
   const selectClasses = `
     w-full px-3 py-2 border rounded-md text-sm text-gray-900
@@ -186,6 +205,10 @@ export function SelectField<T extends Record<string, any>, K extends keyof T>({
         {...registration}
         {...props}
         id={String(name)}
+        required={required}
+        aria-invalid={aria["aria-invalid"]}
+        aria-describedby={aria["aria-describedby"]}
+        aria-required={aria["aria-required"]}
         className={selectClasses}
       >
         {placeholder && (
@@ -200,7 +223,9 @@ export function SelectField<T extends Record<string, any>, K extends keyof T>({
         ))}
       </select>
       {touched && error && (
-        <div className="text-red-500 text-xs mt-1">{error}</div>
+        <div id={aria.errorId} role="alert" className="text-red-500 text-xs mt-1">
+          {error}
+        </div>
       )}
     </div>
   );

--- a/packages/el-form-react-components/src/__tests__/a11y.runtime.test.tsx
+++ b/packages/el-form-react-components/src/__tests__/a11y.runtime.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import React from "react";
 import { z } from "zod";
 import { useForm, FormProvider } from "el-form-react-hooks";
@@ -26,17 +26,8 @@ describe("FieldComponents a11y", () => {
     expect(input.getAttribute("aria-required")).toBe("true");
 
     // produce an error: type an invalid value then blur to mark touched.
-    // The standalone field reads form state through the context holder, which
-    // settles errors/touched one render cycle behind the underlying state, so
-    // we flush microtasks and nudge one more render (a second blur) to let the
-    // touched + error state paint.
     fireEvent.change(input, { target: { value: "x" } });
     fireEvent.blur(input);
-    await act(async () => {
-      await Promise.resolve();
-    });
-    fireEvent.blur(input);
-
     const err = await screen.findByRole("alert");
     expect(err.getAttribute("id")).toBe("email-error");
     expect(input.getAttribute("aria-invalid")).toBe("true");

--- a/packages/el-form-react-components/src/__tests__/a11y.runtime.test.tsx
+++ b/packages/el-form-react-components/src/__tests__/a11y.runtime.test.tsx
@@ -40,6 +40,7 @@ describe("AutoForm a11y", () => {
     const schema = z.object({
       email: z.string().email("bad email"), // required
       nickname: z.string().optional(), // optional
+      country: z.string().default("US"), // has a default => not required
     });
     render(<AutoForm schema={schema} onSubmit={() => {}} />);
 
@@ -48,6 +49,9 @@ describe("AutoForm a11y", () => {
 
     const nickname = screen.getByLabelText(/nickname/i) as HTMLInputElement;
     expect(nickname.getAttribute("aria-required")).toBe(null); // optional => no aria-required
+
+    const country = screen.getByLabelText(/country/i) as HTMLInputElement;
+    expect(country.getAttribute("aria-required")).toBe(null); // default => not required
 
     // AutoForm defaults to validateOn="onSubmit", so submit to surface the
     // error (which also marks the field touched).

--- a/packages/el-form-react-components/src/__tests__/a11y.runtime.test.tsx
+++ b/packages/el-form-react-components/src/__tests__/a11y.runtime.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import React from "react";
 import { z } from "zod";
 import { useForm, FormProvider } from "el-form-react-hooks";
-import { TextField } from "..";
+import { TextField, AutoForm } from "..";
 
 beforeEach(cleanup);
 
@@ -32,5 +32,30 @@ describe("FieldComponents a11y", () => {
     expect(err.getAttribute("id")).toBe("email-error");
     expect(input.getAttribute("aria-invalid")).toBe("true");
     expect(input.getAttribute("aria-describedby")).toBe("email-error");
+  });
+});
+
+describe("AutoForm a11y", () => {
+  it("wires aria-invalid/describedby/required + role=alert on generated fields", async () => {
+    const schema = z.object({
+      email: z.string().email("bad email"), // required
+      nickname: z.string().optional(), // optional
+    });
+    render(<AutoForm schema={schema} onSubmit={() => {}} />);
+
+    const email = screen.getByLabelText(/email/i) as HTMLInputElement;
+    expect(email.getAttribute("aria-required")).toBe("true");
+
+    const nickname = screen.getByLabelText(/nickname/i) as HTMLInputElement;
+    expect(nickname.getAttribute("aria-required")).toBe(null); // optional => no aria-required
+
+    // AutoForm defaults to validateOn="onSubmit", so submit to surface the
+    // error (which also marks the field touched).
+    fireEvent.click(screen.getByRole("button", { name: /submit/i }));
+
+    const err = await screen.findByRole("alert");
+    expect(err.getAttribute("id")).toBe("field-email-error");
+    expect(email.getAttribute("aria-invalid")).toBe("true");
+    expect(email.getAttribute("aria-describedby")).toBe("field-email-error");
   });
 });

--- a/packages/el-form-react-components/src/__tests__/a11y.runtime.test.tsx
+++ b/packages/el-form-react-components/src/__tests__/a11y.runtime.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
+import React from "react";
+import { z } from "zod";
+import { useForm, FormProvider } from "el-form-react-hooks";
+import { TextField } from "..";
+
+beforeEach(cleanup);
+
+function Demo() {
+  const form = useForm({
+    validators: { onChange: z.object({ email: z.string().email("bad email") }) },
+    defaultValues: { email: "" },
+  });
+  return (
+    <FormProvider form={form}>
+      <TextField name="email" label="Email" required />
+    </FormProvider>
+  );
+}
+
+describe("FieldComponents a11y", () => {
+  it("wires aria-required, and aria-invalid + aria-describedby + role=alert on error", async () => {
+    render(<Demo />);
+    const input = screen.getByLabelText("Email") as HTMLInputElement;
+    expect(input.getAttribute("aria-required")).toBe("true");
+
+    // produce an error: type an invalid value then blur to mark touched.
+    // The standalone field reads form state through the context holder, which
+    // settles errors/touched one render cycle behind the underlying state, so
+    // we flush microtasks and nudge one more render (a second blur) to let the
+    // touched + error state paint.
+    fireEvent.change(input, { target: { value: "x" } });
+    fireEvent.blur(input);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    fireEvent.blur(input);
+
+    const err = await screen.findByRole("alert");
+    expect(err.getAttribute("id")).toBe("email-error");
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(input.getAttribute("aria-describedby")).toBe("email-error");
+  });
+});

--- a/packages/el-form-react-components/src/fieldAria.ts
+++ b/packages/el-form-react-components/src/fieldAria.ts
@@ -1,0 +1,29 @@
+export interface FieldAriaInput {
+  fieldId: string;
+  error?: unknown;
+  touched?: unknown;
+  required?: boolean;
+}
+export interface FieldAriaResult {
+  "aria-invalid"?: true;
+  "aria-describedby"?: string;
+  "aria-required"?: true;
+  errorId: string;
+}
+/** ARIA props for an input + the id its error element should carry. */
+export function fieldAriaProps({
+  fieldId,
+  error,
+  touched,
+  required,
+}: FieldAriaInput): FieldAriaResult {
+  const showError = Boolean(touched && error);
+  const errorId = `${fieldId}-error`;
+  return {
+    ...(showError
+      ? { "aria-invalid": true as const, "aria-describedby": errorId }
+      : {}),
+    ...(required ? { "aria-required": true as const } : {}),
+    errorId,
+  };
+}

--- a/packages/el-form-react-components/src/types.ts
+++ b/packages/el-form-react-components/src/types.ts
@@ -11,6 +11,7 @@ export interface AutoFormFieldConfig {
   label?: string;
   type?: FieldType;
   placeholder?: string;
+  required?: boolean;
   colSpan?: GridColumns;
   component?: React.ComponentType<AutoFormFieldProps>;
   options?: Array<{ value: string; label: string }>;
@@ -35,6 +36,10 @@ export interface AutoFormFieldProps {
   onBlur: (e: React.FocusEvent<any>) => void;
   error?: string;
   touched?: boolean;
+  required?: boolean;
+  inputRef?: (
+    el: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | null
+  ) => void;
   options?: Array<{ value: string; label: string }>;
   fields?: AutoFormFieldConfig[];
   onAddItem?: () => void;

--- a/packages/el-form-react-hooks/src/__tests__/focusError.runtime.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/focusError.runtime.test.tsx
@@ -47,8 +47,19 @@ describe("focus-on-error", () => {
   it("does not focus when shouldFocusError is false", async () => {
     const Demo = makeForm({ shouldFocusError: false });
     render(<Demo />);
+    // Pre-focus a sentinel; if focus-on-error were active it would steal focus to input "a".
+    const sentinelBtn = document.createElement("button");
+    sentinelBtn.setAttribute("data-testid", "sentinel");
+    document.body.appendChild(sentinelBtn);
+    sentinelBtn.focus();
+    expect(document.activeElement).toBe(sentinelBtn);
+
     fireEvent.click(screen.getByText("submit"));
     await new Promise((r) => setTimeout(r, 50));
+    // Focus must NOT have been programmatically moved to the first invalid field.
     expect(document.activeElement).not.toBe(screen.getByLabelText("a"));
+    expect(document.activeElement).not.toBe(screen.getByLabelText("b"));
+
+    document.body.removeChild(sentinelBtn);
   });
 });

--- a/packages/el-form-react-hooks/src/__tests__/focusError.runtime.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/focusError.runtime.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import { z } from "zod";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+const schema = z.object({
+  a: z.string().min(1, "a required"),
+  b: z.string().min(1, "b required"),
+});
+
+function makeForm(opts?: { shouldFocusError?: boolean }) {
+  return function Demo() {
+    const { register, handleSubmit } = useForm({
+      validators: { onSubmit: schema },
+      defaultValues: { a: "", b: "" },
+      ...opts,
+    });
+    return (
+      <form onSubmit={handleSubmit(() => {})}>
+        <input aria-label="a" {...register("a")} />
+        <input aria-label="b" {...register("b")} />
+        <button type="submit">submit</button>
+      </form>
+    );
+  };
+}
+
+describe("focus-on-error", () => {
+  it("focuses the first errored field on invalid submit (default on)", async () => {
+    const Demo = makeForm();
+    render(<Demo />);
+    fireEvent.click(screen.getByText("submit"));
+    await waitFor(() =>
+      expect(document.activeElement).toBe(screen.getByLabelText("a"))
+    );
+  });
+
+  it("does not focus when shouldFocusError is false", async () => {
+    const Demo = makeForm({ shouldFocusError: false });
+    render(<Demo />);
+    fireEvent.click(screen.getByText("submit"));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(document.activeElement).not.toBe(screen.getByLabelText("a"));
+  });
+});

--- a/packages/el-form-react-hooks/src/__tests__/setFocus.runtime.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/setFocus.runtime.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import React from "react";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+function Demo() {
+  const { register, setFocus } = useForm<{ a: string; b: string }>({
+    defaultValues: { a: "", b: "" },
+  });
+  return (
+    <div>
+      <input aria-label="a" {...register("a")} />
+      <input aria-label="b" {...register("b")} />
+      <button onClick={() => setFocus("b")}>focus-b</button>
+    </div>
+  );
+}
+
+describe("setFocus", () => {
+  it("moves focus to the named field", () => {
+    render(<Demo />);
+    const b = screen.getByLabelText("b");
+    screen.getByText("focus-b").click();
+    expect(document.activeElement).toBe(b);
+  });
+});

--- a/packages/el-form-react-hooks/src/types.ts
+++ b/packages/el-form-react-hooks/src/types.ts
@@ -45,6 +45,9 @@ export interface UseFormOptions<T extends Record<string, any>> {
 
   // Zod schema for discriminated union support and enhanced validation
   schema?: any;
+
+  /** Focus the first invalid field after a failed submit. Default true. */
+  shouldFocusError?: boolean;
 }
 
 export interface FieldState {

--- a/packages/el-form-react-hooks/src/types/path.ts
+++ b/packages/el-form-react-hooks/src/types/path.ts
@@ -78,6 +78,9 @@ export type RegisterReturn<Value> = {
   name: string;
   onChange: (e: React.ChangeEvent<any>) => void;
   onBlur: (e: React.FocusEvent<any>) => void;
+  ref: (
+    el: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | null
+  ) => void;
 } & (Value extends boolean
   ? { checked: boolean; value?: never; files?: never }
   : Value extends File | FileList | (File | null)[] | File[] | null | undefined

--- a/packages/el-form-react-hooks/src/useForm.ts
+++ b/packages/el-form-react-hooks/src/useForm.ts
@@ -38,6 +38,7 @@ export function useForm<T extends Record<string, any>>(
     validateOn,
     onSubmit,
     schema,
+    shouldFocusError,
   } = options;
 
   // Core refs and state
@@ -98,6 +99,8 @@ export function useForm<T extends Record<string, any>>(
     setFormState,
     validationManager,
     onSubmit,
+    fieldRefs,
+    shouldFocusError,
   });
 
   const errorManagement = createErrorManagementManager<T>({

--- a/packages/el-form-react-hooks/src/useForm.ts
+++ b/packages/el-form-react-hooks/src/useForm.ts
@@ -221,6 +221,12 @@ export function useForm<T extends Record<string, any>>(
 
       const baseProps = {
         name,
+        ref: (
+          el: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | null
+        ) => {
+          if (el) fieldRefs.current.set(name as keyof T, el);
+          else fieldRefs.current.delete(name as keyof T);
+        },
         onChange: async (e: React.ChangeEvent<any>) => {
           const value = (() => {
             // Handle file inputs

--- a/packages/el-form-react-hooks/src/utils/focusError.ts
+++ b/packages/el-form-react-hooks/src/utils/focusError.ts
@@ -1,6 +1,12 @@
 /**
  * Given the errors object (in validateForm key order) and a resolver from field name
  * to its DOM element, return the first errored element that exists and is focusable.
+ *
+ * Nested/array field errors with dotted keys (e.g. "items.0.name") resolve correctly
+ * because `register` stores fieldRefs under the same dotted path. However, errors keyed
+ * at a parent/group path (e.g. a schema-level refinement producing key "skills", or a
+ * root "form" error) have no registered input and are silently skipped — focus lands on
+ * the next resolvable errored field, or nowhere if no resolvable field exists.
  */
 export function findFirstErrorElement(
   errors: Record<string, any>,

--- a/packages/el-form-react-hooks/src/utils/focusError.ts
+++ b/packages/el-form-react-hooks/src/utils/focusError.ts
@@ -1,0 +1,15 @@
+/**
+ * Given the errors object (in validateForm key order) and a resolver from field name
+ * to its DOM element, return the first errored element that exists and is focusable.
+ */
+export function findFirstErrorElement(
+  errors: Record<string, any>,
+  resolve: (name: string) => HTMLElement | undefined
+): HTMLElement | undefined {
+  for (const name of Object.keys(errors)) {
+    if (!errors[name]) continue;
+    const el = resolve(name);
+    if (el && typeof el.focus === "function") return el;
+  }
+  return undefined;
+}

--- a/packages/el-form-react-hooks/src/utils/index.ts
+++ b/packages/el-form-react-hooks/src/utils/index.ts
@@ -58,6 +58,11 @@ export * from "./formHistory";
 export * from "./focusManagement";
 
 /**
+ * Focus-on-error utilities
+ */
+export * from "./focusError";
+
+/**
  * Array operations utilities
  */
 export * from "./arrayOperations";

--- a/packages/el-form-react-hooks/src/utils/submitOperations.ts
+++ b/packages/el-form-react-hooks/src/utils/submitOperations.ts
@@ -1,5 +1,6 @@
 import { FormState, UseFormOptions, UseFormReturn } from "../types";
 import { ValidationManager } from "./validation";
+import { findFirstErrorElement } from "./focusError";
 
 /**
  * Submit operations utilities
@@ -20,6 +21,10 @@ export interface SubmitOperationsOptions<T extends Record<string, any>> {
   setFormState: React.Dispatch<React.SetStateAction<FormState<T>>>;
   validationManager: ValidationManager<T>;
   onSubmit?: UseFormOptions<T>["onSubmit"];
+  fieldRefs: React.MutableRefObject<
+    Map<keyof T, HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+  >;
+  shouldFocusError?: boolean;
 }
 
 /**
@@ -28,7 +33,14 @@ export interface SubmitOperationsOptions<T extends Record<string, any>> {
 export function createSubmitOperationsManager<T extends Record<string, any>>(
   options: SubmitOperationsOptions<T>
 ): SubmitOperationsManager<T> {
-  const { formState, setFormState, validationManager, onSubmit } = options;
+  const {
+    formState,
+    setFormState,
+    validationManager,
+    onSubmit,
+    fieldRefs,
+    shouldFocusError,
+  } = options;
 
   return {
     // Handle submit - simplified
@@ -63,8 +75,17 @@ export function createSubmitOperationsManager<T extends Record<string, any>>(
 
         if (isValid) {
           await onValid(formState.values as T);
-        } else if (onError) {
-          onError(errors);
+        } else {
+          if (shouldFocusError !== false) {
+            const el = findFirstErrorElement(
+              errors as Record<string, any>,
+              (name) => fieldRefs.current.get(name as keyof T)
+            );
+            el?.focus();
+          }
+          if (onError) {
+            onError(errors);
+          }
         }
       };
     },


### PR DESCRIPTION
## Summary

Phase 4 of the El Form revival. Three additive, backward-compatible workstreams across `el-form-core`, `el-form-react-hooks`, and `el-form-react-components`.

### ♿ Accessibility
- AutoForm-generated inputs **and** the standalone `TextField` / `TextareaField` / `SelectField` now wire `aria-invalid`, `aria-describedby` (linked to the error element), and `aria-required`; field errors render with `role="alert"` for screen-reader announcement. Shared `fieldAriaProps` helper, no markup changes needed by consumers.
- **Focus-on-error:** `useForm` gains `shouldFocusError` (default `true`) — after a failed submit, focus moves to the first invalid field. Opt out with `shouldFocusError: false`.
- This required making `register` return a working `ref`: `fieldRefs` was declared but **never populated**, so `setFocus` was a silent no-op. `register` now returns a `ref` that registers each field's DOM node.

### ⏱️ Validation debounce
- New `validationDebounceMs` config debounces **synchronous** validation at both field and form level (default `0` = unchanged), symmetric with the existing `asyncDebounceMs`. Error *clearing* stays immediate; only error *setting* is debounced.
- The previously-untested async debounce now has characterization tests.

### 🐞 Fixes found along the way
- **Standalone field components now show errors on the first blur.** They previously read form state through the `FormProvider` context getter at render time, which lags one render behind; they now subscribe via `useField`. (AutoForm was never affected.) The deeper `FormProvider` getter lag is documented as a known issue for a future fix.
- `getTypeName` now recognizes Zod v4 `ZodDefault`, so `.default()` fields are correctly treated as not-required (no spurious `aria-required`). Also repairs a latent gap in `unwrapZodType`.

### Release
Changeset bumps `el-form-react-hooks`, `el-form-react-components`, and `el-form-core` (minor), cascading patch to `el-form-react`. Batches into the held `3.11.0` "Version Packages" PR alongside `useFieldArray`.

## Test Plan
- [x] `el-form-core` — 16 tests (incl. 5 new debounce + dual-compat regression guard for the getTypeName change)
- [x] `el-form-react-hooks` — 61 tests + tsd type tests (new: setFocus, focus-on-error)
- [x] `el-form-react-components` — 25 tests (new: a11y for AutoForm + FieldComponents; reactivity-fix proven by single-blur test, no act() workaround)
- [x] `el-form-mcp` — 23 tests (unaffected)
- [x] `pnpm build:packages` — all packages build clean, browser-safe (no Node globals)
- [x] `changeset status` → hooks/components/core minor + cascade

🤖 Generated with [Claude Code](https://claude.com/claude-code)