### PR TITLE
test(example): coverage labs + sweep for useWatch, reactive values, submit-meta

### DIFF
--- a/.claude/skills/sweep-form-app/run-sweep.mjs
+++ b/.claude/skills/sweep-form-app/run-sweep.mjs
@@ -34,6 +34,9 @@ const DEMOS = [
   { id: "validation-adapters-lab", label: "Validation Adapters Lab", check: assertValidationAdaptersLab },
   { id: "file-validators-lab", label: "File Validators Lab", check: assertFileValidatorsLab },
   { id: "component-lab", label: "Component Lab", check: assertComponentLab },
+  { id: "use-watch-lab", label: "useWatch Lab", check: assertUseWatchLab },
+  { id: "reactive-values-lab", label: "Reactive Values Lab", check: assertReactiveValuesLab },
+  { id: "submit-meta-lab", label: "Submit Meta Lab", check: assertSubmitMetaLab },
 ];
 
 const ADAPTER_BRANCHES = [
@@ -887,6 +890,124 @@ async function assertComponentLab(page) {
     await waitForJsonTestId(page, "autoform-submit-result", (json) => json.status === "valid", "AutoForm valid submit result");
 
     return "exported fields, createField helper, componentMap, and AutoForm results update";
+  });
+}
+
+async function assertUseWatchLab(page) {
+  return scenario("behavior", async () => {
+    await expectVisible(main(page).getByTestId("use-watch-lab"), "useWatch lab root");
+
+    // Single-path watch reacts to its path only.
+    await clickMainButton(page, "Set First Ada");
+    await waitForJsonTestId(page, "watch-single", (json) => json === "Ada", "single watch reflects first");
+    await waitForJsonTestId(page, "watch-multi", (json) => json.first === "Ada", "multi watch reflects first");
+    await waitForJsonTestId(page, "watch-all", (json) => json.first === "Ada", "all watch reflects first");
+
+    // A second path updates multi and all, and single stays on its own path.
+    await clickMainButton(page, "Set Last Lovelace");
+    await waitForJsonTestId(
+      page,
+      "watch-multi",
+      (json) => json.first === "Ada" && json.last === "Lovelace",
+      "multi watch reflects both paths"
+    );
+    await waitForJsonTestId(page, "watch-all", (json) => json.last === "Lovelace", "all watch reflects last");
+    await waitForJsonTestId(page, "watch-single", (json) => json === "Ada", "single watch unchanged by other path");
+
+    // A path outside multi's set reaches all but not the scoped subscriptions.
+    await clickMainButton(page, "Set Nickname");
+    await waitForJsonTestId(page, "watch-all", (json) => json.nickname === "Countess", "all watch reflects nickname");
+    await waitForJsonTestId(page, "watch-multi", (json) => json.nickname === undefined, "multi watch excludes nickname");
+
+    return "single, multiple, and all useWatch subscriptions react to scoped value changes";
+  });
+}
+
+async function assertReactiveValuesLab(page) {
+  return scenario("behavior", async () => {
+    await expectVisible(main(page).getByTestId("reactive-values-lab"), "reactive values lab root");
+    await waitForJsonTestId(page, "rv-values", (json) => json.name === "Ada", "initial form values from external source");
+    await waitForJsonTestId(page, "rv-external", (json) => json.name === "Ada", "initial external source");
+    await waitForJsonTestId(page, "rv-sync-state", (json) => json.keepDirtyValues === false, "keepDirtyValues starts off");
+
+    // keepDirtyValues off: a new external source overwrites the whole form.
+    await clickMainButton(page, "Push Grace");
+    await waitForJsonTestId(
+      page,
+      "rv-values",
+      (json) => json.name === "Grace" && json.email === "grace@example.com",
+      "external push overwrites form when keepDirty is off"
+    );
+
+    // Make name dirty, then keep dirty fields on the next push.
+    await fillByLabel(page, "Name", "Edited");
+    await waitForJsonTestId(page, "rv-values", (json) => json.name === "Edited", "field edit updates form values");
+    await waitForJsonTestId(page, "rv-sync-state", (json) => json.isDirty === true, "edited field marks form dirty");
+    await clickMainButton(page, "Toggle keepDirtyValues");
+    await waitForJsonTestId(page, "rv-sync-state", (json) => json.keepDirtyValues === true, "keepDirtyValues toggled on");
+
+    await clickMainButton(page, "Push Linus");
+    await waitForJsonTestId(
+      page,
+      "rv-values",
+      (json) => json.name === "Edited" && json.email === "linus@example.com",
+      "keepDirtyValues preserves edited name and syncs untouched email"
+    );
+    await waitForJsonTestId(page, "rv-external", (json) => json.name === "Linus", "external source reflects latest push");
+
+    return "reactive values overwrite when keepDirty is off and preserve edited fields when on";
+  });
+}
+
+async function assertSubmitMetaLab(page) {
+  return scenario("behavior", async () => {
+    await expectVisible(main(page).getByTestId("submit-meta-lab"), "submit meta lab root");
+    await waitForJsonTestId(
+      page,
+      "submit-meta-json",
+      (json) =>
+        json.isSubmitted === false &&
+        json.isSubmitSuccessful === false &&
+        json.submitCount === 0,
+      "submit meta starts at defaults"
+    );
+
+    // Invalid submit: marks submitted, bumps count, but not successful.
+    await clickMainButton(page, "Submit");
+    await expectMainText(page, /Name is required/, "invalid submit validation error");
+    await waitForJsonTestId(
+      page,
+      "submit-meta-json",
+      (json) =>
+        json.isSubmitted === true &&
+        json.submitCount === 1 &&
+        json.isSubmitSuccessful === false,
+      "invalid submit sets isSubmitted and submitCount without success"
+    );
+
+    // Valid submit: success flips on and count increments.
+    await fillByLabel(page, "Name", "Ada");
+    await clickMainButton(page, "Submit");
+    await waitForJsonTestId(
+      page,
+      "submit-meta-json",
+      (json) => json.submitCount === 2 && json.isSubmitSuccessful === true,
+      "valid submit marks isSubmitSuccessful"
+    );
+
+    // Reset clears the submit-meta trio.
+    await clickMainButton(page, "Reset Form");
+    await waitForJsonTestId(
+      page,
+      "submit-meta-json",
+      (json) =>
+        json.isSubmitted === false &&
+        json.isSubmitSuccessful === false &&
+        json.submitCount === 0,
+      "reset clears submit meta"
+    );
+
+    return "submit-meta trio tracks invalid submit, valid submit, and reset";
   });
 }
 

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -22,6 +22,9 @@ import { FieldArrayLab } from "./forms/coverage/FieldArrayLab";
 import { ValidationAdaptersLab } from "./forms/coverage/ValidationAdaptersLab";
 import { FileValidatorsLab } from "./forms/coverage/FileValidatorsLab";
 import { ComponentLab } from "./forms/coverage/ComponentLab";
