### PR TITLE
chore: code-quality cleanup — lint coverage, Node alignment, debounce hang fix

### DIFF
--- a/.changeset/debounce-hang-fix.md
+++ b/.changeset/debounce-hang-fix.md
@@ -1,0 +1,10 @@
+---
+"el-form-core": patch
+---
+
+Fix a debounce bug where a superseded validation's promise never resolved. When several
+debounced validations fired in quick succession (via `asyncDebounceMs` or
+`validationDebounceMs`), only the last one settled — any code awaiting a superseded call
+hung forever. Superseded (and explicitly-cleared) debounced validations now resolve
+immediately with a valid result, since a newer validation is already in flight. Internally,
+the four duplicated debounce code paths are unified into one helper. No API changes.

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -14,7 +14,7 @@ jobs:
           version: 8.15.0
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 

--- a/packages/el-form-core/package.json
+++ b/packages/el-form-core/package.json
@@ -43,7 +43,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "test": "vitest run"
+    "test": "vitest run",
+    "lint": "eslint \"src/**/*.{ts,tsx}\""
   },
   "dependencies": {},
   "peerDependencies": {

--- a/packages/el-form-core/src/validation.ts
+++ b/packages/el-form-core/src/validation.ts
@@ -17,7 +17,7 @@ export function flattenObject(obj: any, prefix = ""): Record<string, any> {
   const flattened: Record<string, any> = {};
 
   for (const key in obj) {
-    if (obj.hasOwnProperty(key)) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
       const newKey = prefix ? `${prefix}.${key}` : key;
 
       if (

--- a/packages/el-form-core/src/validators/__tests__/debounce.test.ts
+++ b/packages/el-form-core/src/validators/__tests__/debounce.test.ts
@@ -23,7 +23,13 @@ describe("async debounce (characterization — existing behavior)", () => {
     // last call's promise — which is the one whose timer survives to fire.
     void engine.validateField("email", "a", { email: "a" }, config, ev);
     void engine.validateField("email", "ab", { email: "ab" }, config, ev);
-    const last = engine.validateField("email", "abc", { email: "abc" }, config, ev);
+    const last = engine.validateField(
+      "email",
+      "abc",
+      { email: "abc" },
+      config,
+      ev
+    );
 
     await vi.advanceTimersByTimeAsync(250);
     await last;
@@ -63,7 +69,13 @@ describe("sync debounce (new — validationDebounceMs)", () => {
     // Fire 3 times rapidly; only the last should actually run after 200ms.
     void engine.validateField("name", "a", { name: "a" }, config, ev);
     void engine.validateField("name", "ab", { name: "ab" }, config, ev);
-    const last = engine.validateField("name", "abc", { name: "abc" }, config, ev);
+    const last = engine.validateField(
+      "name",
+      "abc",
+      { name: "abc" },
+      config,
+      ev
+    );
 
     await vi.advanceTimersByTimeAsync(250);
     await last;
@@ -117,32 +129,28 @@ describe("sync debounce (new — validationDebounceMs)", () => {
 });
 
 describe("superseded debounced validations resolve (no hang)", () => {
-  it(
-    "resolves ALL awaited debounced calls in a rapid burst, not just the last",
-    async () => {
-      const engine = new ValidationEngine();
-      // A field-level schema that rejects empty strings. Only the LAST call's value
-      // ("abc") is non-empty, so the authoritative result is valid; the superseded
-      // calls must resolve with the safe sentinel { isValid: true, errors: {} }.
-      const schema = z.string().min(1, "name required");
-      const config: any = { onChange: schema, validationDebounceMs: 200 };
-      const ev: any = { type: "onChange", isAsync: false, fieldName: "name" };
+  it("resolves ALL awaited debounced calls in a rapid burst, not just the last", async () => {
+    const engine = new ValidationEngine();
+    // A field-level schema that rejects empty strings. Only the LAST call's value
+    // ("abc") is non-empty, so the authoritative result is valid; the superseded
+    // calls must resolve with the safe sentinel { isValid: true, errors: {} }.
+    const schema = z.string().min(1, "name required");
+    const config: any = { onChange: schema, validationDebounceMs: 200 };
+    const ev: any = { type: "onChange", isAsync: false, fieldName: "name" };
 
-      // Fire 3 rapidly and AWAIT ALL THREE. Against the buggy code the first two
-      // promises never resolve, so Promise.all hangs and this test times out.
-      const p1 = engine.validateField("name", "a", { name: "a" }, config, ev);
-      const p2 = engine.validateField("name", "ab", { name: "ab" }, config, ev);
-      const p3 = engine.validateField("name", "abc", { name: "abc" }, config, ev);
+    // Fire 3 rapidly and AWAIT ALL THREE. Against the buggy code the first two
+    // promises never resolve, so Promise.all hangs and this test times out.
+    const p1 = engine.validateField("name", "a", { name: "a" }, config, ev);
+    const p2 = engine.validateField("name", "ab", { name: "ab" }, config, ev);
+    const p3 = engine.validateField("name", "abc", { name: "abc" }, config, ev);
 
-      await vi.advanceTimersByTimeAsync(250);
-      const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+    await vi.advanceTimersByTimeAsync(250);
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
 
-      // The two superseded calls resolve with the safe sentinel.
-      expect(r1).toEqual({ isValid: true, errors: {} });
-      expect(r2).toEqual({ isValid: true, errors: {} });
-      // The last (surviving) call resolves with the real result.
-      expect(r3.isValid).toBe(true);
-    },
-    2000
-  );
+    // The two superseded calls resolve with the safe sentinel.
+    expect(r1).toEqual({ isValid: true, errors: {} });
+    expect(r2).toEqual({ isValid: true, errors: {} });
+    // The last (surviving) call resolves with the real result.
+    expect(r3.isValid).toBe(true);
+  }, 2000);
 });

--- a/packages/el-form-core/src/validators/__tests__/debounce.test.ts
+++ b/packages/el-form-core/src/validators/__tests__/debounce.test.ts
@@ -115,3 +115,34 @@ describe("sync debounce (new — validationDebounceMs)", () => {
     validateSpy.mockRestore();
   });
 });
+
+describe("superseded debounced validations resolve (no hang)", () => {
+  it(
+    "resolves ALL awaited debounced calls in a rapid burst, not just the last",
+    async () => {
+      const engine = new ValidationEngine();
+      // A field-level schema that rejects empty strings. Only the LAST call's value
+      // ("abc") is non-empty, so the authoritative result is valid; the superseded
+      // calls must resolve with the safe sentinel { isValid: true, errors: {} }.
+      const schema = z.string().min(1, "name required");
+      const config: any = { onChange: schema, validationDebounceMs: 200 };
+      const ev: any = { type: "onChange", isAsync: false, fieldName: "name" };
+
+      // Fire 3 rapidly and AWAIT ALL THREE. Against the buggy code the first two
+      // promises never resolve, so Promise.all hangs and this test times out.
+      const p1 = engine.validateField("name", "a", { name: "a" }, config, ev);
+      const p2 = engine.validateField("name", "ab", { name: "ab" }, config, ev);
+      const p3 = engine.validateField("name", "abc", { name: "abc" }, config, ev);
+
+      await vi.advanceTimersByTimeAsync(250);
+      const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+      // The two superseded calls resolve with the safe sentinel.
+      expect(r1).toEqual({ isValid: true, errors: {} });
+      expect(r2).toEqual({ isValid: true, errors: {} });
+      // The last (surviving) call resolves with the real result.
+      expect(r3.isValid).toBe(true);
+    },
+    2000
+  );
+});

--- a/packages/el-form-core/src/validators/adapters.ts
+++ b/packages/el-form-core/src/validators/adapters.ts
@@ -138,7 +138,7 @@ export class SchemaAdapter {
   }
 
   private static validateFunction(
-    validator: Function,
+    validator: (context: ValidatorContext) => any,
     value: any,
     context?: ValidatorContext
   ): ValidationResult {
@@ -170,7 +170,7 @@ export class SchemaAdapter {
   }
 
   private static async validateAsyncFunction(
-    validator: Function,
+    validator: (context: ValidatorContext) => any,
     value: any,
     context?: ValidatorContext
   ): Promise<ValidationResult> {

--- a/packages/el-form-core/src/validators/engine.ts
+++ b/packages/el-form-core/src/validators/engine.ts
@@ -24,7 +24,12 @@ interface PendingDebounce {
 // authoritative result; (b) the hooks layer treats `isValid: true` as "nothing to
 // set", so a superseded result never writes stale errors. Its sole purpose is to
 // unblock the dangling promise.
-const SUPERSEDED_RESULT: ValidationResult = { isValid: true, errors: {} };
+// Frozen so an accidental future `result.errors[x] = ...` on a superseded result
+// throws loudly (strict mode) rather than silently corrupting the shared reference.
+const SUPERSEDED_RESULT: ValidationResult = Object.freeze({
+  isValid: true,
+  errors: Object.freeze({}) as Record<string, string>,
+});
 
 export class ValidationEngine {
   private debounceTimers: Map<string, PendingDebounce> = new Map();
@@ -57,8 +62,10 @@ export class ValidationEngine {
     } else {
       const debounceMs = config.validationDebounceMs || 0;
       if (debounceMs > 0) {
-        return this.debounce(`${context.fieldName}-${event.type}`, debounceMs, () =>
-          SchemaAdapter.validate(validator, value, context)
+        return this.debounce(
+          `${context.fieldName}-${event.type}`,
+          debounceMs,
+          () => SchemaAdapter.validate(validator, value, context)
         );
       }
       return SchemaAdapter.validate(validator, value, context);
@@ -201,8 +208,10 @@ export class ValidationEngine {
       (config[specificDebounceKey] as number) || config.asyncDebounceMs || 0;
 
     if (debounceMs > 0) {
-      return this.debounce(`${context.fieldName}-${event.type}`, debounceMs, () =>
-        SchemaAdapter.validateAsync(validator, context.value, context)
+      return this.debounce(
+        `${context.fieldName}-${event.type}`,
+        debounceMs,
+        () => SchemaAdapter.validateAsync(validator, context.value, context)
       );
     }
 

--- a/packages/el-form-core/src/validators/engine.ts
+++ b/packages/el-form-core/src/validators/engine.ts
@@ -10,8 +10,24 @@ import { SchemaAdapter } from "./adapters";
 // Framework-agnostic timer type that works in both browser and Node.js
 type Timer = number | any;
 
+// A pending debounced validation: its scheduled timer plus the resolver of the
+// Promise handed to the caller. Keeping the resolver reachable lets a superseding
+// call (or an explicit clear) settle the dangling promise instead of leaving any
+// awaiter hung forever.
+interface PendingDebounce {
+  timer: Timer;
+  resolve: (result: ValidationResult) => void;
+}
+
+// Resolution handed to superseded/cleared debounced calls. Safe because: (a) a
+// newer validation for the same key is already in flight and will produce the
+// authoritative result; (b) the hooks layer treats `isValid: true` as "nothing to
+// set", so a superseded result never writes stale errors. Its sole purpose is to
+// unblock the dangling promise.
+const SUPERSEDED_RESULT: ValidationResult = { isValid: true, errors: {} };
+
 export class ValidationEngine {
-  private debounceTimers: Map<string, Timer> = new Map();
+  private debounceTimers: Map<string, PendingDebounce> = new Map();
 
   /**
    * Validates a single field using the provided validator configuration
@@ -41,12 +57,8 @@ export class ValidationEngine {
     } else {
       const debounceMs = config.validationDebounceMs || 0;
       if (debounceMs > 0) {
-        return this.validateSyncWithDebounce(
-          validator,
-          value,
-          context,
-          event,
-          debounceMs
+        return this.debounce(`${context.fieldName}-${event.type}`, debounceMs, () =>
+          SchemaAdapter.validate(validator, value, context)
         );
       }
       return SchemaAdapter.validate(validator, value, context);
@@ -122,20 +134,58 @@ export class ValidationEngine {
    * Clears debounce timer for a specific field
    */
   clearDebounce(fieldName: string, eventType: string): void {
-    const key = `${fieldName}-${eventType}`;
-    const timer = this.debounceTimers.get(key);
-    if (timer) {
-      clearTimeout(timer);
-      this.debounceTimers.delete(key);
-    }
+    this.clearDebounceKey(`${fieldName}-${eventType}`);
   }
 
   /**
    * Clears all debounce timers
    */
   clearAllDebounce(): void {
-    this.debounceTimers.forEach((timer) => clearTimeout(timer));
+    // Resolve every pending awaiter with the safe sentinel before clearing, so an
+    // explicit clear-all never leaves a debounced caller hung.
+    this.debounceTimers.forEach(({ timer, resolve }) => {
+      clearTimeout(timer);
+      resolve(SUPERSEDED_RESULT);
+    });
     this.debounceTimers.clear();
+  }
+
+  /**
+   * Clears the pending debounced validation for a key. If one exists, its awaiter
+   * is resolved with the safe sentinel (a newer call/clear supersedes it) and its
+   * timer is cancelled, so superseded callers never hang.
+   */
+  private clearDebounceKey(key: string): void {
+    const pending = this.debounceTimers.get(key);
+    if (pending) {
+      clearTimeout(pending.timer);
+      pending.resolve(SUPERSEDED_RESULT);
+      this.debounceTimers.delete(key);
+    }
+  }
+
+  /**
+   * Schedules a debounced validation under `key`, superseding any pending call for
+   * the same key. The superseded call's promise is resolved with the safe sentinel
+   * (a newer validation is now in flight that will produce the real result) before
+   * its timer is cleared — preventing superseded awaiters from hanging forever.
+   * The single source of truth for all debounced validation paths.
+   */
+  private debounce(
+    key: string,
+    debounceMs: number,
+    run: () => ValidationResult | Promise<ValidationResult>
+  ): Promise<ValidationResult> {
+    this.clearDebounceKey(key);
+
+    return new Promise<ValidationResult>((resolve) => {
+      const timer = setTimeout(async () => {
+        this.debounceTimers.delete(key);
+        resolve(await run());
+      }, debounceMs);
+
+      this.debounceTimers.set(key, { timer, resolve });
+    });
   }
 
   private async validateAsync(
@@ -151,66 +201,12 @@ export class ValidationEngine {
       (config[specificDebounceKey] as number) || config.asyncDebounceMs || 0;
 
     if (debounceMs > 0) {
-      return this.validateWithDebounce(
-        validator,
-        context,
-        config,
-        event,
-        debounceMs
+      return this.debounce(`${context.fieldName}-${event.type}`, debounceMs, () =>
+        SchemaAdapter.validateAsync(validator, context.value, context)
       );
     }
 
     return SchemaAdapter.validateAsync(validator, context.value, context);
-  }
-
-  private async validateWithDebounce(
-    validator: any,
-    context: ValidatorContext,
-    _config: ValidatorConfig,
-    event: ValidatorEvent,
-    debounceMs: number
-  ): Promise<ValidationResult> {
-    const key = `${context.fieldName}-${event.type}`;
-
-    // Clear existing timer
-    this.clearDebounce(context.fieldName, event.type);
-
-    return new Promise((resolve) => {
-      const timer = setTimeout(async () => {
-        this.debounceTimers.delete(key);
-        const result = await SchemaAdapter.validateAsync(
-          validator,
-          context.value,
-          context
-        );
-        resolve(result);
-      }, debounceMs);
-
-      this.debounceTimers.set(key, timer);
-    });
-  }
-
-  private async validateSyncWithDebounce(
-    validator: any,
-    value: any,
-    context: ValidatorContext,
-    event: ValidatorEvent,
-    debounceMs: number
-  ): Promise<ValidationResult> {
-    const key = `${context.fieldName}-${event.type}`;
-
-    // Clear existing timer (supersede the previous pending validation)
-    this.clearDebounce(context.fieldName, event.type);
-
-    return new Promise((resolve) => {
-      const timer = setTimeout(() => {
-        this.debounceTimers.delete(key);
-        const result = SchemaAdapter.validate(validator, value, context);
-        resolve(result);
-      }, debounceMs);
-
-      this.debounceTimers.set(key, timer);
-    });
   }
 
   private async validateFormSync(
@@ -246,17 +242,9 @@ export class ValidationEngine {
     // function-validator branches above stay synchronous and un-debounced.
     const debounceMs = config.validationDebounceMs || 0;
     if (debounceMs > 0) {
-      const key = `form-${event.type}`;
-      this.clearDebounce("form", event.type);
-
-      return new Promise((resolve) => {
-        const timer = setTimeout(() => {
-          this.debounceTimers.delete(key);
-          resolve(SchemaAdapter.validate(validator, context.value));
-        }, debounceMs);
-
-        this.debounceTimers.set(key, timer);
-      });
+      return this.debounce(`form-${event.type}`, debounceMs, () =>
+        SchemaAdapter.validate(validator, context.value)
+      );
     }
 
     return SchemaAdapter.validate(validator, context.value);
@@ -271,21 +259,9 @@ export class ValidationEngine {
     const debounceMs = config.asyncDebounceMs || 0;
 
     if (debounceMs > 0) {
-      const key = `form-${event.type}`;
-      this.clearDebounce("form", event.type);
-
-      return new Promise((resolve) => {
-        const timer = setTimeout(async () => {
-          this.debounceTimers.delete(key);
-          const result = await this.executeFormAsyncValidation(
-            validator,
-            context
-          );
-          resolve(result);
-        }, debounceMs);
-
-        this.debounceTimers.set(key, timer);
-      });
+      return this.debounce(`form-${event.type}`, debounceMs, () =>
+        this.executeFormAsyncValidation(validator, context)
+      );
     }
 
     return this.executeFormAsyncValidation(validator, context);

--- a/packages/el-form-react-components/package.json
+++ b/packages/el-form-react-components/package.json
@@ -51,7 +51,8 @@
     "build:css": "pnpm exec tailwindcss -i ./src/styles.css -o ./dist/styles.css -c ./tailwind.config.ts --minify",
     "dev": "tsup --watch",
     "dev:css": "pnpm exec tailwindcss -i ./src/styles.css -o ./dist/styles.css -c ./tailwind.config.ts --watch",
-    "test": "pnpm -w -r build && vitest --environment jsdom --run"
+    "test": "pnpm -w -r build && vitest --environment jsdom --run",
+    "lint": "eslint \"src/**/*.{ts,tsx}\""
   },
   "dependencies": {
     "el-form-core": "workspace:^",

--- a/packages/el-form-react-components/src/Form/FormSwitch.tsx
+++ b/packages/el-form-react-components/src/Form/FormSwitch.tsx
@@ -316,10 +316,12 @@ const FormSwitchImpl = (props: any) => {
     }
 
     // Type guard for FormCase elements
-    function isFormCaseElement(el: unknown): el is React.ReactElement<{
+    const isFormCaseElement = (
+      el: unknown
+    ): el is React.ReactElement<{
       value: DiscriminatorPrimitive;
       children: (form: UseFormReturn<any>) => React.ReactNode;
-    }> {
+    }> => {
       if (!React.isValidElement(el)) return false;
       const props: any = el.props;
       return (
@@ -327,7 +329,7 @@ const FormSwitchImpl = (props: any) => {
         ["string", "number", "boolean"].includes(typeof props.value) &&
         typeof props.children === "function"
       );
-    }
+    };
 
     for (const child of childrenArray) {
       if (!isFormCaseElement(child)) continue;

--- a/packages/el-form-react-components/src/__tests__/AutoForm.nestedObjects.test.tsx
+++ b/packages/el-form-react-components/src/__tests__/AutoForm.nestedObjects.test.tsx
@@ -84,15 +84,11 @@ describe("AutoForm nested object support", () => {
       }),
     });
 
-    let submittedData: any = null;
-
     render(
       <AutoForm
         schema={schema}
         initialValues={{ address: { street: "", city: "" } }}
-        onSubmit={(data) => {
-          submittedData = data;
-        }}
+        onSubmit={() => {}}
       />
     );
 

--- a/packages/el-form-react-components/src/__tests__/AutoForm.validation.test.tsx
+++ b/packages/el-form-react-components/src/__tests__/AutoForm.validation.test.tsx
@@ -141,7 +141,6 @@ describe("AutoForm validation user feedback", () => {
 
     // Verify field types
     const usernameInput = screen.getByLabelText("Username") as HTMLInputElement;
-    const emailInput = screen.getByLabelText("Email") as HTMLInputElement;
     const ageInput = screen.getByLabelText("Age") as HTMLInputElement;
 
     expect(usernameInput.type).toBe("text");

--- a/packages/el-form-react-hooks/package.json
+++ b/packages/el-form-react-hooks/package.json
@@ -48,7 +48,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "test": "pnpm -w -r build && vitest --environment jsdom --run && tsd --files tsd.test-d.ts"
+    "test": "pnpm -w -r build && vitest --environment jsdom --run && tsd --files tsd.test-d.ts",
+    "lint": "eslint \"src/**/*.{ts,tsx}\""
   },
   "dependencies": {
     "el-form-core": "workspace:^"

--- a/packages/el-form-react-hooks/src/__tests__/asyncValidation.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/asyncValidation.test.tsx
@@ -26,7 +26,7 @@ function AsyncValidationForm({
     defaultValues: { username: "", email: "" },
     validateOn: "onChange",
     validators: {
-      onChangeAsync: async ({ value, values }) => {
+      onChangeAsync: async ({ value: _value, values }) => {
         onValidate?.(values);
         const result = schema.safeParse(values);
         if (!result.success) {

--- a/packages/el-form-react-hooks/src/__tests__/selector.runtime.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/selector.runtime.test.tsx
@@ -34,12 +34,12 @@ const InputComponent = React.memo(function InputComponent({
   field: string;
 }) {
   const { form } = useFormContext<any>();
-  const props = form.register(field);
+  const registered = form.register(field);
   return (
     <input
       aria-label={`${field}-input`}
-      value={(props as any).value}
-      onChange={(props as any).onChange}
+      value={(registered as any).value}
+      onChange={(registered as any).onChange}
     />
   );
 });

--- a/packages/el-form-react-hooks/src/types/path.ts
+++ b/packages/el-form-react-hooks/src/types/path.ts
@@ -9,7 +9,7 @@ type Primitive =
   | undefined
   | Date
   | bigint
-  | Function;
+  | ((...args: any[]) => any);
 
 // (reserved) Tuple detection helper – left for potential future refinement
 // type IsTuple<T> = T extends readonly [...infer _R] ? true : false;

--- a/packages/el-form-react-hooks/src/utils/equality.ts
+++ b/packages/el-form-react-hooks/src/utils/equality.ts
@@ -17,7 +17,7 @@ export function shallowEqual(obj1: any, obj2: any): boolean {
 
   if (keys1.length !== keys2.length) return false;
 
-  for (let key of keys1) {
+  for (const key of keys1) {
     if (!keys2.includes(key) || obj1[key] !== obj2[key]) {
       return false;
     }
@@ -51,7 +51,7 @@ export function deepEqual(obj1: any, obj2: any): boolean {
 
   if (keys1.length !== keys2.length) return false;
 
-  for (let key of keys1) {
+  for (const key of keys1) {
     if (!keys2.includes(key) || !deepEqual(obj1[key], obj2[key])) {
       return false;
     }

--- a/packages/el-form-react-hooks/src/utils/validation.ts
+++ b/packages/el-form-react-hooks/src/utils/validation.ts
@@ -175,7 +175,7 @@ export function createValidationManager<T extends Record<string, any>>(
       const configuredKeys = (cfg: ValidatorConfig | undefined) =>
         SYNC_KEYS.filter((k) => cfg && typeof (cfg as any)[k] !== "undefined");
 
-      let allErrors: Record<string, string> = {};
+      const allErrors: Record<string, string> = {};
       let isValid = true;
 
       // Validate all fields with field-level validators

--- a/packages/el-form-react/package.json
+++ b/packages/el-form-react/package.json
@@ -81,7 +81,8 @@
   ],
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch"
+    "dev": "tsup --watch",
+    "lint": "eslint \"src/**/*.{ts,tsx}\""
   },
   "dependencies": {
     "el-form-core": "workspace:^",


### PR DESCRIPTION
## Summary

Post-3.11.0 code-quality cleanups from the revival ROADMAP's "Known Issues".

### 🧹 Lint coverage (the big one for trustworthy CI)
- **Fixed the 13 ESLint errors** in shipped package source + tests (`prefer-const`, `no-unused-vars`, bare `Function` type, `no-prototype-builtins`, `no-inner-declarations`, `react/prop-types`) — all behavior-preserving type/syntax changes.
- **Added `lint` scripts to all 4 published packages** so `pnpm lint` (and CI's `eslint.yml`) now actually lints `packages/*/src` — previously it silently lint only the example app, so source lint errors never reached CI. Regressions can't slip past anymore.

### ⚙️ CI consistency
- Aligned **all workflows to Node 20** (`eslint.yml` + `release.yml` were on 18, mismatched with `ci.yml` / `deploy-docs.yml`).

### 🐞 Debounce hang fix (`el-form-core`, patch)
- Fixed a latent bug: when debounced validations fired in quick succession, only the last resolved — any code awaiting a **superseded** validation hung forever. Superseded/cleared debounced validations now resolve immediately with a valid result (a newer validation is already in flight).
- Unified the **four duplicated debounce code paths** into one helper. Public `clearDebounce` / `clearAllDebounce` signatures unchanged.

## Test Plan
- [x] `el-form-core` — 17 tests (incl. new no-hang regression test that times out against old code)
- [x] `el-form-react-hooks` — 61 + tsd
- [x] `el-form-react-components` — 25
- [x] `el-form-mcp` — 23
- [x] `pnpm -r run lint` — now lints package source, **0 errors**
- [x] `pnpm build:packages` — clean
- [x] Changeset: `el-form-core` patch (cascades to dependents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)