### PR TITLE
feat(hooks): add useWatch — reactive value subscription by path

### DIFF
--- a/.changeset/use-watch-hook.md
+++ b/.changeset/use-watch-hook.md
@@ -1,0 +1,13 @@
+---
+"el-form-react-hooks": minor
+---
+
+Add `useWatch` — a reactive hook for subscribing to form value(s) by path, for React Hook Form parity. A reactive mirror of `form.watch()`'s overloads, built on the selector store so each watcher re-renders in isolation:
+
+```ts
+const all = useWatch<MyForm>();                       // Partial<MyForm>
+const email = useWatch<MyForm, "email">("email");      // string
+const pair = useWatch<MyForm, "a" | "b">(["a", "b"]);  // { a: ...; b: ... }
+```
+
+Must be used within a `FormProvider`. Returns values only — use `useField` for `value + error + touched`, or `useFormSelector` for an arbitrary derived slice. The imperative `form.watch()` is unchanged.

--- a/docs/docs/guides/migration.md
+++ b/docs/docs/guides/migration.md
@@ -76,6 +76,7 @@ const { register, handleSubmit, formState } = useForm({
 | `mode: "onChange"` | `validators: { onChange: schema }` (or `validateOn`) | Validation timing is expressed by which event key you put the validator under. |
 | `useFieldArray({ control, name })` | `useFieldArray({ name })` (inside `FormProvider`) or `useFieldArray({ name, form })` | No `control` object — use context or pass `form`. |
 | `field.id` from `useFieldArray` | `field.id` (same idea; configurable via `keyName`) | Stable React keys for rows; see [Array Fields](./array-fields.md). |
+| `useWatch({ control, name })` | `useWatch(name)` / `useWatch([a, b])` / `useWatch()` (inside `FormProvider`) | No `control` — reads context. Returns watched **value(s)** only; reach for `useField` when you also need `error`/`touched`, or `useFormSelector` for a derived slice. |
 
 ### Step-by-step
 

--- a/docs/superpowers/specs/2026-06-09-use-watch-hook-design.md
+++ b/docs/superpowers/specs/2026-06-09-use-watch-hook-design.md
@@ -1,0 +1,116 @@
+# useWatch hook — design (2026-06-09)
+
+## Problem
+
+el-form has a reactive value-subscription story (`useField`, `useFormSelector`) and
+an imperative snapshot reader (`form.watch()`), but no hook named `useWatch`. Users
+migrating from React Hook Form reach for `useWatch` by name. The 2026-06-01
+`useFieldArray` design cut `useWatch` as redundant with `useField`/`useFormSelector`.
+
+We are reversing that decision for one reason only: **migration friction**. A
+`useWatch` that is a thin, correct wrapper over the existing selector store costs ~40
+lines, adds a familiar name, and does not compromise the selector-based design. This is
+exactly the "adopt familiar RHF API shapes only where they genuinely lower migration
+friction" principle from the roadmap.
+
+## API
+
+A reactive mirror of the existing `form.watch()` overloads (positional — consistent
+with el-form's own `watch`, not RHF's `control`-object form). Used within a
+`FormProvider` (reads the same `SubscriptionContext` as `useField`/`useFormSelector`).
+
+```ts
+useWatch<T extends Record<string, any>>(): Partial<T>;                          // all
+useWatch<T extends Record<string, any>, Name extends Path<T>>(name: Name): PathValue<T, Name>; // single
+useWatch<T extends Record<string, any>, Names extends Path<T>>(names: Names[]): { [K in Names]: PathValue<T, K> }; // multiple
+```
+
+Type-parameter names/constraints match `UseFormReturn["watch"]` exactly (`Names`
+plural so the array literal infers the union of path literals — `["a","b"]` →
+`"a" | "b"` — and the keyed-object return survives instead of widening to `Path<T>[]`).
+`T` is supplied explicitly (`useWatch<MyForm>(...)`), consistent with
+`useField<T, Name>` / `useFormSelector<TSelected>` — there is no `control` to infer from.
+
+Returns **values only**. Division of labour stays clear:
+
+- `useWatch` — reactive watched value(s); RHF-familiar name.
+- `useField` — one field's `value + error + touched`.
+- `useFormSelector` — arbitrary derived slice with custom equality.
+- `form.watch()` — imperative one-shot snapshot (unchanged).
+
+## Implementation
+
+Thin wrapper over `useFormSelector` (inherits `useSyncExternalStore` re-render
+isolation):
+
+- **single** `useWatch(name)` → `useFormSelector(s => getNestedValue(s.values, name))`,
+  default `Object.is`.
+- **all** `useWatch()` → `useFormSelector(s => s.values)`, `Object.is` on the `values`
+  reference (it changes on every value mutation, which is the correct cadence for
+  watch-all).
+- **multiple** `useWatch(names)` → `useFormSelector(s => fromEntries(names.map(...)),
+  shallowEqual)`. `shallowEqual` is a **correctness requirement**, not an optimization:
+  the selector builds a fresh object each call, so with `Object.is` `getSnapshot` would
+  return a new reference every render — tripping React's uncached-snapshot path
+  (re-render loop / "getSnapshot should be cached" warning). `shallowEqual` is already
+  exported from `utils`.
+
+The runtime branches on argument shape; the public type is the overload set above
+(identical in shape to `UseFormReturn["watch"]`, minus the imperative call site).
+
+Inherited behaviors (no extra code): **SSR** works via `useFormSelector`'s
+`getServerSnapshot = getSnapshot`; the **"must be within a `FormProvider`"** error comes
+from `useSubscriptionContext` throwing. **watch-all re-renders on every value mutation**
+(any field) — intended and matches RHF's `useWatch()` cadence.
+
+### Known-issue check: the `undefined` sentinel
+
+`useFormSelector` uses `lastSelectedRef === undefined` as its "uninitialized" sentinel
+(useFormSelector.ts:16,26,42). For a single watch of an **unset/`undefined`** field the
+selected slice is `undefined`, so the cache short-circuit never fires and the subscribe
+gate calls `onStoreChange` on every notification — i.e. `useWatch("optionalField")`
+re-renders on unrelated edits. `useField` avoids this (it returns an object, never
+`undefined`); `useWatch(name)` will hit it routinely.
+
+**Resolution (verified):** it does **not** over-render. React's `useSyncExternalStore`
+re-reads `getSnapshot` after each `onStoreChange` and bails via
+`Object.is(undefined, undefined)`, so an unset watched field produces zero extra renders.
+The only residual cost is a redundant `onStoreChange` + one cheap selector
+(`getNestedValue`) evaluation per unrelated change — **no observable behavior difference**
+(no extra renders). Because there is no behavioral delta, the sentinel "fix" (a
+module-private uninitialized marker in `useFormSelector`) would be an untestable
+micro-optimization, so it is **deferred** (YAGNI). The runtime test asserts the
+user-facing guarantee (no over-render); it does not — and need not — pin the internal
+selector churn.
+
+## Scope / non-goals (YAGNI)
+
+- No `disabled` option in v1 (pure ergonomic sugar).
+- No `defaultValue` option. RHF needs it because `useWatch` can render before `control`
+  registers the value; in el-form the value is already seeded from `useForm`'s
+  `defaultValues` at init, so the first render has the real value — the RHF reason does
+  not exist here.
+- Not a replacement for `useField`; no `error`/`touched` in the return.
+- Does not change `form.watch()`.
+
+## Testing
+
+TDD, hooks package (already has vitest + tsd wired):
+
+- **Runtime** (`useWatch.runtime.test.tsx`): watching `x` does not re-render when an
+  unrelated `y` changes; `useWatch(name)` reflects updates; `useWatch(names[])` and
+  `useWatch()` reflect updates and stay isolated via shallow/identity equality; throws
+  outside a `FormProvider`; **pin** the unset-field case — watch an unset field, change an
+  unrelated field, assert the watcher does not re-render (drives the sentinel fix if it
+  fails).
+- **Types** (`tsd.test-d.ts`): `useWatch("user.name")` is `string`; an array-index path
+  `useWatch("skills.0.name")` is `string` (distinct `PathValue` branch);
+  `useWatch(["email","age"])` is the keyed object `{ email: string; age: number }`;
+  `useWatch()` is `Partial<T>`; invalid path is a type error. Also add the parallel
+  keyed-object assertion for the existing `form.watch(["a","b"])` (currently untested at
+  the type level) to lock the shared inference.
+
+## Release
+
+Minor changeset for `el-form-react-hooks` (new hook). Short docs note mapping RHF
+`useWatch` → this hook and contrasting it with `useField`/`useFormSelector`.

--- a/packages/el-form-react-hooks/src/__tests__/useWatch.runtime.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/useWatch.runtime.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import React, { useRef } from "react";
+import { useForm, FormProvider, useWatch } from "..";
+
+beforeEach(cleanup);
+
+type Form = {
+  first: string;
+  last: string;
+  nick?: string;
+  user: { name: string };
+};
+
+const defaults = (): Form => ({ first: "", last: "", user: { name: "" } });
+
+// Memoized so the watcher re-renders ONLY via its own subscription, never just
+// because the form-owning App re-rendered.
+const Single = React.memo(function Single({ path }: { path: any }) {
+  const renders = useRef(0);
+  renders.current += 1;
+  const value = useWatch<Form, any>(path);
+  return (
+    <>
+      <div aria-label="single-renders">{renders.current}</div>
+      <div aria-label="single-value">{String(value ?? "")}</div>
+    </>
+  );
+});
+
+const Multi = React.memo(function Multi() {
+  const renders = useRef(0);
+  renders.current += 1;
+  const v = useWatch<Form, "first" | "last">(["first", "last"]);
+  return (
+    <>
+      <div aria-label="multi-renders">{renders.current}</div>
+      <div aria-label="multi-value">{JSON.stringify(v)}</div>
+    </>
+  );
+});
+
+const All = React.memo(function All() {
+  const v = useWatch<Form>();
+  return <div aria-label="all-value">{JSON.stringify(v)}</div>;
+});
+
+const Nested = React.memo(function Nested() {
+  const renders = useRef(0);
+  renders.current += 1;
+  const user = useWatch<Form, "user">("user");
+  return (
+    <>
+      <div aria-label="nested-renders">{renders.current}</div>
+      <div aria-label="nested-value">{JSON.stringify(user)}</div>
+    </>
+  );
+});
+
+function App({ children }: { children: React.ReactNode }) {
+  const form = useForm<Form>({ defaultValues: defaults() });
+  return (
+    <FormProvider form={form}>
+      {children}
+      <button aria-label="set-first" onClick={() => form.setValue("first", "ada")}>
+        first
+      </button>
+      <button aria-label="set-last" onClick={() => form.setValue("last", "byron")}>
+        last
+      </button>
+      <button aria-label="set-user" onClick={() => form.setValue("user.name", "carol")}>
+        user
+      </button>
+      <button aria-label="set-nick" onClick={() => form.setValue("nick", "nicky")}>
+        nick
+      </button>
+    </FormProvider>
+  );
+}
+
+describe("useWatch", () => {
+  it("useWatch(name) reflects updates to that field", () => {
+    render(
+      <App>
+        <Single path="first" />
+      </App>
+    );
+    expect(screen.getByLabelText("single-value").textContent).toBe("");
+    fireEvent.click(screen.getByLabelText("set-first"));
+    expect(screen.getByLabelText("single-value").textContent).toBe("ada");
+  });
+
+  it("useWatch(name) does not re-render when an unrelated field changes", () => {
+    render(
+      <App>
+        <Single path="first" />
+      </App>
+    );
+    const before = Number(screen.getByLabelText("single-renders").textContent);
+    fireEvent.click(screen.getByLabelText("set-last")); // unrelated
+    expect(Number(screen.getByLabelText("single-renders").textContent)).toBe(before);
+    fireEvent.click(screen.getByLabelText("set-first")); // related
+    expect(
+      Number(screen.getByLabelText("single-renders").textContent)
+    ).toBeGreaterThan(before);
+  });
+
+  it("useWatch(names[]) returns a keyed object and reflects updates", () => {
+    render(
+      <App>
+        <Multi />
+      </App>
+    );
+    expect(JSON.parse(screen.getByLabelText("multi-value").textContent!)).toEqual({
+      first: "",
+      last: "",
+    });
+    fireEvent.click(screen.getByLabelText("set-first"));
+    expect(JSON.parse(screen.getByLabelText("multi-value").textContent!)).toEqual({
+      first: "ada",
+      last: "",
+    });
+  });
+
+  it("useWatch() reflects all values", () => {
+    render(
+      <App>
+        <All />
+      </App>
+    );
+    expect(JSON.parse(screen.getByLabelText("all-value").textContent!).first).toBe("");
+    fireEvent.click(screen.getByLabelText("set-first"));
+    expect(JSON.parse(screen.getByLabelText("all-value").textContent!).first).toBe(
+      "ada"
+    );
+  });
+
+  it("throws when used outside a FormProvider", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<Single path="first" />)).toThrow(/FormProvider/);
+    spy.mockRestore();
+  });
+
+  it("does not over-render when watching an unset field and an unrelated field changes", () => {
+    // The watched slice is `undefined`; React's useSyncExternalStore bails via
+    // Object.is(undefined, undefined), so there is no extra render even though the
+    // store signals a potential change. (This asserts the user-facing guarantee —
+    // no over-render — not the internal selector call count.)
+    render(
+      <App>
+        <Single path="nick" />
+      </App>
+    );
+    const before = Number(screen.getByLabelText("single-renders").textContent);
+    fireEvent.click(screen.getByLabelText("set-first")); // unrelated; nick stays undefined
+    expect(Number(screen.getByLabelText("single-renders").textContent)).toBe(before);
+  });
+
+  it("reflects an unset field once it is set", () => {
+    render(
+      <App>
+        <Single path="nick" />
+      </App>
+    );
+    expect(screen.getByLabelText("single-value").textContent).toBe("");
+    fireEvent.click(screen.getByLabelText("set-nick"));
+    expect(screen.getByLabelText("single-value").textContent).toBe("nicky");
+  });
+
+  it("watches a whole nested object: re-renders on a child change, not on unrelated edits", () => {
+    render(
+      <App>
+        <Nested />
+      </App>
+    );
+    expect(JSON.parse(screen.getByLabelText("nested-value").textContent!)).toEqual({
+      name: "",
+    });
+    const before = Number(screen.getByLabelText("nested-renders").textContent);
+
+    // unrelated top-level edit: the `user` object reference is untouched → no re-render
+    fireEvent.click(screen.getByLabelText("set-first"));
+    expect(Number(screen.getByLabelText("nested-renders").textContent)).toBe(before);
+
+    // editing a child rebuilds the `user` reference → re-render with new value
+    fireEvent.click(screen.getByLabelText("set-user"));
+    expect(
+      Number(screen.getByLabelText("nested-renders").textContent)
+    ).toBeGreaterThan(before);
+    expect(JSON.parse(screen.getByLabelText("nested-value").textContent!)).toEqual({
+      name: "carol",
+    });
+  });
+
+  it("re-subscribes when the watched name changes between renders", () => {
+    function SwitchApp() {
+      const form = useForm<Form>({ defaultValues: { ...defaults(), last: "byron" } });
+      const [path, setPath] = React.useState<"first" | "last">("first");
+      return (
+        <FormProvider form={form}>
+          <Single path={path} />
+          <button aria-label="switch" onClick={() => setPath("last")}>
+            switch
+          </button>
+        </FormProvider>
+      );
+    }
+    render(<SwitchApp />);
+    expect(screen.getByLabelText("single-value").textContent).toBe(""); // first
+    fireEvent.click(screen.getByLabelText("switch"));
+    expect(screen.getByLabelText("single-value").textContent).toBe("byron"); // last
+  });
+});

