### PR TITLE
fix(hooks): make FormProvider context getter current during render

### DIFF
--- a/.changeset/form-provider-getter-reactivity.md
+++ b/.changeset/form-provider-getter-reactivity.md
@@ -1,0 +1,7 @@
+---
+"el-form-react-hooks": patch
+---
+
+Fix `FormProvider` context getter lag. A component reading `useFormContext().form.formState` directly during render previously observed form state one render behind, because the context getter returned a ref that was only refreshed in a post-commit effect. The ref is now updated during render, so direct reads are current within the same render pass.
+
+This does not change any public API. Note that a `React.memo`-wrapped child with unchanged props still won't re-render on state change from a bare direct read — subscribe via `useField` / `useFormSelector` when you need a component to react to state changes.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,8 +2,18 @@
 
 > Honest, current status of the El Form library. Supersedes the old aspirational
 > `agent-actions/FEATURE_CHECKLIST.md` (which was ~90% wishlist and is gitignored).
-> Last updated: 2026-06-05 (after the 3.11.0 release + the code-quality cleanup patch).
-> Grounded in the Phase 0 audit (`docs/superpowers/audit-2026-05-31.md`).
+> Last updated: 2026-06-08 (after Phase B coverage + Phase C example-app sweep work).
+> Grounded in the Phase 0 audit (`docs/superpowers/audit-2026-05-31.md`), the
+> cleanup/coverage effort, and the current Playwright coverage matrix.
+
+## Current package versions
+
+Package manifests on `main` currently show: `el-form-core@2.3.2`,
+`el-form-react-hooks@3.11.3`, `el-form-react-components@4.5.3`,
+`el-form-react@4.1.8`, `el-form-mcp@0.1.0`.
+
+The latest `main` Release workflow was green on 2026-06-08. Live npm registry
+versions were not rechecked from the sandboxed local environment.
 
 ## Shipped & stable
 
@@ -30,9 +40,30 @@
   published on its own track.
 - **Modular packages** — `el-form-core`, `el-form-react-hooks`,
   `el-form-react-components`, `el-form-react`.
+- **Example-app browser coverage harness** — `examples/react` now exposes the current
+  runtime feature surface through user-visible demos/labs, and the manual Playwright sweep
+  asserts behavior route-by-route. This is a pre-launch/manual verification gate, not CI.
 
-Published versions (npm): `el-form-core@2.3.1`, `el-form-react-hooks@3.11.1`,
-`el-form-react-components@4.5.1`, `el-form-react@4.1.6`, `el-form-mcp@0.1.0`.
+## Recently shipped (2026-06-08 coverage + sweep work)
+
+- **Phase B unit/runtime coverage gaps filled** — file upload, form history, core
+  utils/adapters, umbrella `el-form-react` public API smoke coverage, and state utilities.
+- **Phase C browser sweep extended** — the example app now includes focused coverage labs
+  for form controls, field arrays, validation adapter branches, file validators, and
+  component exports/AutoForm customization.
+- **Coverage matrix added** —
+  `docs/superpowers/audits/2026-06-08-example-app-playwright-coverage-matrix.md` maps
+  each public runtime feature to browser coverage or an explicit unit/type fallback.
+- **Latest manual sweep evidence** — `.sweep-results/REPORT.md` showed 20/20 pass and
+  0 console errors after the 2026-06-08 work. `.sweep-results/` remains gitignored.
+
+## Recently shipped (FormProvider reactivity fix)
+
+- **FormProvider getter lag fixed** — direct `useFormContext().form.formState` reads are
+  now current within the same render pass; the context getter is refreshed during render
+  instead of in a post-commit effect. Patch bump for `el-form-react-hooks`. (`React.memo`
+  children with unchanged props still need `useField` / `useFormSelector` to react to
+  state changes.)
 
 ## Recently shipped (2.3.1 code-quality patch)
 