+import { UseWatchLab } from "./forms/coverage/UseWatchLab";
+import { ReactiveValuesLab } from "./forms/coverage/ReactiveValuesLab";
+import { SubmitMetaLab } from "./forms/coverage/SubmitMetaLab";
 
 function App() {
   const [currentTest, setCurrentTest] = useState<TestId>("basic-validation");
@@ -68,6 +71,12 @@ function App() {
         return <FileValidatorsLab />;
       case "component-lab":
         return <ComponentLab />;
+      case "use-watch-lab":
+        return <UseWatchLab />;
+      case "reactive-values-lab":
+        return <ReactiveValuesLab />;
+      case "submit-meta-lab":
+        return <SubmitMetaLab />;
       default:
         return <BasicValidationTest />;
     }

--- a/examples/react/src/components/layout/Sidebar.tsx
+++ b/examples/react/src/components/layout/Sidebar.tsx
@@ -20,7 +20,10 @@ export type TestId =
   | "field-array-lab"
   | "validation-adapters-lab"
   | "file-validators-lab"
-  | "component-lab";
+  | "component-lab"
+  | "use-watch-lab"
+  | "reactive-values-lab"
+  | "submit-meta-lab";
 
 interface NavItem {
   id: TestId;
@@ -106,6 +109,9 @@ const navigation: NavCategory[] = [
       { id: "validation-adapters-lab", label: "Validation Adapters Lab" },
       { id: "file-validators-lab", label: "File Validators Lab" },
       { id: "component-lab", label: "Component Lab" },
+      { id: "use-watch-lab", label: "useWatch Lab" },
+      { id: "reactive-values-lab", label: "Reactive Values Lab" },
+      { id: "submit-meta-lab", label: "Submit Meta Lab" },
     ],
   },
 ];