--- a/packages/el-form-react-hooks/src/index.ts
+++ b/packages/el-form-react-hooks/src/index.ts
@@ -11,6 +11,7 @@ export {
 } from "./FormContext";
 export { useFormSelector } from "./useFormSelector";
 export { useField } from "./useField";
+export { useWatch } from "./useWatch";
 export { useFieldArray } from "./useFieldArray";
 export { shallowEqual } from "./utils";
 export type {

--- a/packages/el-form-react-hooks/src/useWatch.ts
+++ b/packages/el-form-react-hooks/src/useWatch.ts
@@ -1,0 +1,53 @@
+import { getNestedValue } from "el-form-core";
+import { useFormSelector } from "./useFormSelector";
+import { shallowEqual } from "./utils";
+import type { Path, PathValue } from "./types/path";
+import type { FormState } from "./types";
+
+/**
+ * Reactively subscribe to form value(s) by path. A reactive mirror of
+ * `form.watch()`'s overloads, built on the selector store so each watcher
+ * re-renders in isolation (via `useSyncExternalStore`). Must be used within a
+ * `FormProvider`.
+ *
+ * - `useWatch()` — all values.
+ * - `useWatch(name)` — a single path's value.
+ * - `useWatch(names)` — an object keyed by each path.
+ *
+ * Returns values only; use `useField` for `value + error + touched`, or
+ * `useFormSelector` for an arbitrary derived slice.
+ */
+// Overload order matters: the no-arg form must come LAST. A leading `<T>()`
+// overload otherwise captures any single explicit type argument and reports an
+// arg-count error for `useWatch<T, Name>(name)` calls.
+export function useWatch<T extends Record<string, any>, Name extends Path<T>>(
+  name: Name
+): PathValue<T, Name>;
+export function useWatch<T extends Record<string, any>, Names extends Path<T>>(
+  names: Names[]
+): { [K in Names]: PathValue<T, K> };
+export function useWatch<T extends Record<string, any>>(): Partial<T>;
+export function useWatch(nameOrNames?: Path<any> | Path<any>[]): unknown {
+  const isArray = Array.isArray(nameOrNames);
+
+  const selector = (s: FormState<any>) => {
+    if (typeof nameOrNames === "string") {
+      return getNestedValue(s.values, nameOrNames);
+    }
+    if (isArray) {
+      const out: Record<string, unknown> = {};
+      for (const name of nameOrNames as Path<any>[]) {
+        out[name as string] = getNestedValue(s.values, name);
+      }
+      return out;
+    }
+    return s.values;
+  };
+
+  // Single/all return a stable reference between unrelated renders, so Object.is
+  // is correct. The names[] form builds a fresh object each call, so it requires
+  // shallowEqual or getSnapshot would never be cached.
+  const equality = isArray ? shallowEqual : Object.is;
+
+  return useFormSelector(selector, equality as (a: unknown, b: unknown) => boolean);
+}

--- a/packages/el-form-react-hooks/tsd.test-d.ts
+++ b/packages/el-form-react-hooks/tsd.test-d.ts
@@ -1,5 +1,5 @@
 import { expectType, expectError } from "tsd";
-import { useForm, useFieldArray } from "./src";
+import { useForm, useFieldArray, useWatch } from "./src";
 
 // Compile-time assertions for Path and register typings
 // Intentionally in module scope so tsd executes checks
@@ -83,4 +83,32 @@ import { useForm, useFieldArray } from "./src";
   expectError(
     useFieldArray<{ a: string; list: number[] }, "a">({ name: "a" })
   );
+}
+
+{
+  // useWatch overload return types
+  type W = { email: string; age: number; user: { name: string }; skills: { name: string }[] };
+
+  // single path ⇒ value (both type args, like useField<T, Name>)
+  expectType<string>(useWatch<W, "email">("email"));
+  expectType<string>(useWatch<W, "user.name">("user.name"));
+
+  // array-index path (a distinct PathValue branch)
+  expectType<string>(useWatch<W, "skills.0.name">("skills.0.name"));
+
+  // multiple paths ⇒ keyed object
+  expectType<{ email: string; age: number }>(
+    useWatch<W, "email" | "age">(["email", "age"])
+  );
+
+  // no args ⇒ all values
+  expectType<Partial<W>>(useWatch<W>());
+
+  // invalid path is a type error
+  expectError(useWatch<W, "nope">("nope"));
+
+  // mirror: the existing imperative form.watch(names[]) keyed-object overload
+  // (previously untested at the type level — locks the shared inference)
+  const wf = useForm<W>({ defaultValues: { email: "", age: 0, user: { name: "" }, skills: [] } });
+  expectType<{ email: string; age: number }>(wf.watch(["email", "age"]));
 }