@@ -47,18 +78,21 @@ Published versions (npm): `el-form-core@2.3.1`, `el-form-react-hooks@3.11.1`,
 
 ## Planned / under consideration
 
-- [ ] **`useWatch`** — *not committed.* `useField` / `useFormSelector` already provide
-      isolated value subscriptions; a separate `useWatch` would only be added if it
-      genuinely improves on them (see legacy `useFormWatch-hook` branch for exploration).
-- [ ] **FormProvider reactivity (deeper fix)** — the context getter exposes form state one
-      render behind for direct `useFormContext().form.formState` reads. The standalone
-      field components were fixed to subscribe via `useField`, but the underlying getter
-      remains a latent lag for anyone reading `form.formState` directly during render.
 - [ ] **Tighten `BaseFieldProps` typing** — `name` is `keyof T`; could be `Path<T>` for
       nested-path safety in the standalone field components (would remove some `as any`).
 - [ ] **`pnpm test` arg-forwarding** — the hooks `test` script forwards trailing args to
       `tsd`, so `pnpm test -- --run` exits non-zero though assertions pass. Cosmetic
       (CI's arg-free call is fine); split the tsd step to fix.
+- [ ] **`useWatch`** — *not committed.* `useField` / `useFormSelector` already provide
+      isolated value subscriptions; a separate `useWatch` should only be added if it
+      genuinely improves on them. The 2026-06-01 `useFieldArray` design explicitly cut
+      `useWatch`; see the legacy `useFormWatch-hook` branch only as exploration.
+
+Suggested next order for feature work:
+
+1. Tighten `BaseFieldProps.name` to `Path<T>` if the public typing remains ergonomic.
+2. Fix `pnpm test` arg-forwarding as tooling polish.
+3. Revisit `useWatch` only after proving it adds value over existing selector APIs.
 
 ## Design principles
 
@@ -75,13 +109,16 @@ Published versions (npm): `el-form-core@2.3.1`, `el-form-react-hooks@3.11.1`,
 - Other frameworks (Vue / Svelte / Angular / React Native).
 - Analytics, devtools, rich-text/code editors, i18n, multi-step wizard components.
 
-## Known issues (open as of 2026-06-05)
+## Known issues (open as of 2026-06-08)
 
-- **FormProvider getter lag** — see "FormProvider reactivity" under Planned. The only
-  genuinely open *correctness* item; low impact (standalone field components already
-  worked around it via `useField`).
 - **`pnpm test` arg-forwarding** — cosmetic; see Planned. CI is unaffected.
+- **`BaseFieldProps.name` typing** — polish; see Planned.
 
+> The **FormProvider getter lag** is now **resolved**: direct
+> `useFormContext().form.formState` reads are current within the same render pass (the
+> context getter is refreshed during render instead of in a post-commit effect). No open
+> *correctness* items remain.
+>
 > Previously-listed issues now **resolved** in the 2.3.1 patch: package source is linted
 > in CI, Node aligned to 20, the 13 ESLint errors cleared, and the debounce
 > hang/duplication fixed.

--- a/docs/superpowers/HANDOFF-2026-06-06.md
+++ b/docs/superpowers/HANDOFF-2026-06-06.md
@@ -1,5 +1,9 @@
 # El Form — Session Handoff (2026-06-06)
 
+> Superseded by `docs/superpowers/HANDOFF-2026-06-08.md`. This file is a historical
+> snapshot from before the Phase B coverage and Phase C Playwright/example-app work were
+> merged.
+
 Snapshot of where things stand so any session (you or an agent) can pick up cleanly.
 
 ## TL;DR

--- a/docs/superpowers/HANDOFF-2026-06-08.md
+++ b/docs/superpowers/HANDOFF-2026-06-08.md
@@ -1,0 +1,151 @@
+# El Form - Session Handoff (2026-06-08)
+
+Snapshot for continuing feature work after the cleanup, coverage, and Playwright sweep
+effort.
+
+## TL;DR
+
+The cleanup + comprehensive coverage roadmap is merged on `main`. Phase B unit/runtime
+coverage and Phase C example-app Playwright coverage are no longer resume items. The next
+feature-work queue is the live `ROADMAP.md`: FormProvider reactivity first, then
+`BaseFieldProps` path typing, then `pnpm test` arg-forwarding, then only consider
+`useWatch` if it proves useful beyond `useField` / `useFormSelector`.
+
+## Current State (verified 2026-06-08)
+
+- Branch: `main`
+- HEAD: `5273016 fix(example): satisfy file input lint`
+- Base git status before this docs refresh: clean and synced with `origin/main`
+- Expected local changes from this handoff: docs only (`ROADMAP.md`,
+  `docs/superpowers/HANDOFF-2026-06-06.md`,
+  `docs/superpowers/HANDOFF-2026-06-08.md`, and status notes in historical specs/plans)
+- Latest `main` GitHub workflows for `5273016`: CI success, Release success, Deploy Docs
+  success, ESLint success.
+- Package manifests: `el-form-core@2.3.2`, `el-form-react-hooks@3.11.3`,
+  `el-form-react-components@4.5.3`, `el-form-react@4.1.8`, `el-form-mcp@0.1.0`.
+- Pending changesets: none (`.changeset/` only has `README.md` and `config.json`).
+- Open PRs: #55 `docs-sandbox` and #10 `react-query-support`; both are stale/parked and
+  not part of the current roadmap.
+- Latest manual sweep report on disk: `.sweep-results/REPORT.md` showed 20/20 pass,
+  0 fail, 0 console errors. The report and screenshots are gitignored.
+
+## Completed Since The 2026-06-06 Handoff
+
+- Phase A repo cleanup was already merged: dead example/test app clutter removed; kept
+  `examples/react` as the manual Playwright target.
+- Phase B unit/runtime coverage merged:
+  - file upload coverage + validator dedupe,
+  - form history snapshot/change coverage,
+  - core utils + schema adapter coverage,
+  - umbrella `el-form-react` public API smoke coverage,
+  - state utility manager coverage.
+- Phase C example-app sweep work merged:
+  - coverage matrix committed at
+    `docs/superpowers/audits/2026-06-08-example-app-playwright-coverage-matrix.md`,
+  - `examples/react` gained coverage lab routes for current browser-observable library
+    behavior,
+  - `.claude/skills/sweep-form-app/run-sweep.mjs` now performs route-specific behavioral
+    assertions instead of shallow render checks,
+  - final lint fix committed as `5273016`.
+
+## Do Not Resume These As Active Work
+
+- `docs/superpowers/HANDOFF-2026-06-06.md` is historical and stale.
+- `docs/superpowers/specs/2026-06-05-cleanup-and-coverage-design.md` is the historical
+  cleanup/coverage umbrella spec. Its Phase B/C "not started" language has been superseded
+  by the merged work.
+- Worktrees under `.worktrees/el-form-*-coverage` and matching local branches are old
+  coverage slices. Treat them as historical unless the user explicitly asks to clean them
+  up.
+- `react-query-support` remains parked. Do not revive it unless the user explicitly
+  reopens that product direction.
+
+## Resume Here: Feature Work
+
+Recommended first feature/fix slice: **FormProvider reactivity**.
+
+Problem: direct render-time reads from `useFormContext().form.formState` can observe state
+one render behind. Existing standalone field components worked around this by subscribing
+via `useField`, but the context getter itself remains a latent correctness issue for users
+who render from `form.formState` directly.
+
+Likely starting files:
+
+- `packages/el-form-react-hooks/src/FormContext.tsx`
+- `packages/el-form-react-hooks/src/__tests__/selector.runtime.test.tsx`
+- possibly `packages/el-form-react-hooks/src/types.ts`
+- docs only if public guidance changes: `docs/docs/api/form-provider.md`
+
+Suggested acceptance criteria:
+
+- A regression test renders a child inside `FormProvider`, reads
+  `useFormContext().form.formState` directly during render, updates a field, and observes
+  the updated values/errors/touched state without the known one-render lag.
+- Existing `useFormState`, `useFormSelector`, `useField`, and `useFieldArray` selector
+  behavior remains isolated and passing.
+- No public API shape changes unless the implementation clearly requires one.
+- Add a changeset only if the fix changes shipped runtime behavior. This likely counts as
+  a patch-level behavior fix if implemented.
+
+Second candidate: **tighten `BaseFieldProps.name` to `Path<T>`**.
+
+Likely starting files:
+
+- `packages/el-form-react-components/src/types.ts`
+- `packages/el-form-react-components/src/FieldComponents.tsx`
+- `packages/el-form-react-components/src/index.ts`
+- `packages/el-form-react-components/src/__tests__/a11y.runtime.test.tsx`
+- type coverage may belong in a package-local `tsd` test if components does not already
+  have one; avoid broad type-system churn without a focused plan.
+
+Third candidate: **fix `pnpm test` arg-forwarding**.
+
+Problem: the hooks package `test` script runs Vitest and then `tsd`; trailing args such as
+`-- --run` get forwarded to `tsd`, causing a non-zero exit even when assertions pass. CI's
+arg-free call is fine, so this is tooling polish.
+
+Likely starting file:
+
+- `packages/el-form-react-hooks/package.json`
+
+Fourth candidate: **`useWatch` exploration**.
+
+Do not start by implementing it. First write a short spec proving what it improves over
+`useField`, `useFormSelector`, and `useForm().watch`. The 2026-06-01 `useFieldArray`
+design explicitly cut `useWatch`, so any new work should justify why that decision changed.
+
+## Verification Commands
+
+Use focused commands while developing, then run broader gates before PR/merge:
+
+- Lint all packages/apps: `pnpm run lint`
+- Build packages: `pnpm build:packages`
+- Hooks runtime tests: `pnpm --filter el-form-react-hooks exec vitest --environment jsdom --run`
+- Hooks type tests: `pnpm --filter el-form-react-hooks exec tsd --files tsd.test-d.ts`
+- Components runtime tests: `pnpm --filter el-form-react-components exec vitest --environment jsdom --run`
+- Umbrella smoke tests: `pnpm --filter el-form-react exec vitest --run`
+- Example app build: `pnpm --filter el-form-testing-app build`
+- Manual Playwright sweep: use `.claude/skills/sweep-form-app`. It is not CI. Port 3001
+  often collides with an unrelated local app; verify the server is actually the El Form
+  testing app before running the sweep.
+
+## Release / Branching Notes
+
+- For code changes, prefer a feature branch + PR.
+- Stage files explicitly; do not use `git add -A`.
+- Test-only/docs-only changes do not need a changeset.
+- Public runtime fixes or public type improvements should get a patch changeset.
+- The release model is: merge feature PR -> Changesets bot opens/restages a Version PR ->
+  merge the Version PR to publish. Do not manually "Update branch" the changeset release
+  branch.
+
+## Relevant Docs
+
+- `ROADMAP.md` - current source of truth for feature queue.
+- `docs/superpowers/audits/2026-06-08-example-app-playwright-coverage-matrix.md` -
+  coverage matrix for current browser/unit/type coverage.
+- `docs/superpowers/specs/2026-06-08-example-app-playwright-coverage-design.md` -
+  Phase C design, now implemented.
+- `docs/superpowers/specs/2026-06-05-cleanup-and-coverage-design.md` - historical
+  cleanup/coverage umbrella spec.
+- `launch/` - non-code launch/relaunch drafts.

--- a/docs/superpowers/plans/2026-06-08-example-app-playwright-coverage.md
+++ b/docs/superpowers/plans/2026-06-08-example-app-playwright-coverage.md
@@ -10,6 +10,10 @@
 
 **Spec:** `docs/superpowers/specs/2026-06-08-example-app-playwright-coverage-design.md`
 
+**Status update (2026-06-08):** implemented and merged on `main`. This plan is now
+historical; do not resume its unchecked tasks as active work. Use
+`docs/superpowers/HANDOFF-2026-06-08.md` and `ROADMAP.md` for the next feature slice.
+
 ---
 
 ## Scope Rules
@@ -686,4 +690,3 @@ Report:
 - sweep pass/fail summary,
 - verification commands run,
 - remaining browser coverage limits.
-

--- a/docs/superpowers/specs/2026-06-05-cleanup-and-coverage-design.md
+++ b/docs/superpowers/specs/2026-06-05-cleanup-and-coverage-design.md
@@ -5,6 +5,11 @@
 **Owner:** Nic (colorpulse6)
 **Branch:** direct-to-main for Phase A (per owner decision)
 
+**Status update (2026-06-08):** this is now a historical umbrella spec. Phase A, the Phase
+B coverage slices, and Phase C example-app Playwright sweep work have merged to `main`.
+Use `ROADMAP.md` and `docs/superpowers/HANDOFF-2026-06-08.md` for current feature-work
+resume guidance.
+
 ## Context
 
 Post-revival, the library is released (3.11.0 + 2.3.1 patch), documented, and CI-clean.

--- a/docs/superpowers/specs/2026-06-08-example-app-playwright-coverage-design.md
+++ b/docs/superpowers/specs/2026-06-08-example-app-playwright-coverage-design.md
@@ -1,8 +1,13 @@
 # El Form Phase C — Example App Coverage + Playwright Sweep
 
 **Date:** 2026-06-08  
-**Status:** User-approved design, pending review  
+**Status:** Implemented on `main` as of 2026-06-08
 **Branch:** `main`
+
+**Status update:** the example-app coverage labs, coverage matrix, and route-specific
+manual Playwright sweep assertions described here have merged. See
+`docs/superpowers/audits/2026-06-08-example-app-playwright-coverage-matrix.md` and
+`docs/superpowers/HANDOFF-2026-06-08.md` for the current state.
 
 ## Problem
 

--- a/packages/el-form-react-hooks/src/FormContext.tsx
+++ b/packages/el-form-react-hooks/src/FormContext.tsx
@@ -46,9 +46,14 @@ export function FormProvider<T extends Record<string, any>>({
   const listenersRef = useRef(new Set<() => void>());
   const latestFormRef = useRef(form);
 
-  useEffect(() => {
-    latestFormRef.current = form;
-  }, [form]);
+  // Keep the latest form available to the context getter DURING render, not in
+  // a post-commit effect. Reading it from an effect made direct
+  // `useFormContext().form.formState` reads lag one render behind, because the
+  // getter still returned the previous render's form until the effect ran.
+  // Assigning here (the idempotent "latest ref" pattern) makes the getter
+  // current within the same render pass, while the stable context identity and
+  // the selector subscriptions below are unchanged.
+  latestFormRef.current = form;
 
   // Notify subscribers whenever the formState object changes
   useEffect(() => {

--- a/packages/el-form-react-hooks/src/__tests__/formProviderReactivity.runtime.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/formProviderReactivity.runtime.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import React from "react";
+import { useFormContext } from "../FormContext";
+import { useForm, FormProvider } from "..";
+
+beforeEach(cleanup);
+
+type Values = { name: string };
+
+// Reads form state DIRECTLY from the context getter during render, with no
+// selector subscription (useField / useFormSelector). This is the path that
+// previously lagged one render behind because the context getter read a ref
+// that was only refreshed in a post-commit effect.
+function DirectReader() {
+  const { form } = useFormContext<Values>();
+  const value = form.formState.values.name ?? "";
+  const touched = form.formState.touched.name ? "touched" : "untouched";
+  const error = form.formState.errors.name ?? "no-error";
+  return (
+    <>
+      <div data-testid="value">{value}</div>
+      <div data-testid="touched">{touched}</div>
+      <div data-testid="error">{error}</div>
+    </>
+  );
+}
+
+describe("FormProvider context getter reactivity", () => {
+  it("reflects updated values to a direct form.formState reader in the same render", () => {
+    function App() {
+      const form = useForm<Values>({ defaultValues: { name: "" } });
+      return (
+        <FormProvider form={form}>
+          <input aria-label="name" {...(form.register("name") as any)} />
+          <DirectReader />
+        </FormProvider>
+      );
+    }
+
+    render(<App />);
+    expect(screen.getByTestId("value").textContent).toBe("");
+
+    fireEvent.change(screen.getByLabelText("name"), {
+      target: { value: "ada" },
+    });
+    expect(screen.getByTestId("value").textContent).toBe("ada");
+  });
+
+  it("reflects updated touched state to a direct reader after blur", () => {
+    function App() {
+      const form = useForm<Values>({ defaultValues: { name: "" } });
+      return (
+        <FormProvider form={form}>
+          <input aria-label="name" {...(form.register("name") as any)} />
+          <DirectReader />
+        </FormProvider>
+      );
+    }
+
+    render(<App />);
+    expect(screen.getByTestId("touched").textContent).toBe("untouched");
+
+    fireEvent.blur(screen.getByLabelText("name"));
+    expect(screen.getByTestId("touched").textContent).toBe("touched");
+  });
+
+  it("reflects setError updates to a direct reader", () => {
+    function App() {
+      const form = useForm<Values>({ defaultValues: { name: "" } });
+      return (
+        <FormProvider form={form}>
+          <button
+            aria-label="set-error"
+            onClick={() => form.setError("name", "Required")}
+          >
+            set
+          </button>
+          <DirectReader />
+        </FormProvider>
+      );
+    }
+
+    render(<App />);
+    expect(screen.getByTestId("error").textContent).toBe("no-error");
+
+    fireEvent.click(screen.getByLabelText("set-error"));
+    expect(screen.getByTestId("error").textContent).toBe("Required");
+  });
+});


### PR DESCRIPTION
## Problem

`FormProvider` exposes `form` to consumers through a **stable context holder** whose `form` getter returns `latestFormRef.current`. That ref was only refreshed in a **post-commit `useEffect`**, so during the render pass triggered by a state change the getter still returned the *previous* render's `form`. A component reading `useFormContext().form.formState` **directly during render** therefore observed state one render behind.

Selector subscribers (`useField` / `useFormSelector` via `useSyncExternalStore`) were unaffected — which is why the standalone field components had been worked around earlier — but the latent lag remained for any direct `form.formState` read.

## Fix

Refresh `latestFormRef.current = form` **during render** (the idempotent "latest ref" pattern) instead of in an effect, and drop the now-redundant effect. The getter is current within the same render pass; the stable context identity (perf design) and the subscriber-notify effect are unchanged. One-line behavior fix, no public API change.

## Scope / known boundary

A `React.memo`-wrapped child with unchanged props still won't re-render on state change from a bare direct read — subscribe via `useField` / `useFormSelector` when a component needs to *react* to state. This is inherent to the stable-holder design and noted in the changeset.

## Tests

Added `formProviderReactivity.runtime.test.tsx` (TDD — watched it fail first):
- values via `onChange`, touched via `onBlur`, errors via `setError`, all read through the direct `useFormContext().form.formState` path.

Verification (all green):
- Hooks runtime: **107 passed** (incl. 3 new) · tsd: exit 0 · eslint: exit 0
- Components runtime: 25 passed · umbrella smoke: 6 passed
- `pnpm build:packages`: success · `git diff --check`: clean

An independent code-reviewer subagent re-ran red→green and returned **SOUND** (confirmed StrictMode / concurrent-render / SSR safety; the state lives in `useState`, not an external store, so there's no render-phase tearing hazard).

## Release

Includes a patch changeset for `el-form-react-hooks` (internal dependents auto-bump per changeset config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)