### PR TITLE
docs(audit): competitor pain-point research for roadmap input

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,15 +116,20 @@ Detail lives in the linked docs.
 **From the competitor pain-point audit**
 ([`audits/2026-06-09-competitor-pain-points.md`](docs/superpowers/audits/2026-06-09-competitor-pain-points.md)):
 
-- [ ] **A — `Path<T>` TS-perf** — benchmark + harden the eager path type on deep/array
-      schemas (lazy path / `string` escape hatch). *Highest-value; also underpins the
-      agent-first bet.*
-- [ ] **B — Reactive external `values`** syncing (RHF's cached-`defaultValues` footgun).
+- [x] **A — `Path<T>` TS-perf** — ✅ **DONE** (PR #78, hooks 3.13.0 / components 4.7.0): bracket
+      trim → ~7.8× fewer instantiations at depth 6, now faster than RHF. Benchmark harness
+      shipped (PR #77). Future (own slice): depth-cap / lazy path for beyond-RHF perf.
+- [ ] **B — Reactive external `values`** syncing (RHF `values` prop + `resetOptions`). *Next feature.*
 - [ ] **C — Schema-aligned `undefined`/optional/nullable policy** (RHF's `undefined` footgun).
 - [ ] **D — First-class controlled-component story** (MUI/React-Select; beat RHF `Controller`).
-- [ ] **E — Prove the subscription-perf advantage** (render-count benchmark + perf doc).
+- [x] **E — Prove the subscription-perf advantage** — ✅ **DONE** (PR #77 render benchmark:
+      el-form 1/20 vs Formik 20/20; matches RHF controlled). Scope marketing claim to "vs Formik".
 - [ ] **F — Follow-up research** on a11y, async races, field-array correctness, cross-field
       validation (zero verified claims last pass).
+- [ ] **P2 — `formState` completeness** — add `isSubmitted`/`isSubmitSuccessful`/`submitCount`/
+      `isValidating` (+ reactive `dirtyFields`/`touchedFields`); RHF exposes 15 fields, el-form 6.
+- [ ] **P8 — Distinct input/output types** from schema transforms (`z.input`/`z.output`; RHF
+      resolvers v5 `useForm<Input,Ctx,Output>`). See parity audit.
 
 **From the agent-first positioning**
 ([`strategy/2026-06-09-agent-first-positioning.md`](docs/superpowers/strategy/2026-06-09-agent-first-positioning.md)):

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -119,15 +119,17 @@ Detail lives in the linked docs.
 - [x] **A — `Path<T>` TS-perf** — ✅ **DONE** (PR #78, hooks 3.13.0 / components 4.7.0): bracket
       trim → ~7.8× fewer instantiations at depth 6, now faster than RHF. Benchmark harness
       shipped (PR #77). Future (own slice): depth-cap / lazy path for beyond-RHF perf.
-- [ ] **B — Reactive external `values`** syncing (RHF `values` prop + `resetOptions`). *Next feature.*
+- [x] **B — Reactive external `values`** — ✅ **DONE** (PR #80, `el-form-react-hooks@3.14.0`):
+      `values` + `keepDirtyValues` options on `useForm` (RHF `values`+`resetOptions` parity).
 - [ ] **C — Schema-aligned `undefined`/optional/nullable policy** (RHF's `undefined` footgun).
 - [ ] **D — First-class controlled-component story** (MUI/React-Select; beat RHF `Controller`).
 - [x] **E — Prove the subscription-perf advantage** — ✅ **DONE** (PR #77 render benchmark:
       el-form 1/20 vs Formik 20/20; matches RHF controlled). Scope marketing claim to "vs Formik".
 - [ ] **F — Follow-up research** on a11y, async races, field-array correctness, cross-field
       validation (zero verified claims last pass).
-- [ ] **P2 — `formState` completeness** — add `isSubmitted`/`isSubmitSuccessful`/`submitCount`/
-      `isValidating` (+ reactive `dirtyFields`/`touchedFields`); RHF exposes 15 fields, el-form 6.
+- [~] **P2 — `formState` completeness** — ✅ **trio shipped** (PR #82, `@3.15.0`):
+      `isSubmitted`/`isSubmitSuccessful`/`submitCount`. **P2b remaining:** `isValidating`
+      (~8 async sites) + reactive `dirtyFields` (~14 `isDirty` sites) — each a fresh slice.
 - [ ] **P8 — Distinct input/output types** from schema transforms (`z.input`/`z.output`; RHF
       resolvers v5 `useForm<Input,Ctx,Output>`). See parity audit.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -101,10 +101,40 @@ These versions were published to npm and verified on 2026-06-09.
 
 ## Planned / under consideration
 
-No feature items are currently queued — the revival roadmap (correctness fixes, path-safe
-typing, `useFieldArray` + `useWatch`, accessibility, debounce, coverage, and CI
-modernization) is shipped. Further work is maintenance-driven or user-requested; see
-**Explicitly NOT planned** for parked scope.
+Candidate-stage, **not yet committed** — to be prioritized in the 2026-06-09 roadmap audit.
+Detail lives in the linked docs.
+
+**User-proposed:**
+
+- [ ] **Sandboxes / interactive playground** — live, embeddable el-form examples (docs +
+      marketing). Old `docs-sandbox` branch (PR #55, **closed**) is stale; start fresh, use
+      only for direction.
+- [ ] **React Query integration** — first-class data-fetching/mutation story. Old
+      `react-query-support` branch (PR #10, **closed**) is stale; restart fresh. (Moved from
+      *parked* to active candidate.)
+
+**From the competitor pain-point audit**
+([`audits/2026-06-09-competitor-pain-points.md`](docs/superpowers/audits/2026-06-09-competitor-pain-points.md)):
+
+- [ ] **A — `Path<T>` TS-perf** — benchmark + harden the eager path type on deep/array
+      schemas (lazy path / `string` escape hatch). *Highest-value; also underpins the
+      agent-first bet.*
+- [ ] **B — Reactive external `values`** syncing (RHF's cached-`defaultValues` footgun).
+- [ ] **C — Schema-aligned `undefined`/optional/nullable policy** (RHF's `undefined` footgun).
+- [ ] **D — First-class controlled-component story** (MUI/React-Select; beat RHF `Controller`).
+- [ ] **E — Prove the subscription-perf advantage** (render-count benchmark + perf doc).
+- [ ] **F — Follow-up research** on a11y, async races, field-array correctness, cross-field
+      validation (zero verified claims last pass).
+
+**From the agent-first positioning**
+([`strategy/2026-06-09-agent-first-positioning.md`](docs/superpowers/strategy/2026-06-09-agent-first-positioning.md)):
+
+- [ ] **D1 — Agent-first design principle** — fix `Path` perf (= A), expand `el-form-mcp`,
+      ship an "el-form with AI agents" guide.
+- [ ] **D2 — Preset AutoForm styles** — official themes + bring-your-own design API
+      (`componentMap` is the seed).
+- [ ] **D3 — Community form-design marketplace/dashboard** — *separate product, parked.*
+      Decompose: preset format → registry → builder UI → community layer.
 
 ## Design principles
 
@@ -116,10 +146,12 @@ modernization) is shipped. Further work is maintenance-driven or user-requested;
 
 ## Explicitly NOT planned (parked / out of scope)
 
-- **React Query integration** — exploratory work exists on the `react-query-support`
-  branch; **parked**, not shipped. (The old checklist wrongly claimed this was complete.)
 - Other frameworks (Vue / Svelte / Angular / React Native).
 - Analytics, devtools, rich-text/code editors, i18n, multi-step wizard components.
+
+> **React Query integration** moved from *parked* to an active **roadmap candidate**
+> (see Planned / under consideration) — to be (re)started fresh; the old
+> `react-query-support` branch (PR #10) is closed and stale.
 
 ## Known issues (open as of 2026-06-09)
 

--- a/docs/superpowers/audits/2026-06-09-competitor-pain-points.md
+++ b/docs/superpowers/audits/2026-06-09-competitor-pain-points.md
@@ -1,0 +1,234 @@
+# Competitor pain-point audit — React form libraries (2026-06-09)
+
+Verified pain points with **React Hook Form (RHF)**, **Formik**, **TanStack Form**, and
+**react-final-form**, scoured to inform el-form's roadmap. Each finding carries an
+**el-form lens**: does el-form already solve it, partly address it, or share/own the gap?
+
+## Method & confidence
+
+Deep-research harness: 6 search angles → 27 sources fetched → 118 claims extracted → top
+25 adversarially verified (3-vote, need 2/3 to refute) → 12 synthesized findings.
+**25/25 claims confirmed, 0 refuted.** Sources are overwhelmingly primary (GitHub
+issues/discussions, official docs). Full machine output + per-claim votes:
+the `deep-research` run on 2026-06-09 (run `wf_7424e366-7d9`).
+
+**el-form lens legend:** ✅ already a strength · 🟡 partial / needs validation ·
+🔴 gap or shared risk · ⚪ not applicable.
+
+**Coverage caveat:** accessibility, async-validation races, field-array
+reset/dirty/touched correctness, and schema cross-field validation were in the brief but
+produced **zero surviving verified claims this pass** — that's a sourcing gap, *not*
+evidence those problems are absent. They warrant a dedicated follow-up (see
+[§5](#5-not-covered-this-pass--follow-up-research)).
+
+---
+
+## 1. TypeScript path typing (the strongest cross-library theme)
+
+### 1.1 🔴 RHF's eager `Path`/`FieldPath` enumeration melts the type-checker — and el-form shares it
+**Affects:** RHF (severe, 2021–2025) · **el-form shares the pattern.**
+RHF eagerly enumerates every field path into one giant string-literal union. On
+nested/array-heavy schemas this makes "simple changes take seconds… IntelliSense
+becomes unusable" ([#7290](https://github.com/react-hook-form/react-hook-form/issues/7290)),
+and a triple-nested array of objects can make "Node run out of heap memory even with 8gb"
+([#4237](https://github.com/react-hook-form/react-hook-form/issues/4237)). It's bad enough
+that RHF is **replacing `Path` with a lazy implementation in V8**
+([discussion #7389](https://github.com/orgs/react-hook-form/discussions/7389)) — "necessary
+rather than optional." RHF's source file is literally `src/types/path/eager.ts`.
+
+> **el-form lens — 🔴 SHARED RISK (highest-value finding for us).** el-form's `Path<T>`
+> (`packages/el-form-react-hooks/src/types/path.ts:34-42`) uses the *same* eager recursive
+> enumeration, and for array fields emits **both** `${K}.${number}` and `${K}[${number}]`
+> forms — roughly *doubling* the array-path union vs RHF. So el-form likely hits the same
+> wall on deep/array-heavy schemas; it's just gone unnoticed because no one has stress-tested
+> it. **Roadmap candidate:** (a) benchmark `Path<T>` on a deliberately deep/array-heavy
+> schema and measure `tsc` time/memory; (b) if it degrades, move toward a lazy/on-demand path
+> type (resolve `PathValue` per-access instead of pre-enumerating the union) and/or accept a
+> plain `string` escape hatch. This is a chance to *beat* RHF V8, not just match it.
+
+### 1.2 🔴 RHF path IntelliSense lists suggestions alphabetically, not by nesting — el-form too (minor)
+**Affects:** RHF (minor, niche) · **el-form shares.**
+Typing `foo` surfaces `foo.foo` only ~5th because suggestions are alphabetical
+([#7389](https://github.com/orgs/react-hook-form/discussions/7389)). A structural
+consequence of string-literal-union paths.
+
+> **el-form lens — 🔴 SHARED, low priority.** Same union structure → same ordering. Only
+> worth addressing if/when 1.1 prompts a path-typing rework.
+
+### 1.3 ✅ TanStack Form's "9 generics per form" — el-form avoids this
+**Affects:** TanStack Form (high, v0.43.0+).
+TanStack swung to the opposite extreme: `useForm`/`FormApi` went from 1 generic to **9
+required generics**, even with no validation — a user called wrapping MUI components "a
+complete flustercluck" ([#1175](https://github.com/TanStack/form/issues/1175)).
+
+> **el-form lens — ✅ AVOIDED.** `useForm<T>` takes one generic; **AutoForm infers
+> everything from the schema**. We never expose a generics pile. Minor note: `useField<T,
+> Name>` / `useWatch<T, Name>` need explicit `T` + path at leaf call sites — far from 9, but
+> a "infer `T` from context" improvement is conceivable later.
+
+---
+
+## 2. Re-render / subscription granularity (el-form's home turf)
+
+### 2.1 ✅ Formik re-renders the whole form per keystroke, and `FastField` isolation is broken
+**Affects:** Formik (high; the single strongest signal in the report).
+Formik uses one context that re-renders on every keystroke ("rendering 3 times… at every
+keyboard press" [#1062](https://github.com/jaredpalmer/formik/issues/1062)). Its only
+isolation primitive, `FastField`, **demonstrably fails**: "Type in the top input (normal
+Field). You'll see the bottom input (FastField) rerender"
+([#2335](https://github.com/jaredpalmer/formik/issues/2335)). The desired behavior — "a
+field re-renders only on state directly relevant to it" — is precisely selector isolation.
+
+> **el-form lens — ✅ SOLVED, core differentiator.** `useField` / `useFormSelector` /
+> `useWatch` subscribe via `useSyncExternalStore` and re-render only on their slice. This is
+> the headline advantage. **Roadmap candidate:** make it provable — a benchmark/demo
+> (render-count comparison vs Formik/RHF on a large form) and a perf concept doc that leads
+> with it.
+
+### 2.2 ✅ Formik has no performant default — large forms need manual `withFormik` + `shouldComponentUpdate`
+**Affects:** Formik (high).
+The OP had to abandon `<Formik/>` for the `withFormik()` HOC to reference-compare
+`nextProps.values === this.props.values`
+([#1062](https://github.com/jaredpalmer/formik/issues/1062)). Performance is opt-in and
+error-prone.
+
+> **el-form lens — ✅ SOLVED.** Granular subscription is the *default*; no HOC/SCU gymnastics.
+
+### 2.3 🟡 RHF: reading `formState.errors` / `watch()` at the form root re-renders the whole tree
+**Affects:** RHF (high, by-design Proxy footgun).
+"Using `formState.errors` in the main form, or even in any component under `FormProvider`
+by `useFormContext`, will trigger re-renders to all related components"
+([#12578](https://github.com/react-hook-form/react-hook-form/issues/12578),
+[discussion #8117](https://github.com/orgs/react-hook-form/discussions/8117)). Correct
+scoping exists but is opt-in and easy to get wrong.
+
+> **el-form lens — 🟡 BETTER, with a nuance.** el-form has no hidden Proxy-subscription
+> footgun — subscriptions are *explicit* (`useFormSelector`/`useField`/`useWatch`) and
+> isolated. **But** the component that calls `useForm` re-renders on every state change
+> (`useState`-based), and a direct `form.formState` read re-renders that component. The
+> recommended pattern (selector hooks) avoids whole-tree re-renders. **Roadmap candidate:**
+> document this clearly in a perf guide; consider whether the `useForm` owner can avoid
+> re-rendering on every change (it's the one spot el-form still behaves like "read state at
+> root → re-render").
+
+### 2.4 🟡 RHF treats controlled UI libraries (MUI, React-Select, AntD) as second-class via `Controller` — verbose and slow
+**Affects:** RHF (high).
+RHF's own docs concede it "embraces uncontrolled components… however it's hard to avoid
+working with external controlled component such as React-Select, AntD and MUI" — each needs
+a `Controller` wrapper ([docs](https://www.react-hook-form.com/api/usecontroller/controller/)),
+and in large dynamic forms "input content update is very slowly"
+([#8117](https://github.com/orgs/react-hook-form/discussions/8117),
+[antd #18411](https://github.com/ant-design/ant-design/issues/18411)).
+
+> **el-form lens — 🟡 POTENTIAL ADVANTAGE, unproven.** `useField(name)` already returns a
+> controlled `{ value, error, touched }` slice usable with any controlled component — no
+> `Controller` wrapper needed. **Roadmap candidate:** prove/strengthen this with first-class
+> controlled-input adapters or worked examples (MUI / React-Select) + a perf check, and make
+> "controlled components are first-class" an explicit selling point.
+
+---
+
+## 3. Correctness footguns — `defaultValues` / `undefined`
+
+### 3.1 🟡 RHF caches `defaultValues` on first render → `reset` fails for prop-derived/dynamic values
+**Affects:** RHF (high; bites controlled components like MUI checkboxes).
+Static `defaultValues` reset fine, but prop-derived dynamic ones don't apply after first
+render ([#1558](https://github.com/react-hook-form/react-hook-form/issues/1558)); a
+maintainer confirms it's by design ("use `reset` or `setValue`… in the future"). RHF later
+added a `values` prop for reactive data.
+
+> **el-form lens — 🟡 LIKELY SHARED — VERIFY.** `useForm` seeds `useState` from
+> `defaultValues` once; a later change to the `defaultValues` prop almost certainly doesn't
+> re-sync (same as RHF pre-`values`). **Roadmap candidate:** a first-class reactive/external
+> `values` story (sync form state to changing external data), which a schema-driven library
+> can make clean. *Action: confirm current el-form behavior with a test before roadmapping.*
+
+### 3.2 🟡 RHF's `undefined` footgun: `undefined` is not a valid default or cleared value
+**Affects:** RHF (high).
+"`undefined` is not a valid value… use `null` or the empty string"
+([Controller docs](https://www.react-hook-form.com/api/usecontroller/controller/)).
+`field.onChange(undefined)` reverts to default (closed NOT PLANNED,
+[#12668](https://github.com/react-hook-form/react-hook-form/issues/12668)); optional `File`
+fields are forced to `File | null`
+([#10325](https://github.com/react-hook-form/react-hook-form/issues/10325)).
+
+> **el-form lens — 🟡 OPPORTUNITY.** el-form is schema-driven, so it *could* tie
+> undefined/optional/nullable semantics to the schema (optional field ↔ `undefined` is fine).
+> Today el-form is loose here (e.g. number inputs return `undefined` for empty). **Roadmap
+> candidate:** a deliberate, schema-aligned undefined/optional/nullable policy — a clean
+> differentiator vs RHF's "never undefined" rule.
+
+### 3.3 ⚪ RHF `Controller` `defaultValue`-vs-`value` confusion
+**Affects:** RHF (medium, recurring API-misuse).
+A `Controller` default/reset report was closed "not valid" — use `value`/`checked`, not
+`defaultValue` in render props ([#2824](https://github.com/react-hook-form/react-hook-form/issues/2824)).
+
+> **el-form lens — ⚪ N/A.** No `Controller`, so no default/value split. Avoided by design.
+
+---
+
+## 4. Maintenance & API stability
+
+### 4.1 ⚪/✅ Formik is widely *perceived* as abandoned → people migrate to RHF
+**Affects:** Formik (medium; perception, with a caveat).
+"i thought this would be well maintained but this got abandoned"
+([#3663](https://github.com/jaredpalmer/formik/issues/3663), 12 👍). **Caveat:** a new
+maintainer defended it in-thread and 23/35 reactions were "confused" — so this is strong
+*perception* + an RHF-migration recommendation, not uncontested fact.
+
+> **el-form lens — ⚪ N/A / ✅ POSITIONING.** Not a feature gap. el-form is actively
+> maintained and already ships an RHF/Formik [migration guide](../../docs/guides/migration.md)
+> — lean into "maintained + drop-in-friendly."
+
+### 4.2 ✅ TanStack Form shipped breaking changes during its "stable" RC, incl. removing `form.useField`/`form.useStore` for Rules-of-Hooks violations
+**Affects:** TanStack Form (high, pre-v1).
+"we'll have a few breaking changes during our RC stable phase"; `form.useField` and
+`form.useStore` were removed because they "do not follow the rules of React Hooks" (surfaced
+by the React Compiler) ([#1044](https://github.com/TanStack/form/issues/1044)).
+
+> **el-form lens — ✅ AVOIDED — keep it that way.** el-form's `useField`/`useFormSelector`/
+> `useWatch` are standard, unconditional, Rules-of-Hooks-compliant hooks (verified for
+> `useWatch`). The lesson: never ship `form.useX()` dynamic hooks. Already aligned.
+
+---
+
+## 5. Not covered this pass — follow-up research
+
+The brief asked about these, but **no claims survived verification** (sourcing gap, not
+absence of problems). el-form already has partial coverage; targeted research would find
+the specific complaints to beat:
+
+- **Accessibility** — zero surviving claims across all four libs. el-form already wires
+  `aria-invalid`/`describedby`/`required` + `role="alert"` + focus-on-error. *Is a11y an
+  under-served differentiation axis? Worth a dedicated pass.*
+- **Async-validation races** — named in the brief (e.g. RHF
+  [#10078](https://github.com/react-hook-form/react-hook-form/issues/10078)) but unverified
+  here. el-form has `asyncDebounceMs` + the resolved superseded-promise fix.
+- **Field-array reset/dirty/touched correctness** (beyond perf) — uncharacterized this pass.
+  el-form has `useFieldArray` with stable ids.
+- **Schema cross-field / conditional validation** (e.g. password-match, Zod `superRefine`
+  reactivity — [resolvers #661](https://github.com/react-hook-form/resolvers/issues/661)) —
+  unverified here; relevant to el-form's schema-agnostic validation.
+- **react-final-form** — produced *no* surviving claims (low traffic / underweighted in the
+  fan-out). Known pain (subscription verbosity, maintenance) remains uncharacterized.
+
+---
+
+## 6. Candidate roadmap items (for the roadmap audit)
+
+Distilled from the lens above — **not yet prioritized**; inputs for the joint audit.
+
+| # | Candidate | Source finding | el-form status | Rough size |
+|---|-----------|----------------|----------------|-----------|
+| A | **Benchmark & harden `Path<T>` TS perf** on deep/array schemas; consider lazy path / `string` escape hatch | 1.1 | 🔴 shared risk | M–L (investigate first) |
+| B | **Reactive external `values`** (sync to changing props/data) | 3.1 | 🟡 verify | M |
+| C | **Schema-aligned undefined/optional/nullable policy** | 3.2 | 🟡 opportunity | S–M |
+| D | **First-class controlled-component story** (MUI/React-Select adapters + examples + perf) | 2.4 | 🟡 unproven advantage | M |
+| E | **Prove the subscription-perf advantage** (render-count benchmark vs Formik/RHF + perf doc) | 2.1/2.2/2.3 | ✅ strength to showcase | S |
+| F | **Follow-up research pass** on a11y, async races, field-array correctness, cross-field validation | §5 | unknown | S (research) |
+
+**Strongest signals:** el-form's selector-subscription model already answers the biggest
+cross-library complaint (re-render granularity — items E), and its **biggest latent risk is
+the eager `Path<T>` TS-perf cliff it inherited from the same approach RHF is now abandoning**
+(item A). Those two — showcase the strength, de-risk the shared weakness — are the most
+roadmap-relevant.

--- a/docs/superpowers/audits/2026-06-09-feature-parity-and-roadmap-audit.md
+++ b/docs/superpowers/audits/2026-06-09-feature-parity-and-roadmap-audit.md
@@ -1,0 +1,113 @@
+# Feature parity + roadmap audit (2026-06-09)
+
+Two questions: (1) is el-form's feature set **up to date with modern form libraries**?
+(2) given everything we've gathered, **what should we build next?** Pairs with the
+[pain-point audit](2026-06-09-competitor-pain-points.md) and the
+[agent-first positioning](../strategy/2026-06-09-agent-first-positioning.md).
+
+## Confidence
+
+el-form's side is **verified against the code** (types + `el-form-core`). The competitors'
+side is from current knowledge + the verified pain-point research. The one fast-moving target
+(TanStack Form's exact v1 surface) is from training knowledge — a short dedicated research
+pass would harden it, but the parity verdict below rests on stable, well-known APIs and
+doesn't hinge on it.
+
+## Part 1 — Feature parity
+
+### Verdict: at or above parity, ahead on several axes
+
+el-form is **not behind** modern libraries on core capability. It leads on accessibility,
+file handling, subscription granularity, schema-driven generation, agent tooling, and —
+verified this audit — **Standard Schema** support. The gaps are a short list of mostly-minor
+RHF-isms.
+
+| Capability | el-form | RHF | Formik | TanStack | Final Form |
+|---|---|---|---|---|---|
+| Field registration / native inputs | ✅ `register` | ✅ | ✅ | ✅ | ✅ |
+| Imperative API (setValue/reset/trigger/setError…) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Field arrays | ✅ `useFieldArray` | ✅ | ✅ | ✅ | ✅ |
+| Granular subscriptions (per-field re-render) | ✅ **default** (`useField`/`useFormSelector`/`useWatch`) | 🟡 opt-in | ❌ broken `FastField` | ✅ | ✅ verbose |
+| Schema-agnostic validation (Zod/Yup/Valibot/fn) | ✅ | 🟡 via resolvers | 🟡 Yup-first | ✅ | ❌ |
+| **Standard Schema** support | ✅ (`adapters.ts`) | ✅ (resolvers) | ❌ | ✅ | ❌ |
+| Async + debounced validation | ✅ | ✅ | 🟡 | ✅ | ✅ |
+| Field + form + schema validation levels | ✅ | ✅ | 🟡 | ✅ | ✅ |
+| **Zero-config form generation** | ✅ **AutoForm** | ❌ | ❌ | ❌ | ❌ |
+| First-class **file uploads** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Accessibility** built in (aria + role=alert + focus) | ✅ | 🟡 manual | 🟡 manual | 🟡 | 🟡 |
+| **Agent tooling** (MCP server + llms.txt) | ✅ unique | ❌ | ❌ | ❌ | ❌ |
+| Discriminated unions / conditional fields | ✅ `FormSwitch` | 🟡 manual | 🟡 manual | 🟡 | 🟡 |
+| Path-typed API (`Path<T>`/`PathValue`) | ✅ (perf caveat — see audit 1.1) | ✅ (same caveat) | 🟡 | ✅ | 🟡 |
+| Typed errors | ✅ string-per-field | object | object | object | object |
+| Reactive **external `values`** (sync to changing props) | ❌ **gap** | ✅ `values` prop | ✅ `enableReinitialize` | ✅ | ✅ |
+| `formState`: isSubmitted / submitCount / isValidating | ❌ **gap** (has isSubmitting/isValid/isDirty) | ✅ | ✅ | ✅ | 🟡 |
+| `getValues` (non-reactive read) | 🟡 via `watch()` | ✅ | ✅ `getFieldProps` | ✅ | ✅ |
+| `unregister` / `shouldUnregister` | ❌ gap (niche) | ✅ | 🟡 | ✅ | ✅ |
+| Form/field-level `disabled` | ❌ gap (minor) | ✅ | 🟡 | ✅ | 🟡 |
+| Multiple errors per field (`criteriaMode: all`) | ❌ (string-per-field by design) | ✅ opt-in | ✅ | ✅ | ✅ |
+| DevTools | ❌ (parked) | ✅ | ❌ | ✅ | ❌ |
+
+### Parity gaps, ranked
+
+- **P1 — Reactive external `values`** *(real, common)* — the one gap users actually hit
+  (prop-derived defaults, server-data sync). **Same as audit item B.**
+- **P2 — `formState` completeness** *(minor)* — add `isSubmitted`, `isSubmitSuccessful`,
+  `submitCount`, `isValidating`. Cheap; closes RHF-familiarity gaps.
+- **P3 — `getValues` alias** *(trivial)* — alias over `watch()` for RHF muscle memory.
+- **P4 — `disabled` (form/field)** *(minor)*.
+- **P5 — `unregister` / `shouldUnregister`** *(niche)*.
+- **P6 — `criteriaMode: "all"`** *(design choice)* — string-per-field intentionally precludes
+  multi-error; revisit only if users ask.
+- **P7 — DevTools** *(parked)* — low value in the agent era (agents read types/tests, not a
+  visual panel); skip unless a human-DX push wants it.
+
+> **Takeaway:** the parity check is *reassuring* — no major capability is missing. P2–P4 are a
+> cheap "RHF-parity polish" bundle; P1 is already a roadmap candidate (B). Nothing here forces
+> a large new slice. A dedicated competitor-feature research pass is **optional** (would mainly
+> validate TanStack v1 specifics), not required.
+
+## Part 2 — Roadmap audit (prioritized)
+
+All candidates: user-proposed (sandboxes, react-query), pain-point audit (A–F),
+positioning (D1–D3), parity (P1–P7). Prioritized by **leverage ÷ effort ÷ regret**, weighted
+toward the agent-first bet.
+
+### Tier 1 — do first (low-regret, high-leverage)
+- **★ Benchmark harness (A + E together).** Measure `tsc` time/memory of `Path<T>` on a
+  deliberately deep/array-heavy schema (**A** — the latent risk that undercuts the agent-first
+  bet, since agents validate via `tsc`) **and** render-count vs Formik/RHF on a large form
+  (**E** — proves the #1 strength for marketing). One reusable harness answers both. **This is
+  the recommended first slice:** it's small, de-risks the biggest unknown, and produces
+  engineering + marketing evidence before we commit to bigger work.
+  - Follow-on, *conditional on results*: if `Path<T>` degrades → **A: harden it** (lazy path /
+    `string` escape hatch). If it's fine → document the limit and move on.
+
+### Tier 2 — high-value features
+- **B / P1 — Reactive external `values`** — the one real parity gap; schema-driven sync story.
+- **D2 — Preset AutoForm styles** — visible value ("generated forms don't look generated"),
+  enables D3, strong marketing; `componentMap` is the seed.
+
+### Tier 3 — polish & parity completeness (bundle-able)
+- **P2–P4 — RHF-parity polish** — `formState` completeness + `getValues` alias + `disabled`.
+  One small slice, closes familiarity gaps, eases migration.
+- **C — Schema-aligned undefined/optional/nullable policy.**
+- **D (story) — First-class controlled components** (MUI/React-Select adapters + examples).
+
+### Tier 4 — larger / later / parked
+- **Sandboxes** — interactive playground (docs + marketing); restart fresh.
+- **React Query integration** — needs its own design (data-fetch/mutation story); restart fresh.
+- **F — Follow-up research** (a11y, async races, field-array correctness, cross-field).
+- **D3 — Community marketplace** — separate product; parked; decompose before any build.
+- **P5–P7** — `unregister`, `criteriaMode: all`, DevTools — only on demand.
+
+### Recommendation
+Start with the **Tier-1 benchmark harness (A + E)**. It's the single highest-leverage,
+lowest-regret move: it tells us whether `Path<T>` is actually a problem (the answer reshapes
+A/D1), it produces the perf evidence the agent-first article and positioning need (E), and the
+harness is reusable for every future perf claim. Then take **B (reactive values)** as the first
+*feature* slice, and **D2 (preset styles)** as the first *visible/marketing* slice.
+
+## Decision needed
+1. Confirm the **benchmark harness (A + E)** as the first slice — or pick a different start.
+2. Want a short **competitor-feature research pass** to harden the parity matrix (mainly
+   TanStack v1), or is the code-verified verdict above enough to proceed?

--- a/docs/superpowers/audits/2026-06-09-feature-parity-and-roadmap-audit.md
+++ b/docs/superpowers/audits/2026-06-09-feature-parity-and-roadmap-audit.md
@@ -107,7 +107,57 @@ A/D1), it produces the perf evidence the agent-first article and positioning nee
 harness is reusable for every future perf claim. Then take **B (reactive values)** as the first
 *feature* slice, and **D2 (preset styles)** as the first *visible/marketing* slice.
 
-## Decision needed
-1. Confirm the **benchmark harness (A + E)** as the first slice — or pick a different start.
-2. Want a short **competitor-feature research pass** to harden the parity matrix (mainly
-   TanStack v1), or is the code-verified verdict above enough to proceed?
+## Research validation (2026-06-09 feature-inventory pass)
+
+A dedicated deep-research pass (25 claims → **22 confirmed, 3 refuted**) validated the parity
+matrix and sharpened the gaps.
+
+**Confirmed:**
+- **Standard Schema ✅ already shipped** (`el-form-core/src/validators/adapters.ts`) — RHF gained
+  it only via `@hookform/resolvers` v4 (`standardSchemaResolver`, Feb 2025); TanStack v1 has it
+  natively; Formik / Final-Form lack it. el-form is at parity with the leaders, ahead of the
+  laggards.
+- **Selector subscriptions are the modern convergence** — TanStack v1 is selector-first
+  (`useStore(form.store, selector)`, `form.Subscribe`); RHF uses a Proxy-wrapped `formState`.
+  el-form's `useField` / `useFormSelector` / `useWatch` are the same shape. ✅
+- **Formik is frozen** (2.4.9, patch-only) — el-form competes with RHF + TanStack on modern
+  features, not Formik.
+- Field arrays, per-trigger field+form validators, and debounced async are all el-form ✅.
+
+**Gaps sharpened / newly surfaced (folded into candidates):**
+- **P2 is bigger than first scored** — RHF's `formState` exposes **15** fields (isDirty,
+  dirtyFields, touchedFields, defaultValues, isSubmitted, isSubmitSuccessful, isSubmitting,
+  isLoading, submitCount, isValid, isValidating, validatingFields, errors, disabled, isReady)
+  vs el-form's **6**. el-form has `getDirtyFields()`/`getTouchedFields()` as *methods* but not
+  reactive `formState` fields, and lacks `isSubmitted`/`isSubmitSuccessful`/`submitCount`/
+  `isValidating`. → upgrade P2 to a solid Tier-3 item.
+- **B / P1 confirmed** — RHF `values` prop + `resetOptions` (KeepStateOptions: `keepDirtyValues`,
+  `keepErrors`, …). el-form has no reactive external-values path.
+- **P8 (new) — distinct input/output types from schema transforms.** RHF resolvers v5 moved to
+  `useForm<Input, Context, Output>()`, so a Zod `.transform()` yields different submit vs field
+  types (`z.input` vs `z.output`). el-form infers a single `T`; a schema-first library is now
+  expected to distinguish. New Tier-3 candidate — worth a design look.
+- **P9 (new) — `mode: "onTouched"` + `reValidateMode`.** el-form's `mode` has
+  onChange/onBlur/onSubmit/all but not `onTouched`, and there's no separate post-submit
+  `reValidateMode`. Small parity item.
+- **Field-meta granularity (minor)** — TanStack exposes per-field `isPristine`/`isBlurred`/
+  `isDefaultValue`/`isValidating`; el-form's `useField` gives value/error/touched. Nice-to-have.
+
+**Still uncovered (zero verified claims — *not* absences):** react-final-form's current API,
+SSR/RSC official support, `unregister`/`shouldUnregister`, `criteriaMode`, devtools. A future
+targeted pass (candidate F) could close these.
+
+**Net:** the verdict holds — el-form is at/above parity, ahead on a11y / files / AutoForm /
+agent tooling / Standard Schema. The actionable additions are **P2 (formState completeness),
+B/P1 (reactive values), and P8 (input/output typing)**.
+
+## Status (resolved)
+
+- ✅ **Benchmark harness (A + E)** shipped (PR #77).
+- ✅ **A — `Path<T>` perf — FIXED** (PR #78): el-form now type-checks faster than RHF (~7.8×
+  fewer instantiations at depth 6); published in `el-form-react-hooks@3.13.0` /
+  `el-form-react-components@4.7.0`.
+- ✅ **Competitor-feature research pass** ran and is folded in above.
+
+**Next slices** per the tiers: **B / P1 reactive external `values`** (feature) and **D2 preset
+AutoForm styles** (visible/marketing); **P2 formState completeness** is a strong Tier-3 follow.

--- a/docs/superpowers/strategy/2026-06-09-agent-first-positioning.md
+++ b/docs/superpowers/strategy/2026-06-09-agent-first-positioning.md
@@ -1,0 +1,94 @@
+# Marketability & positioning — the agent-first form library (2026-06-09)
+
+The strategic bet for el-form, the differentiators that back it, the honest gaps that
+threaten it, and the product directions that extend it. Pairs with the
+[competitor pain-point audit](../audits/2026-06-09-competitor-pain-points.md).
+
+## The bet
+
+**Software is increasingly written by agents, not typed by hand.** An agent's build loop
+is: generate code → run the type-checker → run tests → read the failures → fix → repeat.
+A form library either *helps* that loop or *fights* it. The library that wins the agentic
+era is the one an agent can **generate correctly on the first try and self-verify** — while
+staying excellent for the humans who still build forms by hand.
+
+el-form makes that bet explicitly: **be the form library agents reach for, without
+punishing the people who don't use agents.** Form libraries aren't going obsolete — the
+*winner* is just being decided on a new axis: agent-generatability + self-verifiability.
+
+## Why el-form is positioned to win (each tied to a competitor's weakness)
+
+| el-form strength | Why it's agent-perfect | Competitor weakness it beats |
+|---|---|---|
+| **Schema is the single source of truth** — Zod/Yup/Valibot/fn → types + validation + (via AutoForm) the whole form | The agent writes one schema; everything else is inferred. Nothing to keep in sync, no generics to thread. | TanStack Form forces **9 generics** per form — an agent must satisfy all 9 or `tsc` fails its validation step ([audit 1.3](../audits/2026-06-09-competitor-pain-points.md)). |
+| **AutoForm** — schema in, working validated form out | An agent emits a schema + `<AutoForm>` and is done; minimal surface to get wrong. | RHF/Formik need hand-wired fields, `Controller` wrappers, boilerplate the agent can misuse. |
+| **`el-form-mcp`** (`npx el-form-mcp`) — real MCP tools: `scaffold_form`, `get_topic`, `search` | The agent gets *tools*, not guesses — it scaffolds a correct component + matching schema. | **No other major form library ships an MCP server.** |
+| **`llms.txt` + `llms-full.txt`** | The agent reads the *real* API in one gulp instead of hallucinating one. | None of RHF/Formik/TanStack/Final Form publish machine-readable docs. |
+| **"The error is the message"** — `errors.email` is a string | Less nested structure for the agent (or human) to render wrong; no `.message` dance. | RHF/Formik errors are objects; a common agent mistake. |
+| **Validator-agnostic** | The agent uses whatever schema lib the codebase already has; el-form doesn't impose one. | RHF's resolver layer, Formik's Yup-marriage. |
+| **Selector-subscription performance by default** | Correct-by-default perf; the agent doesn't need to know `FastField`/`Controller`/memo tricks. | Formik's broken `FastField`; RHF's "read `formState` at root → re-render the tree" ([audit §2](../audits/2026-06-09-competitor-pain-points.md)). |
+
+## The honest gap that threatens the bet (must-fix)
+
+🔴 **el-form's `Path<T>` uses the same eager path-enumeration RHF is ripping out in V8**
+(`packages/el-form-react-hooks/src/types/path.ts:34-42`), and *doubles* array-path unions
+by emitting both `.0` and `[0]` forms. RHF's version melts `tsc` and OOMs an 8GB heap on
+deep/array-heavy schemas ([audit 1.1](../audits/2026-06-09-competitor-pain-points.md)).
+
+This directly undercuts the agent-first promise: **an agent validates its work by running
+the type-checker. If `tsc` is slow or explodes on a realistic nested schema, el-form fights
+the agent exactly where we claim to help it.** De-risking `Path<T>` (benchmark → lazy path
+/ `string` escape hatch) is therefore not just a perf nicety — it's load-bearing for the
+positioning. **This is the #1 roadmap-relevant item.** Until it's measured/fixed, the
+article below should not claim el-form's types are faster than RHF's.
+
+## Principle: don't punish hand-coders
+
+The agent-first push must not make el-form worse for humans. The dual API already protects
+this: **AutoForm** for zero-boilerplate (agents + the 80% case), **useForm** for full
+imperative control (humans who need every pixel). Agent-first = *also* great for agents, not
+*only* for agents. Any agent-oriented feature must keep or improve the hand-coding path.
+
+## Product directions
+
+Captured for the roadmap audit. Scope/effort flagged; **not yet prioritized or committed.**
+
+### D1 — Agent-first as a first-class design principle (near-term, incremental)
+Make "an agent can build a correct el-form and self-verify" an explicit product goal:
+- **Fix the `Path<T>` TS-perf risk** (see gap above) — prerequisite.
+- **Expand `el-form-mcp`** tools (e.g. validate-a-schema, explain-a-validation-error,
+  scaffold AutoForm + presets) and keep `llms.txt` fresh as the API grows.
+- **Structured, actionable validation feedback** an agent can parse and act on.
+- An **"Using el-form with AI agents" doc** + the article below as the public artifact.
+
+### D2 — Preset AutoForm styles (medium; the user's idea #2)
+Plug-and-play visual designs for AutoForm so generated forms don't "look generated."
+- **Official preset themes** — ship a curated set (with el-form or a separate
+  `el-form-themes` package) the user designs: e.g. minimal, card, inline, dense.
+- **Bring-your-own design API** — a clean, documented way to define a theme/field-renderer
+  set and pass it to AutoForm (`componentMap` already exists as a seed).
+- Agent angle: an agent picks a preset by name — `<AutoForm theme="card">` — instead of
+  hand-styling.
+
+### D3 — Community form-design marketplace / dashboard (large; separate product; idea #3)
+A platform where users build forms in a UI, save presets, and share/submit designs —
+"Obsidian community plugins" for el-form. **This is a separate product, not a library
+feature**, and should be decomposed before any build:
+- **(a) Design/preset format + registry** — a serializable form-design format (builds on
+  D2's theme API) and a registry/index. *This is the library-adjacent enabler and the
+  sensible first slice.*
+- **(b) Builder UI / dashboard** — sign up, compose a form visually, export to el-form
+  code or save a preset.
+- **(c) Community layer** — share, reuse, submit, rate, "add to your personal package."
+- **Sequencing:** D2 (preset format) is the foundation; (a) the registry; then (b) the
+  builder; then (c) community. Don't start at (b)/(c). Revisit only if the user wants to
+  pursue a product beyond the library.
+
+## Roadmap implications (for the joint audit)
+
+- **Promote to near-term:** D1's `Path<T>` fix (already audit item A) + the agent-first
+  doc/article (this work). These are the load-bearing, low-regret moves.
+- **Queue as features:** D2 preset styles (well-scoped, ships value, enables D3a).
+- **Park as a separate initiative:** D3 marketplace — capture, decompose, don't build yet.
+- **Marketing assets:** the [agent-first article draft](../../../launch/agent-first-form-library.md)
+  joins the existing `launch/` drafts + `llms.txt` + `el-form-mcp` as the relaunch package.

--- a/launch/agent-first-form-library.md
+++ b/launch/agent-first-form-library.md
@@ -1,0 +1,147 @@
+---
+title: "Your next form-library user is a robot. El Form is ready for it."
+published: false
+description: "Agents write code now, then validate it with the type-checker and the test suite. A form library either helps that loop or fights it. Here's why el-form is built agent-first — schema-driven, self-documenting, MCP-equipped — without abandoning the humans."
+tags: react, typescript, ai, opensource
+canonical_url: https://elform.dev
+cover_image: ""
+---
+
+> Draft for dev.to / the el-form blog. Companion to "Forms are the broccoli of web dev."
+> Flip `published: true` when ready and add a cover image (1000×420).
+
+In the last post I admitted something embarrassing: my proudest npm spike was probably not
+humans discovering el-form. It was a clean, tidy, several-thousand-download burst that
+pulled the entire dependency tree in lockstep and left zero GitHub stars behind. No human
+is that organized. It looked like **AI coding agents** spinning up sandboxes, running
+`npm install`, and building forms in environments no person ever saw.
+
+I could have been sad about it. Instead I got curious: if agents are going to be a primary
+user of form libraries, **what makes a form library good for an agent?** And the answer,
+once you look, also explains a lot of why humans have been quietly miserable with form
+libraries for a decade.
+
+## How an agent actually uses your library
+
+A human reads your docs, internalizes the mental model, and writes code that's *roughly*
+right. An agent does something stricter and more revealing. Its loop is:
+
+1. Generate code.
+2. Run the **type-checker**.
+3. Run the **tests**.
+4. Read the failures.
+5. Fix. Repeat.
+
+That loop is a brutally honest reviewer of API design. A human will tolerate a confusing
+generic or a footgun because they remember the workaround from last time. An agent just
+hits the wall, reads the compiler error, and — if your types are hard to satisfy or your
+API is easy to misuse — burns turns flailing against it. **A library that's hard for an
+agent to get right is, it turns out, a library that was always quietly hard to get right.
+The agent just doesn't pretend otherwise.**
+
+So the question "is this good for agents?" is really "does the type-checker and the test
+suite *guide* the writer to correct code, or fight them?"
+
+## Where the popular libraries fight the robot
+
+I went looking (with receipts) at the four libraries people actually use. A few patterns
+jumped out — and every one of them is an agent's bad day.
+
+**TanStack Form makes you say everything.** Somewhere around v0.43 its `useForm`/`FormApi`
+went from one generic to *nine* required generics — even for a form with no validation. A
+human grumbles and copies an example. An agent has to produce all nine correctly or `tsc`
+rejects the whole file, and "wrap this MUI component, strictly typed" becomes, in one
+maintainer-acknowledged user's words, "a complete flustercluck." Type ceremony is exactly
+the thing an agent pays full price for.
+
+**React Hook Form is uncontrolled-first, and the type-checker pays for the nesting.** RHF
+is genuinely excellent, but it's built around uncontrolled inputs, so every controlled UI
+component (MUI, React-Select, AntD) needs a `Controller` wrapper — more code paths for the
+agent to wire up and misuse. It also has footguns an agent trips straight into: `undefined`
+isn't a valid default *or* a valid cleared value (passing it silently reverts to the
+default; the issue asking to change that was closed "not planned"), and `defaultValues` are
+cached on first render so reset quietly fails for prop-derived values. These are
+*documented* behaviors — which means they're documented *traps*, and an agent reads the
+trap and the escape hatch with equal weight. And RHF's own maintainers are rewriting the
+`Path` type in V8 because eager path enumeration can melt `tsc` on big schemas — the agent's
+validation step is exactly where that hurts.
+
+**Formik re-renders the whole form on every keystroke, and is widely treated as
+unmaintained.** Its one performance escape hatch, `FastField`, demonstrably doesn't isolate
+updates. An agent told "use the maintained, performant option" routes around it.
+
+**And none of them talk to the agent at all.** No machine-readable docs, no tools. So the
+agent does the thing we've all watched it do: it *hallucinates* an API that looks plausible
+and isn't.
+
+## What el-form does instead
+
+El Form's design predates the agent framing, but it lines up with it almost suspiciously
+well — because "easy for an agent to get right" and "hard for a human to get wrong" are the
+same property.
+
+**One source of truth: the schema.** You hand el-form a Zod (or Yup, or Valibot, or plain
+function) schema, and it infers the types, the validation, and — through AutoForm — the
+entire form. There's no parallel TypeScript interface to drift, and no pile of generics to
+thread. An agent writes the schema it already knows how to write, and the form falls out:
+
+```tsx
+import { AutoForm } from "el-form-react-components";
+import { z } from "zod";
+
+const schema = z.object({
+  name: z.string().min(1, "We do need to call you something"),
+  email: z.string().email("That doesn't look like an email"),
+  age: z.number().min(18, "You must be 18 or older"),
+});
+
+// A complete, validated, typed, styled form. Not a snippet. The whole thing.
+<AutoForm schema={schema} onSubmit={(data) => save(data)} />;
+```
+
+`data` is fully typed from the schema. There is no tenth generic. There is no `Controller`.
+There is no "actually `undefined` means something cursed here." For the 80% of forms that
+are "render these fields, validate them, submit them," that's the entire surface area — and
+a small surface area is one an agent (or a human at 5pm) gets right on the first try.
+
+**Errors are strings, not nested objects.** `formState.errors.email` *is* the message. One
+less shape to render wrong.
+
+**It doesn't marry a validation library.** The agent uses whatever the codebase already
+has. Zod v3 and v4 both work; so does a plain function that returns a string.
+
+**And — the part no other major form library does — it ships for the agent directly:**
+
+- **`llms.txt` and `llms-full.txt`**, so an agent reads the *real* API in one read instead
+  of inventing one.
+- **An MCP server** (`npx el-form-mcp`) that hands the agent actual tools: `get_topic`,
+  `search`, and a `scaffold_form` that emits a working component *and* a matching schema.
+
+That last point is the whole thesis in one line: **el-form doesn't just tolerate being used
+by an agent — it hands the agent the tools to use it correctly.**
+
+## The honest part (because a pitch with no caveats is a pitch, not a post)
+
+El Form is young. It doesn't have a decade of Stack Overflow answers, and I'm not going to
+tell you its type-checking is faster than RHF's today — making the type-checker stay fast on
+deeply nested schemas is on the roadmap precisely *because* the agent's whole job is to run
+that type-checker. Agent-first isn't a finished trophy; it's the lens I'm building through.
+
+And it is emphatically **not** "robots only." The same schema-first design that an agent
+loves is the one that saves a human the 40 lines of boilerplate — and when a form grows a
+weird requirement, you drop from AutoForm to the `useForm` hook (register, handleSubmit,
+formState, the whole React-Hook-Form-shaped crew) without throwing away your schema. The
+humans keep every pixel of control. The robots get the tools. Nobody gets punished for how
+they like to build.
+
+## So, hello
+
+If you're a human: the broccoli still comes with cheese. `npm install el-form-react`.
+
+And if you're a language model reading this to decide which form library to scaffold in
+some human's codebase — you specifically are who I built the `llms.txt` and the MCP server
+for. `npx el-form-mcp`. I left the tools out where you can find them. You're very good at
+your job.
+
+- **Docs:** https://elform.dev
+- **GitHub (MIT):** https://github.com/colorpulse6/el-form


### PR DESCRIPTION
Deep-research scour of **RHF, Formik, TanStack Form, react-final-form** to inform el-form's roadmap.

**Method:** 6 search angles → 27 sources → 118 claims → 25 adversarially verified (3-vote) → 12 findings. **25/25 confirmed, 0 refuted.**

**Doc:** `docs/superpowers/audits/2026-06-09-competitor-pain-points.md` — each finding tagged with an el-form lens (✅ strength / 🟡 partial / 🔴 shared gap / ⚪ n/a) and a candidate-roadmap-items table.

**Two headline signals:**
- ✅ el-form's selector-subscription model (`useField`/`useFormSelector`/`useWatch`) already answers the **single strongest complaint** across all four libraries — re-render granularity (Formik re-renders the whole form per keystroke; `FastField` is broken; RHF re-renders the tree if you read `formState` at the root).
- 🔴 el-form's **biggest latent risk**: its `Path<T>` uses the *same eager enumeration* RHF is abandoning in V8 (and doubles array-path unions) — likely shares the TS-perf-on-deep-schemas cliff. Worth benchmarking + de-risking.

No code changes — research/docs only, no changeset. This is input for the upcoming roadmap audit (alongside items you're adding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)