### PR TITLE
ci: bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,13 @@ jobs:
         zod: ["^3.22.0", "^4.0.0"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 8.15.0
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,15 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 8.15.0
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: "pnpm"
@@ -52,10 +50,10 @@ jobs:
           GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/build
 
@@ -68,4 +66,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -8,11 +8,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 8.15.0
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: "pnpm"

--- a/.github/workflows/pr-changeset-label.yml
+++ b/.github/workflows/pr-changeset-label.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label PR when changeset present
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,18 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch full history for changeset
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 8.15.0
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: "pnpm"


### PR DESCRIPTION
## Why

GitHub is deprecating the **Node 20 runtime** for JavaScript actions — it's being forced to Node 24 (and Node 20 removed from runners). Our workflows were emitting the deprecation warning on every run.

## What

Bump every action to its latest **Node 24** major (verified via the GitHub API that each resolves to `runs.using: node24`):

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v6** |
| `actions/setup-node` | v4 | **v6** |
| `pnpm/action-setup` | v4 | **v6** |
| `actions/github-script` | v7 | **v9** |
| `actions/configure-pages` | v4 | **v6** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `actions/deploy-pages` | v4 | **v5** |

**`pnpm/action-setup`**: dropped the `version: 8.15.0` input. Newer majors error when both that input *and* a `packageManager` field are present, so it now reads `packageManager: "pnpm@8.15.0"` from `package.json` (single source of truth).

The project's Node target (`node-version: 20` in setup-node) is **unchanged** — this PR only addresses the *action runtime* deprecation, not the build/test Node version.

## Verification

- All five workflow files parse as valid YAML; the inputs we rely on (`fetch-depth`, `cache`, `registry-url`, `path`, `github-token`/`script`) are still supported in the bumped majors.
- CI itself is the real test: `ci.yml`, `eslint.yml`, and `pr-changeset-label.yml` (github-script) run on this PR and exercise the new versions directly.
- `release.yml` reuses the same three core actions as `ci.yml`; the Pages trio in `deploy-docs.yml` (`configure-pages`/`upload-pages-artifact`/`deploy-pages`) only runs on push to `main`, so it's verified post-merge — I'll watch the first deploy-docs run.

No package changes → no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)