### PR TITLE
File upload coverage and validator dedupe

### DIFF
--- a/.changeset/brave-files-validate.md
+++ b/.changeset/brave-files-validate.md
@@ -1,0 +1,5 @@
+---
+"el-form-core": patch
+---
+
+Fix file validators so File array inputs no longer throw in non-browser runtimes where `FileList` is unavailable.

--- a/.changeset/brave-files-validate.md
+++ b/.changeset/brave-files-validate.md
@@ -1,5 +1,6 @@
 ---
 "el-form-core": patch
+"el-form-react-hooks": patch
 ---
 
-Fix file validators so File array inputs no longer throw in non-browser runtimes where `FileList` is unavailable.
+Fix file validators so File array inputs no longer throw in non-browser runtimes where `File` or `FileList` globals are unavailable, and ensure `clearFiles` clears file preview state.

--- a/docs/superpowers/HANDOFF-2026-06-06.md
+++ b/docs/superpowers/HANDOFF-2026-06-06.md
@@ -1,0 +1,112 @@
+# El Form — Session Handoff (2026-06-06)
+
+Snapshot of where things stand so any session (you or an agent) can pick up cleanly.
+
+## TL;DR
+
+The **el-form revival is shipped** (3.11.0 + 2.3.1 patch live on npm). A follow-on
+**cleanup + comprehensive-coverage effort** is in progress. Phase A (delete dead example
+apps) is **done and on main**. Phase B slice 1 (**file-upload coverage + dedupe**) has an
+**approved, plan-reviewed spec + implementation plan ready to execute** — paused right
+before implementation. Resume by executing that plan.
+
+## Current state (verified 2026-06-06)
+
+- **main @ `dc628e6`** (`chore: remove dead example apps…`), local in sync with origin.
+- **Published on npm:** `el-form-core@2.3.1`, `el-form-react-hooks@3.11.1`,
+  `el-form-react-components@4.5.1`, `el-form-react@4.1.6`, `el-form-mcp@0.1.0`.
+- **Active worktree:** `.worktrees/el-form-file-coverage` on branch `el-form-file-coverage`
+  @ `b74b7a6`, clean, **4 commits ahead of main** (all docs: spec + plan, no code yet).
+- **No release pending** (no changesets on main).
+- **Open PRs (pre-existing, not part of this effort):** #55 `docs-sandbox`, #10
+  `react-query-support` — both stale/parked, leave alone.
+- **Worktrees are gitignored** via `.git/info/exclude` (not the tracked `.gitignore`).
+
+## ⚠️ Do-not-touch: concurrent work on main
+
+- A **marketing landing page / dashboard** was merged to main earlier
+  (`feat(docs): add marketing landing page`) — lives in `docs/src/pages/index.tsx` +
+  `docs/src/components/landing/`. This is the user's own work; **do not modify or sweep it
+  into commits.** When staging, stage your files explicitly (don't `git add -A`).
+- A **prior scheduled agent** (session 5e0fd180) has historically advanced main on its own
+  (docs, el-form-mcp). Always `git fetch` + re-check main before acting; rebase if drifted.
+
+## RESUME HERE → Phase B slice 1: file-upload coverage + dedupe
+
+Everything is designed and ready; only implementation remains.
+
+- **Spec:** `docs/superpowers/specs/2026-06-05-file-upload-coverage-design.md` (approved by
+  user + spec-review).
+- **Plan:** `docs/superpowers/plans/2026-06-05-file-upload-coverage.md` (plan-reviewed;
+  one factual error caught & fixed — `getFileExtension("README")` returns `""`, not the
+  name).
+- **How to resume:** in the `el-form-file-coverage` worktree, run deps (`pnpm install`),
+  then execute the plan via **superpowers:subagent-driven-development** (the chosen mode —
+  fresh subagent per task + two-stage review on substantive tasks, per the user's standing
+  "second opinions" preference). The plan's 5 tasks:
+  1. Test core `fileValidators` (pure)
+  2. Test hooks `fileUtils` DOM helpers (jsdom)
+  3. Test `useForm` addFile/removeFile/clearFiles (jsdom runtime)
+  4. Dedupe: `fileUtils` delegates validation to `el-form-core` (internal-only, no public change)
+  5. Final gate + changeset ONLY if a public bug was surfaced
+- **Workflow for this branch:** branch → PR (user chose PR + changeset flow for code changes).
+  The dedupe alone needs **no changeset** (internal). A changeset is needed only if a real
+  bug is found and fixed that changes public behavior.
+
+## The bigger plan: cleanup + comprehensive coverage (3 phases)
+
+Spec: `docs/superpowers/specs/2026-06-05-cleanup-and-coverage-design.md`. Memory:
+`cleanup-and-coverage-effort.md`.
+
+- **Phase A — DONE** (main `dc628e6`): deleted `examples/showcase` (stray untracked app) +
+  `examples/tests` (empty) + 3 stale `.gitignore` entries. Kept + verified `examples/react`
+  (the Playwright sweep target).
+- **Phase B — IN PROGRESS.** Fill unit/runtime test gaps. Slice 1 = file upload (ready to
+  execute, above). Remaining slices (not yet spec'd): **form history** (`formHistory.ts`),
+  **core utils + adapters** (`validation.ts`/`utils.ts`/`adapters.ts`), **umbrella
+  `el-form-react`** (0 tests — public-API smoke), **state utils** (`formState`/
+  `errorManagement`/`dirtyState`). Principle: "tests for everything we build."
+- **Phase C — NOT STARTED.** Extend the Playwright sweep (`.claude/skills/sweep-form-app`
+  + `examples/react` demos) to exercise every feature in-browser (file upload, history
+  undo/redo, focus-on-error, a11y attrs, debounce, useFieldArray reorder) beyond the
+  current render/add-increment asserts.
+
+## Known issues still open (from ROADMAP.md "Known issues")
+
+- **FormProvider getter lag** — context getter exposes form state one render behind for
+  direct `useFormContext().form.formState` render-time reads. Standalone field components
+  were worked around (they use `useField`); the underlying getter is a latent deeper fix.
+  Low impact. (See `cleanup-and-coverage-effort.md` / ROADMAP.)
+- **`pnpm test` arg-forwarding** — hooks `test` script forwards trailing args to `tsd`, so
+  `pnpm test -- --run` exits non-zero though assertions pass. Cosmetic; CI unaffected.
+- **`BaseFieldProps.name` is `keyof T`** — could be `Path<T>` for nested-path safety
+  (would remove some `as any` in the field components). Polish.
+
+## Other open threads (not code)
+
+- **Relaunch posts** in `launch/` (Show HN / r/reactjs / dev.to) — drafted during the
+  agent-discoverability work; now have a real shipped 3.11.0/2.3.1 to point at. User's call
+  to post (outward-facing).
+- **el-form-mcp** stays on its own release track (@0.1.0).
+
+## How to verify / common commands
+
+- Build: `pnpm build:packages`
+- Tests: core `pnpm --filter el-form-core exec vitest --run`; hooks
+  `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run`; components
+  `pnpm --filter el-form-react-components exec vitest --environment jsdom --run`; tsd
+  `pnpm --filter el-form-react-hooks exec tsd --files tsd.test-d.ts`
+- Lint (now covers package source): `pnpm -r run lint`
+- Playwright sweep: the `sweep-form-app` skill — boots `examples/react`; **port 3001
+  collides with an unrelated "Cerebro Mobile" server**, so run el-form on another port
+  (e.g. 3017) and Playwright installs in an isolated dir (`/tmp/elform-pw`); root
+  `npm install` fails on workspace `link:` deps.
+- Release model: merging a feature PR does NOT publish — it (re)stages a "Version Packages"
+  PR; merging THAT publishes. Never click "Update branch" on the `changeset-release/main`
+  PR (it's bot-force-pushed).
+
+## Relevant memory files
+
+`el-form-revival-effort`, `cleanup-and-coverage-effort`, `subagent-review-preference`,
+`debounce-superseded-promise-hang` (fixed), `test-suite-and-sweep-pr`,
+`agent-discoverability-strategy`, `download-spike-investigation`.

--- a/docs/superpowers/plans/2026-06-05-file-upload-coverage.md
+++ b/docs/superpowers/plans/2026-06-05-file-upload-coverage.md
@@ -1,0 +1,507 @@
+# File-Upload Coverage + Dedupe Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax. Get a second-opinion subagent review (spec-compliance then code-quality) after the substantive tasks, per the user's standing preference.
+
+**Goal:** Comprehensively test the file-upload feature (core validators, hooks file utils, and `useForm`'s file methods) and dedupe the near-duplicate validation logic so `el-form-core` is the single source of truth.
+
+**Architecture:** Characterization-first TDD. Add unit tests for `el-form-core/fileValidators` (pure) and `el-form-react-hooks/fileUtils` (jsdom), plus a runtime test for `useForm`'s `addFile`/`removeFile`/`clearFiles`. Then dedupe: `fileUtils` re-exports core's `validateFile`/`validateFiles`/`FileValidationOptions` (which `el-form-react-hooks` already depends on) and keeps only the DOM-specific helpers (`getFileInfo`/`formatFileSize`/`getFileExtension`/`getFilePreview`). The deduped functions are internal-only (not in the hooks public index), so the `null`→`undefined` return change is not a breaking change.
+
+**Tech Stack:** TypeScript 5, Vitest (node for core, jsdom for hooks) + @testing-library/react, tsup, tsd.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-file-upload-coverage-design.md`
+**Working location:** `.worktrees/el-form-file-coverage` (branch `el-form-file-coverage`, off `main` @ `dc628e6`). Paths relative to repo root.
+
+---
+
+## Key facts (verified — don't re-derive)
+
+- **Core file validators are public:** `el-form-core/src/validators/fileValidators.ts` is re-exported via `validators/index.ts:9` (`export * from "./fileValidators"`) → core index. Exports: `validateFile`, `validateFiles`, `createFileValidator`, `fileValidator`, `fileValidators` (presets), `FileValidationOptions`. Pure functions; `validateFile`/`validateFiles` return `undefined` on pass.
+- **Hooks fileUtils are internal:** `el-form-react-hooks/src/utils/fileUtils.ts` is `export *`'d from `utils/index.ts:73`, but the hooks public index (`src/index.ts`) only does `export { shallowEqual } from "./utils"` (NAMED). So `fileUtils.validateFile`/`validateFiles`/`formatFileSize`/`getFileExtension` are NOT public. `getFileInfo`/`getFilePreview` are public only as `useForm` return methods; `FileInfo`/`FileValidationOptions` appear in the public d.ts as types.
+- `types.ts` imports `FileValidationOptions` (line 2) and `FileInfo` (inline `import(...)` line 160) from `./utils/fileUtils` — the dedupe must keep both importable from there.
+- Both `FileValidationOptions` interfaces are byte-identical (same md5).
+- `FileList` is `undefined` in core's node env and not constructible in jsdom — tests use `File[]`.
+
+## Commands
+
+- Core tests (node): `pnpm --filter el-form-core exec vitest --run src/validators/__tests__/fileValidators.test.ts`
+- Hooks unit (jsdom): `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/utils/__tests__/fileUtils.test.ts`
+- Hooks runtime (jsdom): `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__/fileMethods.runtime.test.tsx`
+- Full core / hooks suites: `pnpm --filter el-form-core exec vitest --run` ; `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run`
+- Build + dts: `pnpm build:packages`
+- tsd: `pnpm --filter el-form-react-hooks exec tsd --files tsd.test-d.ts`
+
+Construct files: `new File(["content"], "name.png", { type: "image/png" })` (jsdom & node both support `File`). For size, `new File([new ArrayBuffer(n)], ...)` gives `.size === n`.
+
+---
+
+## File structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `packages/el-form-core/src/validators/__tests__/fileValidators.test.ts` | Test core validators + presets | Create |
+| `packages/el-form-react-hooks/src/utils/__tests__/fileUtils.test.ts` | Test DOM file utils | Create |
+| `packages/el-form-react-hooks/src/__tests__/fileMethods.runtime.test.tsx` | Test useForm addFile/removeFile/clearFiles | Create |
+| `packages/el-form-react-hooks/src/utils/fileUtils.ts` | Dedupe: delegate validation to core, keep DOM helpers | Modify |
+| `packages/el-form-core/src/validators/fileValidators.ts` | (only if a bug fix is needed) | Maybe-modify |
+
+---
+
+## Task 1: Test core `fileValidators` (pure)
+
+**Files:** Create `packages/el-form-core/src/validators/__tests__/fileValidators.test.ts`
+
+- [ ] **Step 1: Write the tests** (characterization — pins current behavior incl. quirks)
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  validateFile,
+  validateFiles,
+  createFileValidator,
+  fileValidator,
+  fileValidators,
+} from "../fileValidators";
+
+const file = (name: string, type: string, size = 10) =>
+  new File([new ArrayBuffer(size)], name, { type });
+
+describe("validateFile", () => {
+  it("passes a valid file (returns undefined)", () => {
+    expect(validateFile(file("a.png", "image/png"), { maxSize: 100 })).toBeUndefined();
+  });
+  it("rejects oversize", () => {
+    expect(validateFile(file("a.png", "image/png", 200), { maxSize: 100 })).toMatch(/less than/);
+  });
+  it("rejects undersize (minSize)", () => {
+    expect(validateFile(file("a.png", "image/png", 5), { minSize: 100 })).toMatch(/at least/);
+  });
+  it("rejects disallowed type", () => {
+    expect(validateFile(file("a.gif", "image/gif"), { acceptedTypes: ["image/png"] })).toMatch(/not allowed/);
+  });
+  it("rejects disallowed extension (case-insensitive)", () => {
+    expect(validateFile(file("a.PNG", "image/png"), { acceptedExtensions: ["jpg"] })).toMatch(/extension/);
+    expect(validateFile(file("a.PNG", "image/png"), { acceptedExtensions: ["png"] })).toBeUndefined();
+  });
+  // PINNED QUIRK: maxSize:0 / minSize:0 are falsy → the limit is skipped (treated as "unset").
+  // This is intentional-by-omission; do NOT "fix" without a changeset (public core behavior).
+  it("treats maxSize: 0 as no limit (falsy-skip — pinned behavior)", () => {
+    expect(validateFile(file("a.png", "image/png", 999), { maxSize: 0 })).toBeUndefined();
+  });
+  it("treats minSize: 0 as no limit (falsy-skip — pinned behavior)", () => {
+    expect(validateFile(file("a.png", "image/png", 0), { minSize: 0 })).toBeUndefined();
+  });
+});
+
+describe("validateFiles", () => {
+  it("rejects too many files (maxFiles)", () => {
+    const fs = [file("a.png", "image/png"), file("b.png", "image/png")];
+    expect(validateFiles(fs, { maxFiles: 1 })).toMatch(/Maximum 1/);
+  });
+  it("rejects too few files (minFiles)", () => {
+    expect(validateFiles([file("a.png", "image/png")], { minFiles: 2 })).toMatch(/Minimum 2/);
+  });
+  it("delegates to validateFile and returns the first failing message", () => {
+    const fs = [file("a.png", "image/png"), file("big.png", "image/png", 999)];
+    expect(validateFiles(fs, { maxSize: 100 })).toMatch(/less than/);
+  });
+  it("accepts a File[] within limits", () => {
+    expect(validateFiles([file("a.png", "image/png")], { maxFiles: 2 })).toBeUndefined();
+  });
+  // PINNED: maxFiles:0 / minFiles:0 falsy-skip (same pattern as maxSize). Symmetry pin.
+  it("treats maxFiles: 0 as no limit (falsy-skip — pinned)", () => {
+    const fs = [file("a.png", "image/png"), file("b.png", "image/png")];
+    expect(validateFiles(fs, { maxFiles: 0 })).toBeUndefined();
+  });
+});
+
+describe("createFileValidator / fileValidator", () => {
+  it("returns undefined for falsy value", () => {
+    expect(createFileValidator({ maxSize: 1 })({ value: null } as any)).toBeUndefined();
+  });
+  it("validates a single File", () => {
+    expect(createFileValidator({ maxSize: 5 })({ value: file("a.png", "image/png", 99) } as any)).toMatch(/less than/);
+  });
+  it("validates a File[] (array branch)", () => {
+    const v = createFileValidator({ maxFiles: 1 });
+    expect(v({ value: [file("a.png", "image/png"), file("b.png", "image/png")] } as any)).toMatch(/Maximum 1/);
+  });
+  it("returns undefined for a non-file value", () => {
+    expect(createFileValidator({ maxSize: 1 })({ value: "hello" } as any)).toBeUndefined();
+  });
+  it("fileValidator is an alias for createFileValidator", () => {
+    expect(typeof fileValidator({ maxSize: 1 })).toBe("function");
+  });
+  // NOTE: the `value instanceof FileList` branch is browser-only and not unit-testable
+  // (FileList is undefined in node and not constructible). The File[] branch above covers
+  // the array path; the FileList instanceof line is exercised only in a real browser.
+});
+
+describe("fileValidators presets", () => {
+  it("image: accepts png within 5MB, rejects wrong type", () => {
+    expect(fileValidators.image({ value: file("a.png", "image/png") } as any)).toBeUndefined();
+    expect(fileValidators.image({ value: file("a.txt", "text/plain") } as any)).toMatch(/not allowed/);
+  });
+  it("avatar: maxFiles 1 — rejects 2 files", () => {
+    const fs = [file("a.png", "image/png"), file("b.png", "image/png")];
+    expect(fileValidators.avatar({ value: fs } as any)).toMatch(/Maximum 1/);
+  });
+  it("document: accepts pdf, rejects image", () => {
+    expect(fileValidators.document({ value: file("a.pdf", "application/pdf") } as any)).toBeUndefined();
+    expect(fileValidators.document({ value: file("a.png", "image/png") } as any)).toMatch(/not allowed/);
+  });
+  it("gallery / video / audio accept a valid sample", () => {
+    expect(fileValidators.gallery({ value: [file("a.png", "image/png")] } as any)).toBeUndefined();
+    expect(fileValidators.video({ value: file("a.mp4", "video/mp4") } as any)).toBeUndefined();
+    expect(fileValidators.audio({ value: file("a.mp3", "audio/mpeg") } as any)).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect PASS** (this is characterization of existing, correct behavior)
+
+Run: `pnpm --filter el-form-core exec vitest --run src/validators/__tests__/fileValidators.test.ts`
+Expected: all pass. **If any test FAILS, that's a real bug** — STOP, report it (we fix inline per the spec, with a changeset if it changes public behavior). The `maxSize:0`/`maxFiles:0` tests assert the *current* falsy-skip; if you believe that's wrong, flag it rather than changing the assertion.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/el-form-core/src/validators/__tests__/fileValidators.test.ts
+git commit -m "test(core): comprehensive fileValidators coverage (validateFile/Files, presets, edge cases)"
+```
+
+---
+
+## Task 2: Test hooks `fileUtils` DOM helpers (jsdom)
+
+**Files:** Create `packages/el-form-react-hooks/src/utils/__tests__/fileUtils.test.ts`
+
+- [ ] **Step 1: Write the tests**
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import {
+  getFileInfo,
+  formatFileSize,
+  getFileExtension,
+  getFilePreview,
+} from "../fileUtils";
+
+const file = (name: string, type: string, size = 10) =>
+  new File([new ArrayBuffer(size)], name, { type });
+
+describe("formatFileSize", () => {
+  it("0 bytes", () => expect(formatFileSize(0)).toBe("0 Bytes"));
+  it("bytes", () => expect(formatFileSize(500)).toBe("500 Bytes"));
+  it("KB", () => expect(formatFileSize(1024)).toBe("1 KB"));
+  it("MB", () => expect(formatFileSize(1024 * 1024)).toBe("1 MB"));
+  it("rounds to 2 decimals", () => expect(formatFileSize(1536)).toBe("1.5 KB"));
+});
+
+describe("getFileExtension (PINNED quirks)", () => {
+  it("normal extension", () => expect(getFileExtension("a.png")).toBe("png"));
+  it("multi-dot returns last segment", () => expect(getFileExtension("a.b.tar.gz")).toBe("gz"));
+  it("dotfile returns the name after the dot", () => expect(getFileExtension(".gitignore")).toBe("gitignore"));
+  // QUIRK: no-dot filename returns the WHOLE string (the `>>> 0` trick), not "".
+  // Pinned deliberately — changing it shifts getFileInfo().extension (public). Do not "fix".
+  it("no-extension returns the whole name (pinned quirk)", () => expect(getFileExtension("README")).toBe("README"));
+});
+
+describe("getFileInfo", () => {
+  it("populates all fields; isImage true for image/*", () => {
+    const info = getFileInfo(file("photo.png", "image/png", 2048));
+    expect(info.name).toBe("photo.png");
+    expect(info.size).toBe(2048);
+    expect(info.type).toBe("image/png");
+    expect(info.formattedSize).toBe("2 KB");
+    expect(info.isImage).toBe(true);
+    expect(info.extension).toBe("png");
+    expect(typeof info.lastModified).toBe("number");
+  });
+  it("isImage false for non-image", () => {
+    expect(getFileInfo(file("a.txt", "text/plain")).isImage).toBe(false);
+  });
+});
+
+describe("getFilePreview", () => {
+  it("returns null for non-image", async () => {
+    expect(await getFilePreview(file("a.txt", "text/plain"))).toBeNull();
+  });
+  it("returns a data URL for an image (mocked FileReader)", async () => {
+    const original = globalThis.FileReader;
+    class MockReader {
+      onload: any = null;
+      onerror: any = null;
+      result = "data:image/png;base64,AAAA";
+      readAsDataURL() {
+        // fire onload on next tick with `this` as target
+        setTimeout(() => this.onload?.({ target: this }), 0);
+      }
+    }
+    (globalThis as any).FileReader = MockReader;
+    const preview = await getFilePreview(file("a.png", "image/png"));
+    expect(preview).toBe("data:image/png;base64,AAAA");
+    (globalThis as any).FileReader = original;
+  });
+  it("returns null on reader error (mocked)", async () => {
+    const original = globalThis.FileReader;
+    class MockReader {
+      onload: any = null;
+      onerror: any = null;
+      readAsDataURL() {
+        setTimeout(() => this.onerror?.(new Error("boom")), 0);
+      }
+    }
+    (globalThis as any).FileReader = MockReader;
+    const preview = await getFilePreview(file("a.png", "image/png"));
+    expect(preview).toBeNull();
+    (globalThis as any).FileReader = original;
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect PASS**
+
+Run: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/utils/__tests__/fileUtils.test.ts`
+Expected: all pass. If a `formatFileSize` boundary or extension quirk assertion fails, the expected value in the test may be wrong (compute it from the source) — fix the test to match real behavior, not the source. If a genuine bug surfaces, STOP and report.
+
+> Implementer note: `getFilePreview`'s real impl reads `e.target?.result`. The MockReader passes `{ target: this }` and `this.result` is the data URL — make sure your mock matches how the source reads the result (`reader.onload = (e) => resolve(e.target?.result)`). Adjust the mock if the source shape differs after you read it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/el-form-react-hooks/src/utils/__tests__/fileUtils.test.ts
+git commit -m "test(hooks): fileUtils DOM helpers (getFileInfo/formatFileSize/getFileExtension/getFilePreview)"
+```
+
+---
+
+## Task 3: Test `useForm` file methods (jsdom runtime)
+
+**Files:** Create `packages/el-form-react-hooks/src/__tests__/fileMethods.runtime.test.tsx`
+
+- [ ] **Step 1: Read the source first**
+
+Read `packages/el-form-react-hooks/src/useForm.ts` lines ~398-458 (`addFile`/`removeFile`/`clearFiles`) so your assertions match the real behavior:
+- `addFile(name, file)`: if current value is an array → append; else → set the file.
+- `removeFile(name, index)`: splice at index (array) + splice the filePreview entry.
+- `removeFile(name)` (no index): set field to `null`, delete filePreview entry.
+- `clearFiles(name)`: set field to `null`.
+
+- [ ] **Step 2: Write the test**
+
+```tsx
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+const mk = (name: string) => new File(["x"], name, { type: "image/png" });
+
+function Demo() {
+  const { watch, addFile, removeFile, clearFiles } = useForm<{ docs: File[] }>({
+    defaultValues: { docs: [] },
+  });
+  const docs = (watch("docs") as File[]) || [];
+  return (
+    <div>
+      <span data-testid="count">{docs.length}</span>
+      <span data-testid="names">{docs.map((f) => f.name).join(",")}</span>
+      <button onClick={() => addFile("docs", mk("a.png"))}>add-a</button>
+      <button onClick={() => addFile("docs", mk("b.png"))}>add-b</button>
+      <button onClick={() => removeFile("docs", 0)}>remove-0</button>
+      <button onClick={() => removeFile("docs")}>remove-all</button>
+      <button onClick={() => clearFiles("docs")}>clear</button>
+    </div>
+  );
+}
+
+describe("useForm file methods", () => {
+  it("addFile appends to an array field", () => {
+    render(<Demo />);
+    fireEvent.click(screen.getByText("add-a"));
+    fireEvent.click(screen.getByText("add-b"));
+    expect(screen.getByTestId("count").textContent).toBe("2");
+    expect(screen.getByTestId("names").textContent).toBe("a.png,b.png");
+  });
+  it("removeFile(index) removes a specific file", () => {
+    render(<Demo />);
+    fireEvent.click(screen.getByText("add-a"));
+    fireEvent.click(screen.getByText("add-b"));
+    fireEvent.click(screen.getByText("remove-0"));
+    expect(screen.getByTestId("names").textContent).toBe("b.png");
+  });
+  it("removeFile() with no index clears the field to null", () => {
+    render(<Demo />);
+    fireEvent.click(screen.getByText("add-a"));
+    fireEvent.click(screen.getByText("remove-all"));
+    // field is null → watch returns null → our `|| []` makes count 0
+    expect(screen.getByTestId("count").textContent).toBe("0");
+  });
+  it("clearFiles sets the field to null", () => {
+    render(<Demo />);
+    fireEvent.click(screen.getByText("add-a"));
+    fireEvent.click(screen.getByText("clear"));
+    expect(screen.getByTestId("count").textContent).toBe("0");
+  });
+});
+```
+
+- [ ] **Step 3: Run — expect PASS** (adjust assertions to the real behavior you read in Step 1; if a method misbehaves vs. its evident intent, STOP and report a bug)
+
+Run: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__/fileMethods.runtime.test.tsx`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/el-form-react-hooks/src/__tests__/fileMethods.runtime.test.tsx
+git commit -m "test(hooks): useForm addFile/removeFile/clearFiles runtime coverage"
+```
+
+---
+
+## Task 4: Dedupe — `fileUtils` delegates validation to core
+
+**Files:** Modify `packages/el-form-react-hooks/src/utils/fileUtils.ts`
+
+Now that both modules are characterized, remove the duplication. `fileUtils`'s `validateFile`/`validateFiles`/`FileValidationOptions` are internal-only (verified), so switching them to core's `undefined`-returning versions is safe.
+
+- [ ] **Step 1: Rewrite `fileUtils.ts`** to keep only DOM helpers + re-export core's validators/type:
+
+```ts
+// Re-export the validation surface from el-form-core (single source of truth).
+// These were previously duplicated here (returning `null`); core returns `undefined`.
+// They are internal to this package (not in the public hooks index), so the change is safe.
+export {
+  validateFile,
+  validateFiles,
+  type FileValidationOptions,
+} from "el-form-core";
+
+export interface FileInfo {
+  name: string;
+  size: number;
+  type: string;
+  lastModified: number;
+  formattedSize: string;
+  isImage: boolean;
+  extension: string;
+}
+
+export function getFileInfo(file: File): FileInfo {
+  return {
+    name: file.name,
+    size: file.size,
+    type: file.type,
+    lastModified: file.lastModified,
+    formattedSize: formatFileSize(file.size),
+    isImage: file.type.startsWith("image/"),
+    extension: getFileExtension(file.name),
+  };
+}
+
+export function formatFileSize(bytes: number): string {
+  if (bytes === 0) return "0 Bytes";
+  const k = 1024;
+  const sizes = ["Bytes", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
+}
+
+export function getFileExtension(fileName: string): string {
+  return fileName.slice(((fileName.lastIndexOf(".") - 1) >>> 0) + 2);
+}
+
+export async function getFilePreview(file: File): Promise<string | null> {
+  if (!file.type.startsWith("image/")) return null;
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onload = (e) => resolve(e.target?.result as string);
+    reader.onerror = () => resolve(null);
+    reader.readAsDataURL(file);
+  });
+}
+```
+
+> Verify `el-form-core` exports `validateFile`, `validateFiles`, and `FileValidationOptions` (it does, via `validators/index.ts`). Confirm `types.ts` still resolves `FileValidationOptions` and `FileInfo` from `./utils/fileUtils` (both are still exported above — `FileValidationOptions` is now a re-export, `FileInfo` stays local).
+
+- [ ] **Step 2: Re-run BOTH file test files** — they must still pass (the fileUtils test imports only the DOM helpers; if it imported the local validateFile, update those to expect `undefined` now):
+
+```
+pnpm --filter el-form-core build   # core must be built so the hooks import resolves
+pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/utils/__tests__/fileUtils.test.ts
+pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run src/__tests__/fileMethods.runtime.test.tsx
+```
+
+- [ ] **Step 3: Full hooks suite + build + tsd (no regressions / no public-surface change)**
+
+```
+pnpm build:packages
+pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run
+pnpm --filter el-form-react-hooks exec tsd --files tsd.test-d.ts
+```
+Then assert the public surface is unchanged:
+```
+grep -nE "validateFile|validateFiles|FileInfo|FileValidationOptions|getFileInfo|getFilePreview" packages/el-form-react-hooks/dist/index.d.ts
+```
+Expected: `FileInfo`, `FileValidationOptions`, `getFileInfo`, `getFilePreview` present (as before); `validateFile`/`validateFiles` NOT newly added to the public d.ts (they weren't public before and must not become public).
+
+- [ ] **Step 4: Lint (the new lint coverage must stay clean)**
+
+```
+npx eslint "packages/el-form-react-hooks/src/utils/fileUtils.ts"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/el-form-react-hooks/src/utils/fileUtils.ts
+git commit -m "refactor(hooks): fileUtils delegates validation to el-form-core (single source of truth; internal-only, no public change)"
+```
+
+---
+
+## Task 5: Final gate (+ changeset only if a public bug was fixed)
+
+- [ ] **Step 1: Full workspace gate**
+
+```
+pnpm --filter el-form-core exec vitest --run
+pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run
+pnpm --filter el-form-react-hooks exec tsd --files tsd.test-d.ts
+pnpm --filter el-form-react-components exec vitest --environment jsdom --run   # file demos use components
+pnpm build:packages
+pnpm -r run lint
+```
+All green.
+
+- [ ] **Step 2: Changeset — ONLY if Tasks 1-3 surfaced a real bug that was fixed and the fix changes public behavior** (core `fileValidators`/`FileValidationOptions` or `getFileInfo`/`getFilePreview`). The dedupe alone is internal → **no changeset**. If no public behavior changed, skip this step and note "no changeset (test-only + internal dedupe)" in the report.
+
+If a changeset IS needed:
+```bash
+cat > .changeset/file-validation-fix.md <<'EOF'
+---
+"el-form-core": patch
+---
+
+<describe the file-validation behavior fix>
+EOF
+```
+
+- [ ] **Step 3: Verify scope**
+
+```
+git diff --stat dc628e6..HEAD -- packages
+```
+Expected: the 3 new test files + `fileUtils.ts` (+ `fileValidators.ts` only if a bug was fixed). No unrelated churn.
+
+---
+
+## Done criteria
+
+- Core `fileValidators` and hooks `fileUtils` comprehensively tested; `useForm` file methods tested.
+- `fileUtils` no longer duplicates validation logic — delegates to `el-form-core`.
+- Public hooks d.ts surface unchanged (no `validateFile`/`validateFiles` leak; `FileInfo`/`FileValidationOptions`/`getFileInfo`/`getFilePreview` intact).
+- All suites + build + lint + tsd green.
+- Pinned quirks (maxSize/maxFiles/minSize/minFiles falsy-skip, `getFileExtension` no-dot) documented with comments in the tests.
+- No changeset unless a public behavior bug was fixed.

--- a/docs/superpowers/plans/2026-06-05-file-upload-coverage.md
+++ b/docs/superpowers/plans/2026-06-05-file-upload-coverage.md
@@ -200,10 +200,13 @@ describe("formatFileSize", () => {
 describe("getFileExtension (PINNED quirks)", () => {
   it("normal extension", () => expect(getFileExtension("a.png")).toBe("png"));
   it("multi-dot returns last segment", () => expect(getFileExtension("a.b.tar.gz")).toBe("gz"));
-  it("dotfile returns the name after the dot", () => expect(getFileExtension(".gitignore")).toBe("gitignore"));
-  // QUIRK: no-dot filename returns the WHOLE string (the `>>> 0` trick), not "".
-  // Pinned deliberately — changing it shifts getFileInfo().extension (public). Do not "fix".
-  it("no-extension returns the whole name (pinned quirk)", () => expect(getFileExtension("README")).toBe("README"));
+  // VERIFIED behavior of the `slice(((lastIndexOf(".")-1)>>>0)+2)` trick:
+  // for a no-dot name ("README") and a dotfile (".gitignore"), lastIndexOf(".") is -1 / 0,
+  // so the unsigned-shift produces a huge slice index → "". The trick INTENTIONALLY returns
+  // "" for no-extension and dotfile names. Pinned; changing it shifts getFileInfo().extension
+  // (public). Do NOT "fix".
+  it("dotfile returns empty string (.gitignore -> '')", () => expect(getFileExtension(".gitignore")).toBe(""));
+  it("no-extension returns empty string (README -> '')", () => expect(getFileExtension("README")).toBe(""));
 });
 
 describe("getFileInfo", () => {
@@ -425,7 +428,25 @@ export async function getFilePreview(file: File): Promise<string | null> {
 
 > Verify `el-form-core` exports `validateFile`, `validateFiles`, and `FileValidationOptions` (it does, via `validators/index.ts`). Confirm `types.ts` still resolves `FileValidationOptions` and `FileInfo` from `./utils/fileUtils` (both are still exported above — `FileValidationOptions` is now a re-export, `FileInfo` stays local).
 
-- [ ] **Step 2: Re-run BOTH file test files** — they must still pass (the fileUtils test imports only the DOM helpers; if it imported the local validateFile, update those to expect `undefined` now):
+- [ ] **Step 1b: Add a delegation assertion to the fileUtils test** (documents the dedupe)
+
+Append to `src/utils/__tests__/fileUtils.test.ts` — confirms the re-exported `validateFile`
+now comes from core and returns `undefined` on pass (not the old `null`):
+
+```ts
+import { validateFile as fileUtilsValidateFile } from "../fileUtils";
+describe("validateFile (delegated to el-form-core after dedupe)", () => {
+  const f = (name: string, type: string, size = 10) => new File([new ArrayBuffer(size)], name, { type });
+  it("passes -> undefined (core's sentinel, not null)", () => {
+    expect(fileUtilsValidateFile(f("a.png", "image/png", 5), { maxSize: 100 })).toBeUndefined();
+  });
+  it("fails -> message", () => {
+    expect(fileUtilsValidateFile(f("a.png", "image/png", 200), { maxSize: 100 })).toMatch(/less than/);
+  });
+});
+```
+
+- [ ] **Step 2: Re-run BOTH file test files** — they must still pass:
 
 ```
 pnpm --filter el-form-core build   # core must be built so the hooks import resolves
@@ -442,9 +463,14 @@ pnpm --filter el-form-react-hooks exec tsd --files tsd.test-d.ts
 ```
 Then assert the public surface is unchanged:
 ```
-grep -nE "validateFile|validateFiles|FileInfo|FileValidationOptions|getFileInfo|getFilePreview" packages/el-form-react-hooks/dist/index.d.ts
+grep -nE "export \* from .el-form-core|FileInfo|FileValidationOptions|getFileInfo|getFilePreview" packages/el-form-react-hooks/dist/index.d.ts
 ```
-Expected: `FileInfo`, `FileValidationOptions`, `getFileInfo`, `getFilePreview` present (as before); `validateFile`/`validateFiles` NOT newly added to the public d.ts (they weren't public before and must not become public).
+Expected: the hooks d.ts still has `export * from 'el-form-core'` (intact) and `FileInfo` /
+`FileValidationOptions` / `getFileInfo` / `getFilePreview` are still present. NOTE: core's
+`validateFile`/`validateFiles` are *already* transitively public via that `export *` — the
+dedupe doesn't change what's exposed, it just stops `fileUtils` from declaring its own
+duplicate copies. So there is no public-surface change; this check confirms nothing was
+accidentally removed.
 
 - [ ] **Step 4: Lint (the new lint coverage must stay clean)**
 

--- a/docs/superpowers/specs/2026-06-05-file-upload-coverage-design.md
+++ b/docs/superpowers/specs/2026-06-05-file-upload-coverage-design.md
@@ -140,11 +140,12 @@ So:
    + a code comment rather than changing it (`0` as a meaningful limit is an odd use case).
    Pin all four (maxSize/minSize/maxFiles/minFiles) for symmetry. If we DO change it, that's
    a public `el-form-core` behavior change → changeset.
-2. **`getFileExtension` quirks** — `("README").slice(((lastIndexOf(".")-1)>>>0)+2)` returns
-   the WHOLE string `"README"` (not `""`) for a no-dot filename; dotfiles (`.gitignore`)
-   return `"gitignore"`. These are unintuitive — assert them explicitly with a comment so a
-   future reader doesn't "fix" the quirk. Pin, don't change (it's a shared helper; changing
-   it would shift `getFileInfo().extension`, a public field → changeset).
+2. **`getFileExtension` quirks (VERIFIED)** — `("README").slice(((lastIndexOf(".")-1)>>>0)+2)`
+   returns **`""`** for a no-dot filename, and `.gitignore` (dotfile) also returns **`""`**.
+   The `>>> 0` unsigned-shift turns the `-1`/`0` lastIndexOf into a huge slice index →
+   empty string. The trick INTENTIONALLY yields `""` for no-extension/dotfile names. Assert
+   explicitly with a comment so a future reader doesn't "fix" it. Pin, don't change (shared
+   helper; changing it would shift `getFileInfo().extension`, a public field → changeset).
 3. **`null` vs `undefined` divergence** — resolved by dedupe (hooks adopts core's
    `undefined`). Confirmed no internal caller relied on `null` (grep-verified in review).
 

--- a/docs/superpowers/specs/2026-06-05-file-upload-coverage-design.md
+++ b/docs/superpowers/specs/2026-06-05-file-upload-coverage-design.md
@@ -1,0 +1,125 @@
+# Phase B (slice 1): File-Upload Coverage + Dedupe — Design Spec
+
+**Date:** 2026-06-05
+**Status:** Approved (design); plan to follow
+**Owner:** Nic (colorpulse6)
+**Parent:** `2026-06-05-cleanup-and-coverage-design.md` (Phase B)
+
+## Context
+
+The file-upload feature is a whole shipped capability with **zero direct tests**. It lives
+in two modules with near-duplicate logic:
+
+- **`el-form-core/src/validators/fileValidators.ts`** (173 lines, pure, public via
+  `validators/index.ts` → core index): `validateFile`, `validateFiles`,
+  `createFileValidator`, `fileValidator`, the `fileValidators` presets (image/avatar/
+  document/gallery/video/audio), and `FileValidationOptions`. Returns `undefined` on pass.
+- **`el-form-react-hooks/src/utils/fileUtils.ts`** (102 lines, needs DOM): `getFileInfo`,
+  `formatFileSize`, `getFileExtension`, `getFilePreview` (FileReader), plus **its own**
+  `validateFile`/`validateFiles`/`FileValidationOptions` that duplicate core's logic but
+  return **`null`** on pass.
+
+### Public-surface facts (verified against `dist/index.d.ts`)
+
+- The hooks index only does `export { shallowEqual } from "./utils"` — so `fileUtils`'s
+  `validateFile`/`validateFiles`/`formatFileSize`/`getFileExtension` are **NOT public**.
+- Public file surface: `FileInfo` (type), `FileValidationOptions` (byte-identical to
+  core's — same md5), and `getFileInfo`/`getFilePreview` (as `useForm` return methods).
+- Nothing internal consumes `fileUtils.validateFile`/`validateFiles` (grep-confirmed).
+- `types.ts` imports `FileValidationOptions` + `FileInfo` from `./utils/fileUtils`.
+
+## Goals
+
+1. **Comprehensive characterization + behavior tests** for both file modules.
+2. **Dedupe**: make `fileUtils` the single DOM-layer module and delegate the validation
+   logic + `FileValidationOptions` to core (the single source of truth). Backward-compatible
+   because the duplicated functions are internal-only.
+3. **Fix real bugs inline** if the tests surface any (with a changeset when the fix changes
+   public behavior).
+
+## Decisions (from brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Duplication | **Test both, then dedupe now.** `fileUtils` delegates `validateFile`/`validateFiles`/`FileValidationOptions` to `el-form-core`; keeps the DOM-only `getFileInfo`/`formatFileSize`/`getFileExtension`/`getFilePreview`. |
+| Bugs found | **Fix inline** (test the correct behavior). Changeset only if the fix changes *public* behavior (core's `fileValidators`/`FileValidationOptions` or `getFileInfo`/`getFilePreview`). |
+
+## Architecture / changes
+
+### Tests (new)
+- `packages/el-form-core/src/validators/__tests__/fileValidators.test.ts` — node env, pure.
+- `packages/el-form-react-hooks/src/utils/__tests__/fileUtils.test.ts` — jsdom (for
+  `File`, `FileReader`).
+
+### Dedupe (source)
+- `fileUtils.ts`: remove its local `validateFile`/`validateFiles` and re-export core's
+  (or thin-wrap if a `null` return must be preserved for any *internal* caller — none
+  found, so prefer a clean re-export of core's `undefined`-returning versions).
+- `FileValidationOptions`: `fileUtils` re-exports core's type instead of declaring its own
+  identical copy. `types.ts` continues to import `FileValidationOptions`/`FileInfo` from
+  `./utils/fileUtils` (which now re-exports core's option type + keeps `FileInfo`), so no
+  change needed at the `types.ts` import site.
+- Keep `FileInfo`, `getFileInfo`, `formatFileSize`, `getFileExtension`, `getFilePreview`
+  in `fileUtils` (DOM-specific; `getFileInfo` is used by `useForm` and is public).
+- `el-form-react-hooks` already depends on `el-form-core`, so importing from it is fine.
+
+## Test matrix
+
+### core/fileValidators (pure)
+- `validateFile`: pass; maxSize fail; minSize fail; acceptedTypes reject; acceptedExtensions
+  reject (case-insensitive); **edge: `maxSize: 0` is falsy → currently skipped** (pin or fix
+  — see Open Questions); returns `undefined` on pass.
+- `validateFiles`: maxFiles over; minFiles under; per-file delegation (first failing file's
+  message); accepts both `FileList` and `File[]`.
+- `createFileValidator` / `fileValidator`: `File` → validateFile; `FileList`/array →
+  validateFiles; falsy value → undefined; non-file value → undefined.
+- `fileValidators` presets: each accepts a valid sample and rejects a wrong-type / oversized
+  sample (image, avatar (maxFiles:1), document, gallery (maxFiles:10), video, audio).
+
+### hooks/fileUtils (jsdom)
+- `formatFileSize`: 0 → "0 Bytes"; Bytes/KB/MB/GB boundaries; rounding.
+- `getFileExtension`: normal (`a.png`→`png`); no extension (`README`); dotfile (`.gitignore`);
+  multi-dot (`a.b.tar.gz`→`gz`); pins the `>>> 0` bit-shift behavior.
+- `getFileInfo`: all fields; `isImage` true for `image/*`, false otherwise; `formattedSize`
+  and `extension` correct.
+- `getFilePreview`: non-image → `null`; image → a data-URL string (mock `FileReader.onload`);
+  reader error → `null` (mock `onerror`).
+- `validateFile`/`validateFiles` post-dedupe: behave identically to core (now returning
+  `undefined`); a test documents they delegate to core.
+
+## Error handling / risk
+
+- `getFilePreview` uses `FileReader` (async, DOM) — tests mock it deterministically rather
+  than relying on real file reads.
+- The dedupe touches `fileUtils` (internal) — low risk since the changed functions aren't
+  public. Verify `useForm`'s file methods (`addFile`/`removeFile`/`clearFiles`/`getFileInfo`/
+  `getFilePreview`) and the existing component file tests stay green.
+
+## Testing / verification
+
+- New test files pass; `pnpm --filter el-form-core exec vitest --run` and
+  `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run` green.
+- `pnpm build:packages` clean; `dist/index.d.ts` for hooks still exports `FileInfo`,
+  `FileValidationOptions`, `getFileInfo`, `getFilePreview` (no public-surface regression).
+- Existing component file tests (`AdvancedFileValidation`/`ZodFileValidation` demos +
+  `AutoForm` file paths) unaffected.
+- tsd green (the `FileValidationOptions` type move must not break type tests).
+
+## Open questions (resolve in plan, each with a test)
+
+1. **`maxSize: 0` / `minSize: 0` falsy-skip** — `if (options.maxSize && ...)` means a
+   `0` threshold is ignored. Is that a real bug or intended ("0 = no limit")? **Leaning:**
+   it's a footgun but plausibly intended as "unset"; pin current behavior with a test and a
+   code comment rather than changing it — `0` as a meaningful limit is an odd use case.
+   Confirm in plan; if we DO change it, that's a public `el-form-core` behavior change →
+   changeset.
+2. **`null` vs `undefined` divergence** — resolved by dedupe (hooks adopts core's
+   `undefined`). Confirm no internal caller relied on `null` (none found).
+
+## Success criteria
+
+- Both file modules comprehensively tested (validators, presets, info/preview/format/ext).
+- `fileUtils` no longer duplicates core's validation logic; single source of truth in core.
+- No public-API regression (verified via `dist/index.d.ts` + tsd).
+- Any real bug found is fixed inline with a changeset if public-facing.
+- All suites + build green.

--- a/docs/superpowers/specs/2026-06-05-file-upload-coverage-design.md
+++ b/docs/superpowers/specs/2026-06-05-file-upload-coverage-design.md
@@ -50,6 +50,19 @@ in two modules with near-duplicate logic:
 - `packages/el-form-core/src/validators/__tests__/fileValidators.test.ts` — node env, pure.
 - `packages/el-form-react-hooks/src/utils/__tests__/fileUtils.test.ts` — jsdom (for
   `File`, `FileReader`).
+- `packages/el-form-react-hooks/src/__tests__/fileMethods.runtime.test.tsx` — jsdom; covers
+  `useForm`'s public `addFile` / `removeFile` / `clearFiles` + `filePreview` state (now
+  in scope per the review — they're public, untested methods).
+
+### `FileList` testing constraint (from spec review)
+`FileList` is not constructible in node OR jsdom and is `undefined` in the core node env.
+So:
+- Core tests exercise the array path with **`File[]`** only. The `value instanceof FileList`
+  branch in `createFileValidator`/`validateFiles` is covered behaviorally by `File[]`; the
+  FileList-specific `instanceof` line gets a code comment noting it's a browser-only path
+  not exercised by unit tests. Do NOT attempt to fabricate a `FileList`.
+- `useForm` file-method tests use `File` / `File[]` values (which is what `register`
+  produces — it already converts a `FileList` to an array on change).
 
 ### Dedupe (source)
 - `fileUtils.ts`: remove its local `validateFile`/`validateFiles` and re-export core's
@@ -87,6 +100,16 @@ in two modules with near-duplicate logic:
 - `validateFile`/`validateFiles` post-dedupe: behave identically to core (now returning
   `undefined`); a test documents they delegate to core.
 
+### useForm file methods (jsdom runtime — now in scope)
+- `addFile(name, file)`: on an empty/single field → sets the file; on an existing
+  array/FileList field → appends (`[...existing, file]`).
+- `removeFile(name, index)`: splices the file at `index` from the array AND splices the
+  matching `filePreview` entry.
+- `removeFile(name)` (no index): clears the field to `null` and deletes its `filePreview`.
+- `clearFiles(name)`: sets the field to `null`.
+- Construct files via `new File(["x"], "a.png", { type: "image/png" })`; drive through a
+  rendered `useForm` (mirror the existing hooks runtime test setup).
+
 ## Error handling / risk
 
 - `getFilePreview` uses `FileReader` (async, DOM) — tests mock it deterministically rather
@@ -99,22 +122,31 @@ in two modules with near-duplicate logic:
 
 - New test files pass; `pnpm --filter el-form-core exec vitest --run` and
   `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run` green.
-- `pnpm build:packages` clean; `dist/index.d.ts` for hooks still exports `FileInfo`,
-  `FileValidationOptions`, `getFileInfo`, `getFilePreview` (no public-surface regression).
+- **Build FIRST, then assert the public surface:** run `pnpm build:packages`, then check
+  the freshly-built `packages/el-form-react-hooks/dist/index.d.ts` still exports `FileInfo`,
+  `FileValidationOptions`, `getFileInfo`, `getFilePreview` and does NOT newly expose
+  `validateFile`/`validateFiles` (no public-surface regression). Don't rely on a stale/absent
+  dist.
 - Existing component file tests (`AdvancedFileValidation`/`ZodFileValidation` demos +
   `AutoForm` file paths) unaffected.
 - tsd green (the `FileValidationOptions` type move must not break type tests).
 
 ## Open questions (resolve in plan, each with a test)
 
-1. **`maxSize: 0` / `minSize: 0` falsy-skip** — `if (options.maxSize && ...)` means a
-   `0` threshold is ignored. Is that a real bug or intended ("0 = no limit")? **Leaning:**
-   it's a footgun but plausibly intended as "unset"; pin current behavior with a test and a
-   code comment rather than changing it — `0` as a meaningful limit is an odd use case.
-   Confirm in plan; if we DO change it, that's a public `el-form-core` behavior change →
-   changeset.
-2. **`null` vs `undefined` divergence** — resolved by dedupe (hooks adopts core's
-   `undefined`). Confirm no internal caller relied on `null` (none found).
+1. **`maxSize: 0` / `minSize: 0` (and `maxFiles: 0` / `minFiles: 0`) falsy-skip** —
+   `if (options.maxSize && ...)` (and the same pattern for maxFiles/minFiles in
+   `validateFiles`) means a `0` threshold is ignored. Real bug or intended ("0 = no
+   limit")? **Leaning:** footgun but plausibly "unset"; **pin current behavior** with tests
+   + a code comment rather than changing it (`0` as a meaningful limit is an odd use case).
+   Pin all four (maxSize/minSize/maxFiles/minFiles) for symmetry. If we DO change it, that's
+   a public `el-form-core` behavior change → changeset.
+2. **`getFileExtension` quirks** — `("README").slice(((lastIndexOf(".")-1)>>>0)+2)` returns
+   the WHOLE string `"README"` (not `""`) for a no-dot filename; dotfiles (`.gitignore`)
+   return `"gitignore"`. These are unintuitive — assert them explicitly with a comment so a
+   future reader doesn't "fix" the quirk. Pin, don't change (it's a shared helper; changing
+   it would shift `getFileInfo().extension`, a public field → changeset).
+3. **`null` vs `undefined` divergence** — resolved by dedupe (hooks adopts core's
+   `undefined`). Confirmed no internal caller relied on `null` (grep-verified in review).
 
 ## Success criteria
 

--- a/packages/el-form-core/src/validators/__tests__/fileValidators.test.ts
+++ b/packages/el-form-core/src/validators/__tests__/fileValidators.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateFile,
+  validateFiles,
+  createFileValidator,
+  fileValidator,
+  fileValidators,
+} from "../fileValidators";
+
+const file = (name: string, type: string, size = 10) =>
+  new File([new ArrayBuffer(size)], name, { type });
+
+describe("validateFile", () => {
+  it("returns undefined for a valid file", () => {
+    expect(
+      validateFile(file("avatar.png", "image/png"), { maxSize: 100 })
+    ).toBeUndefined();
+  });
+
+  it("rejects a file above maxSize", () => {
+    expect(
+      validateFile(file("large.png", "image/png", 200), { maxSize: 100 })
+    ).toBe("File size must be less than 100 Bytes");
+  });
+
+  it("rejects a file below minSize", () => {
+    expect(
+      validateFile(file("small.png", "image/png", 5), { minSize: 100 })
+    ).toBe("File size must be at least 100 Bytes");
+  });
+
+  it("rejects a disallowed acceptedTypes value", () => {
+    expect(
+      validateFile(file("photo.gif", "image/gif"), {
+        acceptedTypes: ["image/png"],
+      })
+    ).toBe("File type image/gif is not allowed");
+  });
+
+  it("checks acceptedExtensions against the lowercased file extension", () => {
+    expect(
+      validateFile(file("photo.TXT", "text/plain"), {
+        acceptedExtensions: ["png"],
+      })
+    ).toBe("File extension .txt is not allowed");
+
+    expect(
+      validateFile(file("photo.PNG", "image/png"), {
+        acceptedExtensions: ["png"],
+      })
+    ).toBeUndefined();
+  });
+
+  it("treats maxSize: 0 as no limit because the option is falsy", () => {
+    expect(
+      validateFile(file("large.png", "image/png", 999), { maxSize: 0 })
+    ).toBeUndefined();
+  });
+
+  it("treats minSize: 0 as no limit because the option is falsy", () => {
+    expect(
+      validateFile(file("empty.png", "image/png", 0), { minSize: 0 })
+    ).toBeUndefined();
+  });
+});
+
+describe("validateFiles", () => {
+  it("rejects more than maxFiles", () => {
+    expect(
+      validateFiles(
+        [file("a.png", "image/png"), file("b.png", "image/png")],
+        { maxFiles: 1 }
+      )
+    ).toBe("Maximum 1 files allowed");
+  });
+
+  it("rejects fewer than minFiles", () => {
+    expect(validateFiles([file("a.png", "image/png")], { minFiles: 2 })).toBe(
+      "Minimum 2 files required"
+    );
+  });
+
+  it("returns the first failing per-file validation message", () => {
+    expect(
+      validateFiles(
+        [
+          file("notes.txt", "text/plain", 10),
+          file("large.png", "image/png", 999),
+        ],
+        { maxSize: 100, acceptedTypes: ["image/png"] }
+      )
+    ).toBe("File type text/plain is not allowed");
+  });
+
+  it("accepts File[] values within limits", () => {
+    expect(
+      validateFiles([file("a.png", "image/png")], { maxFiles: 2 })
+    ).toBeUndefined();
+  });
+
+  it("treats maxFiles: 0 as no limit because the option is falsy", () => {
+    expect(
+      validateFiles(
+        [file("a.png", "image/png"), file("b.png", "image/png")],
+        { maxFiles: 0 }
+      )
+    ).toBeUndefined();
+  });
+});
+
+describe("createFileValidator / fileValidator", () => {
+  it("returns undefined for a falsy value", () => {
+    expect(createFileValidator({ maxSize: 1 })({ value: null } as any)).toBe(
+      undefined
+    );
+  });
+
+  it("validates a single File value", () => {
+    expect(
+      createFileValidator({ maxSize: 5 })({
+        value: file("large.png", "image/png", 99),
+      } as any)
+    ).toBe("File size must be less than 5 Bytes");
+  });
+
+  it("validates File[] values through the array branch", () => {
+    const validator = createFileValidator({ maxFiles: 1 });
+
+    expect(
+      validator({
+        value: [file("a.png", "image/png"), file("b.png", "image/png")],
+      } as any)
+    ).toBe("Maximum 1 files allowed");
+  });
+
+  it("returns undefined for a non-file value", () => {
+    expect(
+      createFileValidator({ maxSize: 1 })({ value: "hello" } as any)
+    ).toBeUndefined();
+  });
+
+  it("fileValidator returns a validator function", () => {
+    expect(typeof fileValidator({ maxSize: 1 })).toBe("function");
+  });
+
+  // FileList is browser-only and is not constructible in this node test.
+  // The File[] case above pins the array path; browser coverage should exercise FileList.
+});
+
+describe("fileValidators presets", () => {
+  it("image accepts png and rejects text", () => {
+    expect(
+      fileValidators.image({ value: file("photo.png", "image/png") } as any)
+    ).toBeUndefined();
+    expect(
+      fileValidators.image({ value: file("notes.txt", "text/plain") } as any)
+    ).toBe("File type text/plain is not allowed");
+  });
+
+  it("avatar rejects two files", () => {
+    expect(
+      fileValidators.avatar({
+        value: [file("a.png", "image/png"), file("b.png", "image/png")],
+      } as any)
+    ).toBe("Maximum 1 files allowed");
+  });
+
+  it("document accepts pdf and rejects image", () => {
+    expect(
+      fileValidators.document({
+        value: file("paper.pdf", "application/pdf"),
+      } as any)
+    ).toBeUndefined();
+    expect(
+      fileValidators.document({ value: file("photo.png", "image/png") } as any)
+    ).toBe("File type image/png is not allowed");
+  });
+
+  it("gallery accepts a valid image sample", () => {
+    expect(
+      fileValidators.gallery({
+        value: [file("photo.png", "image/png")],
+      } as any)
+    ).toBeUndefined();
+  });
+
+  it("video accepts a valid sample", () => {
+    expect(
+      fileValidators.video({ value: file("clip.mp4", "video/mp4") } as any)
+    ).toBeUndefined();
+  });
+
+  it("audio accepts a valid sample", () => {
+    expect(
+      fileValidators.audio({ value: file("sound.mp3", "audio/mpeg") } as any)
+    ).toBeUndefined();
+  });
+});

--- a/packages/el-form-core/src/validators/__tests__/fileValidators.test.ts
+++ b/packages/el-form-core/src/validators/__tests__/fileValidators.test.ts
@@ -139,6 +139,25 @@ describe("createFileValidator / fileValidator", () => {
     ).toBeUndefined();
   });
 
+  it("returns undefined for non-file values when File globals are unavailable", () => {
+    const hadFile = "File" in globalThis;
+    const hadFileList = "FileList" in globalThis;
+    const originalFile = (globalThis as any).File;
+    const originalFileList = (globalThis as any).FileList;
+
+    try {
+      delete (globalThis as any).File;
+      delete (globalThis as any).FileList;
+
+      expect(
+        createFileValidator({ maxSize: 1 })({ value: "hello" } as any)
+      ).toBeUndefined();
+    } finally {
+      if (hadFile) (globalThis as any).File = originalFile;
+      if (hadFileList) (globalThis as any).FileList = originalFileList;
+    }
+  });
+
   it("fileValidator returns a validator function", () => {
     expect(typeof fileValidator({ maxSize: 1 })).toBe("function");
   });

--- a/packages/el-form-core/src/validators/fileValidators.ts
+++ b/packages/el-form-core/src/validators/fileValidators.ts
@@ -91,7 +91,7 @@ export function createFileValidator(
   return ({ value }) => {
     if (!value) return undefined;
 
-    if (value instanceof File) {
+    if (typeof File !== "undefined" && value instanceof File) {
       return validateFile(value, options);
     }
 

--- a/packages/el-form-core/src/validators/fileValidators.ts
+++ b/packages/el-form-core/src/validators/fileValidators.ts
@@ -95,7 +95,10 @@ export function createFileValidator(
       return validateFile(value, options);
     }
 
-    if (value instanceof FileList || Array.isArray(value)) {
+    if (
+      Array.isArray(value) ||
+      (typeof FileList !== "undefined" && value instanceof FileList)
+    ) {
       return validateFiles(value, options);
     }
 

--- a/packages/el-form-react-hooks/src/__tests__/fileMethods.runtime.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/fileMethods.runtime.test.tsx
@@ -37,9 +37,9 @@ function FileMethodsDemo() {
 }
 
 function FilePreviewDemo() {
-  const { register, filePreview, removeFile } = useForm<{ docs: File | null }>({
-    defaultValues: { docs: null },
-  });
+  const { register, filePreview, removeFile, clearFiles } = useForm<{
+    docs: File | null;
+  }>({ defaultValues: { docs: null } });
   const registration = register("docs");
 
   return (
@@ -55,6 +55,7 @@ function FilePreviewDemo() {
       </button>
       <span data-testid="preview">{filePreview.docs ?? ""}</span>
       <button onClick={() => removeFile("docs")}>remove-all</button>
+      <button onClick={() => clearFiles("docs")}>clear</button>
     </div>
   );
 }
@@ -125,6 +126,33 @@ describe("file methods", () => {
     });
 
     fireEvent.click(screen.getByText("remove-all"));
+
+    expect(screen.getByTestId("preview").textContent).toBe("");
+  });
+
+  it("clearFiles clears filePreview state", async () => {
+    const dataUrl = "data:image/png;base64,cHJldmlldw==";
+
+    class MockFileReader {
+      onload: ((event: { target?: { result: string } }) => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      readAsDataURL() {
+        this.onload?.({ target: { result: dataUrl } });
+      }
+    }
+
+    vi.stubGlobal("FileReader", MockFileReader);
+
+    render(<FilePreviewDemo />);
+
+    fireEvent.click(screen.getByText("select-a"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("preview").textContent).toBe(dataUrl);
+    });
+
+    fireEvent.click(screen.getByText("clear"));
 
     expect(screen.getByTestId("preview").textContent).toBe("");
   });

--- a/packages/el-form-react-hooks/src/__tests__/fileMethods.runtime.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/fileMethods.runtime.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitFor,
+} from "@testing-library/react";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+afterEach(() => vi.unstubAllGlobals());
+
+const mk = (name: string) => new File(["x"], name, { type: "image/png" });
+
+function FileMethodsDemo() {
+  const { watch, addFile, removeFile, clearFiles } = useForm<{ docs: File[] }>({
+    defaultValues: { docs: [] },
+  });
+  const value = watch("docs") as File[] | null;
+  const docs = value || [];
+
+  return (
+    <div>
+      <span data-testid="count">{docs.length}</span>
+      <span data-testid="names">{docs.map((file) => file.name).join(",")}</span>
+      <span data-testid="kind">
+        {value === null ? "null" : Array.isArray(value) ? "array" : typeof value}
+      </span>
+      <button onClick={() => addFile("docs", mk("a.png"))}>add-a</button>
+      <button onClick={() => addFile("docs", mk("b.png"))}>add-b</button>
+      <button onClick={() => removeFile("docs", 0)}>remove-0</button>
+      <button onClick={() => removeFile("docs")}>remove-all</button>
+      <button onClick={() => clearFiles("docs")}>clear</button>
+    </div>
+  );
+}
+
+function FilePreviewDemo() {
+  const { register, filePreview, removeFile } = useForm<{ docs: File | null }>({
+    defaultValues: { docs: null },
+  });
+  const registration = register("docs");
+
+  return (
+    <div>
+      <button
+        onClick={() =>
+          void registration.onChange({
+            target: { type: "file", files: [mk("a.png")] },
+          } as any)
+        }
+      >
+        select-a
+      </button>
+      <span data-testid="preview">{filePreview.docs ?? ""}</span>
+      <button onClick={() => removeFile("docs")}>remove-all</button>
+    </div>
+  );
+}
+
+describe("file methods", () => {
+  it("addFile appends to an array field", () => {
+    render(<FileMethodsDemo />);
+
+    fireEvent.click(screen.getByText("add-a"));
+    fireEvent.click(screen.getByText("add-b"));
+
+    expect(screen.getByTestId("count").textContent).toBe("2");
+    expect(screen.getByTestId("names").textContent).toBe("a.png,b.png");
+    expect(screen.getByTestId("kind").textContent).toBe("array");
+  });
+
+  it("removeFile removes a specific file by index", () => {
+    render(<FileMethodsDemo />);
+
+    fireEvent.click(screen.getByText("add-a"));
+    fireEvent.click(screen.getByText("add-b"));
+    fireEvent.click(screen.getByText("remove-0"));
+
+    expect(screen.getByTestId("count").textContent).toBe("1");
+    expect(screen.getByTestId("names").textContent).toBe("b.png");
+  });
+
+  it("removeFile without an index clears the field to null", () => {
+    render(<FileMethodsDemo />);
+
+    fireEvent.click(screen.getByText("add-a"));
+    fireEvent.click(screen.getByText("remove-all"));
+
+    expect(screen.getByTestId("count").textContent).toBe("0");
+    expect(screen.getByTestId("kind").textContent).toBe("null");
+  });
+
+  it("clearFiles sets the field to null", () => {
+    render(<FileMethodsDemo />);
+
+    fireEvent.click(screen.getByText("add-a"));
+    fireEvent.click(screen.getByText("clear"));
+
+    expect(screen.getByTestId("count").textContent).toBe("0");
+    expect(screen.getByTestId("kind").textContent).toBe("null");
+  });
+
+  it("removeFile without an index clears filePreview state", async () => {
+    const dataUrl = "data:image/png;base64,cHJldmlldw==";
+
+    class MockFileReader {
+      onload: ((event: { target?: { result: string } }) => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      readAsDataURL() {
+        this.onload?.({ target: { result: dataUrl } });
+      }
+    }
+
+    vi.stubGlobal("FileReader", MockFileReader);
+
+    render(<FilePreviewDemo />);
+
+    fireEvent.click(screen.getByText("select-a"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("preview").textContent).toBe(dataUrl);
+    });
+
+    fireEvent.click(screen.getByText("remove-all"));
+
+    expect(screen.getByTestId("preview").textContent).toBe("");
+  });
+});

--- a/packages/el-form-react-hooks/src/useForm.ts
+++ b/packages/el-form-react-hooks/src/useForm.ts
@@ -452,7 +452,14 @@ export function useForm<T extends Record<string, any>>(
 
   const clearFiles = useCallback(
     (name: string) => {
+      const fieldName = name as keyof T;
       formStateManager.setValue(name, null);
+
+      setFilePreview((prev) => {
+        const updated = { ...prev };
+        delete updated[fieldName];
+        return updated;
+      });
     },
     [formStateManager]
   );

--- a/packages/el-form-react-hooks/src/utils/__tests__/fileUtils.test.ts
+++ b/packages/el-form-react-hooks/src/utils/__tests__/fileUtils.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  formatFileSize,
+  getFileExtension,
+  getFileInfo,
+  getFilePreview,
+} from "../fileUtils";
+
+const file = (name: string, type: string, size = 10) =>
+  new File([new ArrayBuffer(size)], name, { type });
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("formatFileSize", () => {
+  it("formats zero bytes", () => {
+    expect(formatFileSize(0)).toBe("0 Bytes");
+  });
+
+  it("formats raw byte counts", () => {
+    expect(formatFileSize(512)).toBe("512 Bytes");
+  });
+
+  it("formats kilobytes, megabytes, and gigabytes", () => {
+    expect(formatFileSize(1024)).toBe("1 KB");
+    expect(formatFileSize(1024 * 1024)).toBe("1 MB");
+    expect(formatFileSize(1024 * 1024 * 1024)).toBe("1 GB");
+  });
+
+  it("rounds converted sizes to two decimals", () => {
+    expect(formatFileSize(1234)).toBe("1.21 KB");
+    expect(formatFileSize(2.345 * 1024 * 1024)).toBe("2.35 MB");
+  });
+});
+
+describe("getFileExtension", () => {
+  it("returns a normal extension", () => {
+    expect(getFileExtension("avatar.png")).toBe("png");
+  });
+
+  it("returns the last segment for multi-dot file names", () => {
+    expect(getFileExtension("archive.tar.gz")).toBe("gz");
+  });
+
+  it("pins dotfiles and names without extensions to an empty extension", () => {
+    // Current public behavior: dotfiles and no-dot names have no extension.
+    // Changing this would affect getFileInfo().extension as well.
+    expect(getFileExtension(".gitignore")).toBe("");
+    expect(getFileExtension("README")).toBe("");
+  });
+});
+
+describe("getFileInfo", () => {
+  it("returns public file metadata and derived fields", () => {
+    const image = file("profile.photo.png", "image/png", 1536);
+
+    expect(getFileInfo(image)).toEqual({
+      name: "profile.photo.png",
+      size: 1536,
+      type: "image/png",
+      lastModified: image.lastModified,
+      formattedSize: "1.5 KB",
+      isImage: true,
+      extension: "png",
+    });
+  });
+
+  it("marks non-image files as not images", () => {
+    expect(getFileInfo(file("report.pdf", "application/pdf")).isImage).toBe(false);
+  });
+});
+
+describe("getFilePreview", () => {
+  it("returns null for non-image files", async () => {
+    await expect(getFilePreview(file("report.pdf", "application/pdf"))).resolves.toBe(
+      null
+    );
+  });
+
+  it("returns a data URL for image files", async () => {
+    const dataUrl = "data:image/png;base64,cHJldmlldw==";
+    const image = file("avatar.png", "image/png");
+    let readFile: File | null = null;
+
+    class MockFileReader {
+      onload: ((event: { target?: { result: string } }) => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      readAsDataURL(file: File) {
+        readFile = file;
+        this.onload?.({ target: { result: dataUrl } });
+      }
+    }
+
+    vi.stubGlobal("FileReader", MockFileReader);
+
+    await expect(getFilePreview(image)).resolves.toBe(dataUrl);
+    expect(readFile).toBe(image);
+  });
+
+  it("returns null when the image reader errors", async () => {
+    class MockFileReader {
+      onload: ((event: { target?: { result: string } }) => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      readAsDataURL(_file: File) {
+        this.onerror?.();
+      }
+    }
+
+    vi.stubGlobal("FileReader", MockFileReader);
+
+    await expect(getFilePreview(file("avatar.png", "image/png"))).resolves.toBe(
+      null
+    );
+  });
+});

--- a/packages/el-form-react-hooks/src/utils/__tests__/fileUtils.test.ts
+++ b/packages/el-form-react-hooks/src/utils/__tests__/fileUtils.test.ts
@@ -4,6 +4,8 @@ import {
   getFileExtension,
   getFileInfo,
   getFilePreview,
+  validateFile,
+  validateFiles,
 } from "../fileUtils";
 
 const file = (name: string, type: string, size = 10) =>
@@ -114,5 +116,33 @@ describe("getFilePreview", () => {
     await expect(getFilePreview(file("avatar.png", "image/png"))).resolves.toBe(
       null
     );
+  });
+});
+
+describe("validateFile", () => {
+  it("returns the core sentinel for valid files", () => {
+    expect(validateFile(file("avatar.png", "image/png", 10), { maxSize: 100 })).toBe(
+      undefined
+    );
+  });
+
+  it("returns a core validation message for oversized files", () => {
+    expect(validateFile(file("avatar.png", "image/png", 101), { maxSize: 100 })).toBe(
+      "File size must be less than 100 Bytes"
+    );
+  });
+});
+
+describe("validateFiles", () => {
+  it("returns the core sentinel for valid file arrays", () => {
+    expect(
+      validateFiles([file("avatar.png", "image/png", 10)], { maxFiles: 2 })
+    ).toBeUndefined();
+  });
+
+  it("returns a core validation message for invalid file arrays", () => {
+    expect(
+      validateFiles([file("avatar.png", "image/png", 101)], { maxSize: 100 })
+    ).toBe("File size must be less than 100 Bytes");
   });
 });

--- a/packages/el-form-react-hooks/src/utils/fileUtils.ts
+++ b/packages/el-form-react-hooks/src/utils/fileUtils.ts
@@ -1,3 +1,11 @@
+// Re-export the validation surface from el-form-core (single source of truth).
+// These were previously duplicated here (returning `null`); core returns `undefined`.
+export {
+  validateFile,
+  validateFiles,
+  type FileValidationOptions,
+} from "el-form-core";
+
 export interface FileInfo {
   name: string;
   size: number;
@@ -6,15 +14,6 @@ export interface FileInfo {
   formattedSize: string;
   isImage: boolean;
   extension: string;
-}
-
-export interface FileValidationOptions {
-  maxSize?: number;
-  minSize?: number;
-  maxFiles?: number;
-  minFiles?: number;
-  acceptedTypes?: string[];
-  acceptedExtensions?: string[];
 }
 
 export function getFileInfo(file: File): FileInfo {
@@ -50,53 +49,4 @@ export async function getFilePreview(file: File): Promise<string | null> {
     reader.onerror = () => resolve(null);
     reader.readAsDataURL(file);
   });
-}
-
-export function validateFile(
-  file: File,
-  options: FileValidationOptions
-): string | null {
-  if (options.maxSize && file.size > options.maxSize) {
-    return `File size must be less than ${formatFileSize(options.maxSize)}`;
-  }
-
-  if (options.minSize && file.size < options.minSize) {
-    return `File size must be at least ${formatFileSize(options.minSize)}`;
-  }
-
-  if (options.acceptedTypes && !options.acceptedTypes.includes(file.type)) {
-    return `File type ${file.type} is not allowed`;
-  }
-
-  if (options.acceptedExtensions) {
-    const ext = getFileExtension(file.name).toLowerCase();
-    if (!options.acceptedExtensions.includes(ext)) {
-      return `File extension .${ext} is not allowed`;
-    }
-  }
-
-  return null;
-}
-
-export function validateFiles(
-  files: FileList | File[],
-  options: FileValidationOptions
-): string | null {
-  const fileArray = Array.from(files);
-
-  if (options.maxFiles && fileArray.length > options.maxFiles) {
-    return `Maximum ${options.maxFiles} files allowed`;
-  }
-
-  if (options.minFiles && fileArray.length < options.minFiles) {
-    return `Minimum ${options.minFiles} files required`;
-  }
-
-  // Validate each file
-  for (const file of fileArray) {
-    const error = validateFile(file, options);
-    if (error) return error;
-  }
-
-  return null;
 }


### PR DESCRIPTION
## Summary
- Adds comprehensive coverage for core file validators, hooks file utilities, and `useForm` file methods.
- Fixes file validator runtime guards so non-browser runtimes without `File`/`FileList` globals do not throw for non-file or `File[]` values.
- Dedupes hooks file validation by re-exporting `validateFile`, `validateFiles`, and `FileValidationOptions` from `el-form-core`; keeps DOM helpers local.
- Fixes `clearFiles()` so it clears stale `filePreview` state.
- Adds a patch changeset for `el-form-core` and `el-form-react-hooks`.

## Test Plan
- `pnpm --filter el-form-core exec vitest --run` — 4 files / 41 tests passed
- `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run` — 17 files / 83 tests passed
- `pnpm --filter el-form-react-hooks exec tsd --files tsd.test-d.ts` — exit 0
- `pnpm --filter el-form-react-components exec vitest --environment jsdom --run` — 7 files / 25 tests passed; existing stderr deprecation/validation logs only
- `pnpm build:packages` — passed
- `pnpm -r run lint` — passed
- `grep -nE "export \\* from .el-form-core|FileInfo|FileValidationOptions|getFileInfo|getFilePreview" packages/el-form-react-hooks/dist/index.d.ts` — expected exports present
- `git diff --check d1c485b..HEAD` — clean