### PR TITLE
feat(hooks): reactive `values` + `keepDirtyValues` for useForm

### DIFF
--- a/.changeset/reactive-values.md
+++ b/.changeset/reactive-values.md
@@ -1,0 +1,11 @@
+---
+"el-form-react-hooks": minor
+---
+
+Add a reactive `values` option to `useForm` for forms backed by props or server data. When the `values` object's content changes, the form re-syncs to it (deep-compared, so a new-object/same-content render is a no-op); it also takes precedence over `defaultValues` for the initial state. Pair it with `keepDirtyValues: true` to preserve fields the user is mid-editing while untouched fields sync (the equivalent of React Hook Form's `values` prop + `resetOptions: { keepDirtyValues: true }`, and Formik's `enableReinitialize`).
+
+```ts
+useForm({ values: serverData, keepDirtyValues: true });
+```
+
+Purely additive — existing forms are unaffected. Notes: `values` replaces the whole value object (provide the full shape, not a partial patch — omitted keys are dropped); `isDirty` is still measured against the original `defaultValues`, not the latest synced `values`; and don't put `File`/`Blob` instances in reactive `values` (the deep-compare can't tell two files apart, so a file swap won't re-sync).

--- a/docs/docs/guides/migration.md
+++ b/docs/docs/guides/migration.md
@@ -66,6 +66,9 @@ const { register, handleSubmit, formState } = useForm({
 - `setValue`, `reset`, `watch`, `trigger`, `setFocus`, `getFieldState` all exist.
 - `useFieldArray` exists for dynamic lists (see [Array Fields](./array-fields.md)).
 - Focus-on-error is on by default (`shouldFocusError`), just like RHF.
+- The reactive `values` prop works the same way for server/prop-driven forms;
+  `keepDirtyValues: true` is the equivalent of RHF's `resetOptions: { keepDirtyValues: true }`
+  (preserve the user's in-progress edits when external data arrives).
 
 ### What's different
 
@@ -138,6 +141,7 @@ const { register, handleSubmit, formState } = useForm({
 | `formik.handleSubmit` | `handleSubmit(onValid)` |
 | `value` + `onChange` + `onBlur` + `name` (4 props) | `{...register("name")}` (one spread) |
 | `formik.values.x` | `watch("x")` or `formState`-driven components |
+| `enableReinitialize` + changing `initialValues` | reactive `values` prop (+ `keepDirtyValues`) |
 | `formik.errors.x` / `formik.touched.x` | `formState.errors.x` / `formState.touched.x` |
 | `<Field>` / `<FieldArray>` render-prop components | `register` + `useFieldArray` hook, or [AutoForm](./auto-form.md) |
 

--- a/docs/superpowers/specs/2026-06-09-reactive-values-design.md
+++ b/docs/superpowers/specs/2026-06-09-reactive-values-design.md
@@ -1,0 +1,80 @@
+# Reactive external `values` — design (2026-06-09)
+
+## Problem
+
+el-form seeds initial state from `defaultValues` (once) and can update values imperatively
+(`reset({ values })`, `setValues`). There's no **reactive** path: when a `values` object
+derived from props/server data changes, the form doesn't re-sync. RHF (`values` prop +
+`resetOptions`) and Formik (`enableReinitialize`) both offer this; the feature-inventory
+research confirmed it's a table-stakes gap (roadmap B / P1).
+
+## API
+
+Two new `useForm` options (additive, non-breaking):
+
+```ts
+useForm<T>({
+  values?: Partial<T>;        // reactive external values; re-syncs when content changes
+  keepDirtyValues?: boolean;  // default false; when true, preserve user-edited fields on sync
+  // ...existing options
+});
+```
+
+- When `values` is provided it **seeds the initial** form values (takes precedence over
+  `defaultValues`), and thereafter **re-syncs whenever its content changes**.
+
+## Behaviour
+
+A `useEffect` deep-compares `options.values` against a `syncedRef` (so a new-object/
+same-content render does **not** re-sync or loop — `deepEqual` from `utils/equality`).
+On a real change:
+
+- **`keepDirtyValues: false` (default, RHF-style overwrite):** set values to the new
+  external object and **clear the dirty set** (the form now matches the new source of truth,
+  so nothing is dirty). `errors`/`touched` are left as-is (predictable; use `reset()` for a
+  full wipe).
+- **`keepDirtyValues: true`:** merge — for each key, if the field is in the dirty set keep
+  its **current** value, otherwise take the **new external** value. The dirty set is left
+  unchanged (edited fields stay dirty, untouched fields stay clean).
+
+**Why this is simple here:** el-form tracks dirty via an explicit, mutation-driven
+**set** (`dirtyFieldsRef`), not a value-vs-default comparison at render. So writing values
+through `setFormState` doesn't disturb dirty tracking — `keepDirtyValues` is just "which
+value wins per key," with no dirty-baseline reconciliation needed.
+
+Sync does **not** auto-run validation (matches RHF default).
+
+## Scope / non-goals (YAGNI)
+
+- No full `resetOptions`/`KeepStateOptions` surface (keepErrors/keepTouched/keepSubmitCount…)
+  in v1 — just `keepDirtyValues`, the one the research flagged as load-bearing for
+  server-data forms. Add more later only on demand.
+- No deep merge of partial `values` into existing untouched edits beyond the per-key rule
+  above.
+
+## Implementation
+
+- `packages/el-form-react-hooks/src/types.ts` — add `values?` + `keepDirtyValues?` to
+  `UseFormOptions`.
+- `packages/el-form-react-hooks/src/useForm.ts` — initial `useState` values become
+  `options.values ?? defaultValues`; add a `syncedValuesRef` + a `useEffect` implementing the
+  deep-compare guard and the two sync branches via `setFormState` / `dirtyManager`.
+- Reuse `deepEqual` (`utils/equality.ts`).
+
+## Tests (TDD, hooks runtime)
+
+`valuesSync.runtime.test.tsx`:
+
+- `values` seeds initial state (precedence over `defaultValues`).
+- changing `values` content re-syncs into the form (a reader reflects the new value).
+- same-content new object → **no** clobber (edit a field, re-render with an equal `values`
+  object; the edit survives — proves the deep-compare guard).
+- `keepDirtyValues: false` — edit a field, change `values` → field overwritten, `isDirty`
+  false.
+- `keepDirtyValues: true` — edit a field, change `values` → edited field keeps the user's
+  value (still dirty), other fields sync.
+
+## Release
+
+Minor changeset for `el-form-react-hooks`. Add a `values`/`keepDirtyValues` row to the RHF
+migration guide (`values` prop / `enableReinitialize` mapping).

--- a/packages/el-form-react-hooks/src/__tests__/valuesSync.runtime.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/valuesSync.runtime.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, cleanup, act } from "@testing-library/react";
+import React from "react";
+import { useForm, FormProvider } from "..";
+
+beforeEach(cleanup);
+
+type V = { a: string; b: string };
+
+// App owns useForm and reads formState directly (current within the render pass).
+// `api` exposes the form so tests can edit fields; `values`/`keepDirty` are props
+// so tests can re-render with new external data.
+function makeApp() {
+  let api: any;
+  function App({
+    values,
+    keepDirty,
+  }: {
+    values?: Partial<V>;
+    keepDirty?: boolean;
+  }) {
+    const form = useForm<V>({
+      defaultValues: { a: "", b: "" },
+      values,
+      keepDirtyValues: keepDirty,
+    });
+    api = form;
+    return (
+      <FormProvider form={form}>
+        <div data-testid="a">{form.formState.values.a ?? ""}</div>
+        <div data-testid="b">{form.formState.values.b ?? ""}</div>
+        <div data-testid="dirty">{String(form.formState.isDirty)}</div>
+      </FormProvider>
+    );
+  }
+  return { App, getApi: () => api };
+}
+
+const a = () => screen.getByTestId("a").textContent;
+const b = () => screen.getByTestId("b").textContent;
+const dirty = () => screen.getByTestId("dirty").textContent;
+
+describe("useForm reactive `values`", () => {
+  it("seeds initial values from `values` (precedence over defaultValues)", () => {
+    const { App } = makeApp();
+    render(<App values={{ a: "X", b: "Y" }} />);
+    expect(a()).toBe("X");
+    expect(b()).toBe("Y");
+  });
+
+  it("re-syncs when `values` content changes", () => {
+    const { App } = makeApp();
+    const { rerender } = render(<App values={{ a: "1", b: "2" }} />);
+    expect(a()).toBe("1");
+    rerender(<App values={{ a: "3", b: "2" }} />);
+    expect(a()).toBe("3");
+    expect(b()).toBe("2");
+  });
+
+  it("does NOT clobber edits when re-rendered with an equal-content `values` object", () => {
+    const { App, getApi } = makeApp();
+    const { rerender } = render(<App values={{ a: "1", b: "1" }} />);
+    act(() => {
+      getApi().setValue("a", "edited");
+    });
+    expect(a()).toBe("edited");
+    // new object, same content -> deep-compare guard should skip the re-sync
+    rerender(<App values={{ a: "1", b: "1" }} />);
+    expect(a()).toBe("edited");
+  });
+
+  it("keepDirtyValues=false (default): overwrites edited fields and clears dirty", () => {
+    const { App, getApi } = makeApp();
+    const { rerender } = render(<App values={{ a: "1", b: "1" }} />);
+    act(() => {
+      getApi().setValue("a", "edited");
+    });
+    expect(dirty()).toBe("true");
+    rerender(<App values={{ a: "2", b: "2" }} />);
+    expect(a()).toBe("2"); // overwritten
+    expect(dirty()).toBe("false");
+  });
+
+  it("keepDirtyValues=true: preserves edited fields, syncs the rest", () => {
+    const { App, getApi } = makeApp();
+    const { rerender } = render(
+      <App values={{ a: "1", b: "1" }} keepDirty />
+    );
+    act(() => {
+      getApi().setValue("a", "edited");
+    });
+    rerender(<App values={{ a: "2", b: "2" }} keepDirty />);
+    expect(a()).toBe("edited"); // user edit preserved
+    expect(b()).toBe("2"); // untouched field synced
+    expect(dirty()).toBe("true");
+  });
+
+  it("syncs when `values` goes from undefined to defined", () => {
+    const { App } = makeApp();
+    const { rerender } = render(<App values={undefined} />);
+    expect(a()).toBe(""); // falls back to defaultValues
+    rerender(<App values={{ a: "later", b: "later" }} />);
+    expect(a()).toBe("later");
+  });
+
+  it("keepDirtyValues=true preserves a nested dirty field while syncing siblings", () => {
+    type NV = { user: { first: string; last: string } };
+    let api: any;
+    function App({ values }: { values?: Partial<NV> }) {
+      const form = useForm<NV>({
+        defaultValues: { user: { first: "", last: "" } },
+        values,
+        keepDirtyValues: true,
+      });
+      api = form;
+      return (
+        <FormProvider form={form}>
+          <div data-testid="first">{form.formState.values.user?.first ?? ""}</div>
+          <div data-testid="last">{form.formState.values.user?.last ?? ""}</div>
+        </FormProvider>
+      );
+    }
+    const { rerender } = render(
+      <App values={{ user: { first: "A", last: "B" } }} />
+    );
+    act(() => {
+      api.setValue("user.first", "edited");
+    });
+    rerender(<App values={{ user: { first: "X", last: "Y" } }} />);
+    expect(screen.getByTestId("first").textContent).toBe("edited"); // nested dirty kept
+    expect(screen.getByTestId("last").textContent).toBe("Y"); // sibling synced
+  });
+});

--- a/packages/el-form-react-hooks/src/types.ts
+++ b/packages/el-form-react-hooks/src/types.ts
@@ -48,6 +48,17 @@ export interface UseFormOptions<T extends Record<string, any>> {
 
   /** Focus the first invalid field after a failed submit. Default true. */
   shouldFocusError?: boolean;
+
+  /** Reactive external values. When this object's content changes, the form
+   *  re-syncs to it (deep-compared, so a new-object/same-content render is a
+   *  no-op). Takes precedence over `defaultValues` for the initial values —
+   *  useful for forms backed by props or server data. */
+  values?: Partial<T>;
+
+  /** When reactive `values` change, keep fields the user has already edited
+   *  (dirty) instead of overwriting them; untouched fields still sync. Default
+   *  false (overwrite, matching React Hook Form's default). */
+  keepDirtyValues?: boolean;
 }
 
 export interface FieldState {

--- a/packages/el-form-react-hooks/src/useForm.ts
+++ b/packages/el-form-react-hooks/src/useForm.ts
@@ -1,5 +1,6 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import type { Path, PathValue, RegisterReturn } from "./types/path";
+import { deepEqual } from "./utils/equality";
 import {
   FormState,
   UseFormOptions,
@@ -39,6 +40,8 @@ export function useForm<T extends Record<string, any>>(
     onSubmit,
     schema,
     shouldFocusError,
+    values: externalValues,
+    keepDirtyValues = false,
   } = options;
 
   // Core refs and state
@@ -50,7 +53,7 @@ export function useForm<T extends Record<string, any>>(
   const formStateRef = useRef<FormState<T>>();
 
   const [formState, setFormState] = useState<FormState<T>>({
-    values: defaultValues,
+    values: externalValues ?? defaultValues,
     errors: {},
     touched: {},
     isSubmitting: false,
@@ -71,6 +74,39 @@ export function useForm<T extends Record<string, any>>(
 
   // Create utility managers
   const dirtyManager = createDirtyStateManager<T>(dirtyFieldsRef);
+
+  // Reactive external `values`: re-sync the form when the `values` option's
+  // content changes. Deep-compared against the last synced snapshot so a
+  // new-object / same-content render does not re-sync or loop. Dirty state is a
+  // mutation-driven set, so writing values here doesn't disturb dirty tracking.
+  const syncedValuesRef = useRef(externalValues);
+  useEffect(() => {
+    if (externalValues === undefined) return;
+    if (deepEqual(externalValues, syncedValuesRef.current)) return;
+    syncedValuesRef.current = externalValues;
+    if (keepDirtyValues) {
+      // Keep user-edited (dirty) paths; sync everything else from the new data.
+      setFormState((prev) => {
+        let merged: Partial<T> = { ...externalValues };
+        for (const path of dirtyFieldsRef.current) {
+          merged = setNestedValue(
+            merged as any,
+            path,
+            getNestedValue(prev.values as any, path)
+          ) as Partial<T>;
+        }
+        return { ...prev, values: merged };
+      });
+    } else {
+      // Overwrite: the form now matches the new source of truth -> nothing dirty.
+      dirtyManager.clearDirtyState();
+      setFormState((prev) => ({
+        ...prev,
+        values: { ...externalValues },
+        isDirty: false,
+      }));
+    }
+  }, [externalValues, keepDirtyValues]);
   const validationManager = createValidationManager<T>({
     validationEngine,
     validators,


### PR DESCRIPTION
Roadmap item **B / P1** — reactive external `values`, the one real parity gap the audit + feature-inventory research both flagged (RHF `values` prop + `resetOptions`; Formik `enableReinitialize`).

## What
A reactive `values` option on `useForm` for forms backed by props/server data:

```ts
useForm({ values: serverData, keepDirtyValues: true });
```

- When `values`'s **content** changes (deep-compared, so a new-object/same-content render is a no-op), the form re-syncs. It also **seeds the initial state** (precedence over `defaultValues`).
- **`keepDirtyValues: true`** preserves fields the user is mid-editing while untouched fields sync.

## Why it's clean
el-form tracks dirty via a **mutation-driven set**, so writing values through `setFormState` doesn't disturb dirty tracking — `keepDirtyValues` is a per-path "which value wins" merge (`setNestedValue`, nested-path aware). No dirty-baseline reconciliation needed.

## Caveats (documented in the changeset + migration guide)
- `values` replaces the **whole** value object (provide the full shape; omitted keys drop) — matches RHF.
- `isDirty` is measured against the original `defaultValues`, not the latest synced `values` (consistent with el-form's existing `reset({values})`).
- Don't put `File`/`Blob` in reactive `values` — the deep-compare can't distinguish files, so a swap won't re-sync (a pre-existing `deepEqual` limitation; flagged for a future fix).

## Verification
- **7 runtime tests**: initial-seed precedence, content-change resync, the deep-compare **no-clobber** guard, both `keepDirtyValues` branches, `undefined`→defined, and **nested** dirty-field preservation.
- build + hooks (123) + tsd + components (26) + umbrella (6) green; lint clean.
- Independent review: **SOUND** — adversarially probed no-loop / no-mount-resync / nested-merge / no-regression; the only latent issue (File in `deepEqual`) is pre-existing and documented.

Design: `docs/superpowers/specs/2026-06-09-reactive-values-design.md`. Minor changeset (additive). Deferred: full `resetOptions` surface (keepErrors/keepTouched/…) — YAGNI for v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)