--- a/examples/react/src/forms/coverage/ReactiveValuesLab.tsx
+++ b/examples/react/src/forms/coverage/ReactiveValuesLab.tsx
@@ -1,0 +1,135 @@
+import { useState } from "react";
+import { useForm } from "el-form-react-hooks";
+import {
+  Button,
+  Card,
+  FormGroup,
+  FormSection,
+  inputBaseClasses,
+} from "../../components/ui";
+
+type ReactiveValues = {
+  name: string;
+  email: string;
+};
+
+const defaultValues: ReactiveValues = {
+  name: "Ada",
+  email: "ada@example.com",
+};
+
+function formatJson(value: unknown) {
+  return JSON.stringify(value, null, 2);
+}
+
+// Exercises the reactive `values` option plus `keepDirtyValues`: pushing a new
+// external source either overwrites the whole form (keepDirty off) or preserves
+// the user's edited fields while syncing the rest (keepDirty on).
+export function ReactiveValuesLab() {
+  const [externalValues, setExternalValues] =
+    useState<ReactiveValues>(defaultValues);
+  const [keepDirty, setKeepDirty] = useState(false);
+
+  const { register, formState, watch } = useForm<ReactiveValues>({
+    defaultValues,
+    values: externalValues,
+    keepDirtyValues: keepDirty,
+  });
+
+  const values = watch();
+
+  return (
+    <div className="space-y-6" data-testid="reactive-values-lab">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900">Reactive Values Lab</h2>
+        <p className="mt-1 text-sm text-gray-600">
+          The <code>values</code> option re-syncs the form when the external
+          source changes; <code>keepDirtyValues</code> preserves edited fields.
+        </p>
+      </div>
+
+      <FormSection title="External source controls" variant="blue">
+        <Button
+          type="button"
+          className="mr-2 mb-2"
+          onClick={() =>
+            setExternalValues({
+              name: "Grace",
+              email: "grace@example.com",
+            })
+          }
+        >
+          Push Grace
+        </Button>
+        <Button
+          type="button"
+          className="mr-2 mb-2"
+          onClick={() =>
+            setExternalValues({
+              name: "Linus",
+              email: "linus@example.com",
+            })
+          }
+        >
+          Push Linus
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          className="mr-2 mb-2"
+          onClick={() => setKeepDirty((prev) => !prev)}
+        >
+          Toggle keepDirtyValues
+        </Button>
+      </FormSection>
+
+      <FormSection title="Form fields" variant="gray">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <FormGroup label="Name" htmlFor="rv-name">
+            <input
+              id="rv-name"
+              type="text"
+              {...register("name")}
+              className={inputBaseClasses}
+            />
+          </FormGroup>
+          <FormGroup label="Email" htmlFor="rv-email">
+            <input
+              id="rv-email"
+              type="email"
+              {...register("email")}
+              className={inputBaseClasses}
+            />
+          </FormGroup>
+        </div>
+      </FormSection>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <Card>
+          <h3 className="mb-2 text-sm font-semibold text-gray-900">
+            Form values
+          </h3>
+          <pre data-testid="rv-values" className="text-xs">
+            {formatJson(values)}
+          </pre>
+        </Card>
+        <Card>
+          <h3 className="mb-2 text-sm font-semibold text-gray-900">
+            External source
+          </h3>
+          <pre data-testid="rv-external" className="text-xs">
+            {formatJson(externalValues)}
+          </pre>
+        </Card>
+        <Card>
+          <h3 className="mb-2 text-sm font-semibold text-gray-900">
+            Sync state
+          </h3>
+          <pre data-testid="rv-sync-state" className="text-xs">
+            {formatJson({ keepDirtyValues: keepDirty, isDirty: formState.isDirty })}
+          </pre>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/examples/react/src/forms/coverage/SubmitMetaLab.tsx
+++ b/examples/react/src/forms/coverage/SubmitMetaLab.tsx
@@ -1,0 +1,98 @@
+import { useForm } from "el-form-react-hooks";
+import z from "zod";
+import {
+  Button,
+  Card,
+  FormGroup,
+  FormSection,
+  inputBaseClasses,
+} from "../../components/ui";
+
+type SubmitMetaValues = {
+  name: string;
+};
+
+const schema = z.object({
+  name: z.string().min(1, "Name is required"),
+});
+
+const defaultValues: SubmitMetaValues = {
+  name: "",
+};
+
+function formatJson(value: unknown) {
+  return JSON.stringify(value, null, 2);
+}
+
+// Exercises the formState submit-meta trio: isSubmitted / isSubmitSuccessful /
+// submitCount (plus isSubmitting). An invalid submit flips isSubmitted and bumps
+// submitCount without success; a valid submit sets isSubmitSuccessful; reset
+// clears all of them.
+export function SubmitMetaLab() {
+  const { register, formState, submit, reset } = useForm<SubmitMetaValues>({
+    defaultValues,
+    validators: { onSubmit: schema },
+    onSubmit: () => {
+      // No side effect needed; the meta panel reflects submission state.
+    },
+  });
+
+  const meta = {
+    isSubmitted: formState.isSubmitted,
+    isSubmitSuccessful: formState.isSubmitSuccessful,
+    submitCount: formState.submitCount,
+    isSubmitting: formState.isSubmitting,
+  };
+
+  return (
+    <div className="space-y-6" data-testid="submit-meta-lab">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900">Submit Meta Lab</h2>
+        <p className="mt-1 text-sm text-gray-600">
+          Tracks <code>isSubmitted</code>, <code>isSubmitSuccessful</code>, and{" "}
+          <code>submitCount</code> across invalid submit, valid submit, and
+          reset.
+        </p>
+      </div>
+
+      <FormSection title="Field" variant="gray">
+        <FormGroup
+          label="Name"
+          htmlFor="meta-name"
+          required
+          error={formState.errors.name as string}
+        >
+          <input
+            id="meta-name"
+            type="text"
+            {...register("name")}
+            className={inputBaseClasses}
+          />
+        </FormGroup>
+      </FormSection>
+
+      <FormSection title="Submit controls" variant="amber">
+        <Button type="button" className="mr-2 mb-2" onClick={() => submit()}>
+          Submit
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          className="mr-2 mb-2"
+          onClick={() => reset()}
+        >
+          Reset Form
+        </Button>
+      </FormSection>
+
+      <Card>
+        <h3 className="mb-2 text-sm font-semibold text-gray-900">
+          Submit meta
+        </h3>
+        <pre data-testid="submit-meta-json" className="text-xs">
+          {formatJson(meta)}
+        </pre>
+      </Card>
+    </div>
+  );
+}

--- a/examples/react/src/forms/coverage/UseWatchLab.tsx
+++ b/examples/react/src/forms/coverage/UseWatchLab.tsx
@@ -1,0 +1,107 @@
+import { useForm, FormProvider, useWatch } from "el-form-react-hooks";
+import { Button, Card, FormSection } from "../../components/ui";
+
+// Defaults are seeded to defined values (not undefined) so every watch panel
+// renders parseable JSON for the sweep's readJsonTestId — `formatJson(undefined)`
+// would render an empty <pre> and break JSON.parse.
+type WatchValues = {
+  first: string;
+  last: string;
+  nickname?: string;
+};
+
+function formatJson(value: unknown) {
+  return JSON.stringify(value, null, 2);
+}
+
+// These read reactively via useWatch and MUST live inside a FormProvider.
+function SingleWatch() {
+  const first = useWatch<WatchValues, "first">("first");
+  return (
+    <pre data-testid="watch-single" className="text-xs">
+      {formatJson(first)}
+    </pre>
+  );
+}
+
+function MultiWatch() {
+  const pair = useWatch<WatchValues, "first" | "last">(["first", "last"]);
+  return (
+    <pre data-testid="watch-multi" className="text-xs">
+      {formatJson(pair)}
+    </pre>
+  );
+}
+
+function AllWatch() {
+  const all = useWatch<WatchValues>();
+  return (
+    <pre data-testid="watch-all" className="text-xs">
+      {formatJson(all)}
+    </pre>
+  );
+}
+
+export function UseWatchLab() {
+  const form = useForm<WatchValues>({
+    defaultValues: { first: "", last: "" },
+  });
+
+  return (
+    <div className="space-y-6" data-testid="use-watch-lab">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900">useWatch Lab</h2>
+        <p className="mt-1 text-sm text-gray-600">
+          Reactive value subscriptions by path: single, multiple, and all values.
+        </p>
+      </div>
+
+      <FormProvider form={form}>
+        <FormSection title="Controls" variant="blue">
+          <Button
+            type="button"
+            className="mr-2 mb-2"
+            onClick={() => form.setValue("first", "Ada")}
+          >
+            Set First Ada
+          </Button>
+          <Button
+            type="button"
+            className="mr-2 mb-2"
+            onClick={() => form.setValue("last", "Lovelace")}
+          >
+            Set Last Lovelace
+          </Button>
+          <Button
+            type="button"
+            className="mr-2 mb-2"
+            onClick={() => form.setValue("nickname", "Countess")}
+          >
+            Set Nickname
+          </Button>
+        </FormSection>
+
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+          <Card>
+            <h3 className="mb-2 text-sm font-semibold text-gray-900">
+              useWatch("first")
+            </h3>
+            <SingleWatch />
+          </Card>
+          <Card>
+            <h3 className="mb-2 text-sm font-semibold text-gray-900">
+              useWatch(["first", "last"])
+            </h3>
+            <MultiWatch />
+          </Card>
+          <Card>
+            <h3 className="mb-2 text-sm font-semibold text-gray-900">
+              useWatch()
+            </h3>
+            <AllWatch />
+          </Card>
+        </div>
+      </FormProvider>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds three browser **coverage labs** to `examples/react` demoing the recently-shipped `el-form-react-hooks` features, plus route-specific assertions in the Playwright sweep that drive them in a real browser.

| Lab | Feature | Coverage |
|-----|---------|----------|
| `UseWatchLab` | `useWatch` | single (`useWatch("first")`), multi (`useWatch(["first","last"])`), all (`useWatch()`) — scoped reactive updates |
| `ReactiveValuesLab` | `values` + `keepDirtyValues` | overwrite path (keepDirty off) vs keep-edited-fields merge path (keepDirty on) |
| `SubmitMetaLab` | `isSubmitted` / `isSubmitSuccessful` / `submitCount` | invalid submit → valid submit → reset |

Wired into `App.tsx` + `Sidebar.tsx` ("Coverage Labs" nav), with `assertUseWatchLab` / `assertReactiveValuesLab` / `assertSubmitMetaLab` added to `.claude/skills/sweep-form-app/run-sweep.mjs`.

## Verification

- Example `tsc --noEmit` — clean
- `pnpm lint` (`eslint --max-warnings 0`) — clean
- **Full sweep: 23/23 PASS, 0 console errors**
- Independent reviewer ran **mutation tests** (deliberately broke `keepDirtyValues` and the submit schema) and confirmed the matching assertions fail — the coverage is honest, not false-passing.

## Scope

Touches only the private example app (`el-form-testing-app`) and the sweep skill — **no published-package source changed**, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)