### PR DESCRIPTION
## What

Adds `useWatch`, a reactive hook for subscribing to form value(s) by path — for **React Hook Form parity** (RHF users reach for `useWatch` by name). It's a reactive mirror of the existing imperative `form.watch()`, built as a thin wrapper over `useFormSelector`, so each watcher re-renders in isolation via `useSyncExternalStore`.

```ts
const all   = useWatch<MyForm>();                       // Partial<MyForm>
const email = useWatch<MyForm, "email">("email");        // string
const pair  = useWatch<MyForm, "a" | "b">(["a", "b"]);   // { a: ...; b: ... }
```

Must be used within a `FormProvider`. **Returns values only** — `useField` stays the `value + error + touched` hook, `useFormSelector` the arbitrary-derived-slice tool, and `form.watch()` the imperative snapshot (all unchanged).

## Design notes

- **Equality:** single/all use `Object.is` (the slice ref is stable between unrelated renders); the `names[]` form uses `shallowEqual` — *required*, not an optimization, because that selector builds a fresh object each call (else `getSnapshot` never caches).
- **Overload order:** no-arg form is **last**. A leading `useWatch<T>()` overload otherwise captures the single explicit type arg and breaks `useWatch<T, Name>(name)` resolution. Path forms take both type args, consistent with `useField<T, Name>`.
- **Watch-all** re-renders on every value mutation (intended, matches RHF); error/touched-only updates preserve the `values` ref and don't trigger it.

## Verification

- **9 runtime tests**: re-render isolation, single/multi/all reflect updates, nested-object watch (re-renders on a child change, not unrelated edits), name switching between renders, unset→set, no over-render on an unset field, throws outside `FormProvider`.
- **tsd**: all three overload return types, nested + array-index paths, the keyed-object form, invalid-path error — plus the previously-untested `form.watch([...])` keyed-object inference.
- Gates: hooks runtime **116 passed**, tsd green, lint clean, `build:packages` success; umbrella + components unaffected.

Followed brainstorming → committed spec (`docs/superpowers/specs/2026-06-09-use-watch-hook-design.md`) → spec review → TDD. Independent implementation review: **SOUND** (overloads compiled, equality traced to source). One reviewer note — `useFormSelector`'s `undefined` sentinel causes a benign extra selector eval (no extra render) when watching an unset field; verified no observable impact, so the sentinel micro-opt is deferred (documented in the spec).

## Release

Minor changeset for `el-form-react-hooks` (dependents auto-patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)