### PR TITLE
docs: comparison page + name disambiguation + SEO metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 [![React](https://img.shields.io/badge/React-20232A?logo=react&logoColor=61DAFB)](https://reactjs.org/)
 [![MIT License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Bundle Size](https://img.shields.io/bundlephobia/minzip/el-form-react)](https://bundlephobia.com/package/el-form-react)
-[![Build Status](https://img.shields.io/github/workflow/status/colorpulse6/el-form/CI)](https://github.com/colorpulse6/el-form/actions)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/colorpulse6/el-form/ci.yml?branch=main)](https://github.com/colorpulse6/el-form/actions)
 
 **TypeScript-first React form library** with zero-boilerplate AutoForm and powerful useForm hook. The best React Hook Form alternative with schema-first validation (Zod, Yup, Valibot), built-in components, and enterprise-grade form management.
+
+> ℹ️ **El Form** is a **React** library (npm: `el-form-react`). It is unrelated to Vue Element Plus's built-in `<el-form>` component — if you landed here looking for the Vue/Element form, you want [Element Plus](https://element-plus.org/en-US/component/form) instead.
 
 ## 🤖 For AI Agents & LLMs
 

--- a/docs/docs/comparison.md
+++ b/docs/docs/comparison.md
@@ -1,0 +1,133 @@
+---
+sidebar_position: 5
+title: El Form vs React Hook Form, Formik & TanStack Form
+description: An honest comparison of El Form with React Hook Form, Formik, TanStack Form, and Final Form — feature matrix, trade-offs, and when to pick each React form library.
+keywords:
+  - react hook form alternative
+  - el form vs react hook form
+  - formik alternative
+  - tanstack form comparison
+  - best react form library
+  - react form library comparison
+  - schema-driven react forms
+---
+
+# El Form vs other React form libraries
+
+A fair, up-to-date comparison of **El Form** with the libraries most teams evaluate:
+**React Hook Form (RHF)**, **Formik**, **TanStack Form**, and **react-final-form**.
+
+We'll start with the honest version: **React Hook Form is the safe default for most apps** —
+it's battle-tested, has an enormous ecosystem, and is downloaded millions of times a week.
+El Form is newer and smaller. So this page is about *where El Form is genuinely different*,
+not about claiming it beats everything.
+
+> **TL;DR** — Reach for El Form when you want **forms generated directly from a schema**
+> (`AutoForm`), **accessibility and file uploads built in**, **per-field re-render isolation
+> by default**, and **first-class tooling for AI agents**. Reach for RHF when you want the
+> largest ecosystem and the most StackOverflow answers; for TanStack Form when you want a
+> headless, framework-spanning core and don't mind heavier generics; and treat Formik as
+> legacy (it's in patch-only maintenance).
+
+## Feature matrix
+
+| Capability | El Form | React Hook Form | Formik | TanStack Form |
+|---|:---:|:---:|:---:|:---:|
+| Zero-config form generation (**AutoForm**) | ✅ | ❌ | ❌ | ❌ |
+| Per-field subscriptions **by default** | ✅ | ⚠️ opt-in¹ | ❌² | ✅ |
+| Schema-agnostic (Zod / Yup / Valibot / fn) | ✅ | ⚠️ via resolvers | ⚠️ Yup-first | ✅ |
+| [Standard Schema](https://standardschema.dev) support | ✅ | ✅ (resolvers v4) | ❌ | ✅ |
+| First-class **file uploads** | ✅ | ❌ | ❌ | ❌ |
+| **Accessibility** built in (`aria-*` + `role="alert"` + focus-on-error) | ✅ | ⚠️ manual | ⚠️ manual | ⚠️ manual |
+| Field arrays | ✅ `useFieldArray` | ✅ | ✅ | ✅ |
+| Reactive external `values` sync | ✅ | ✅ | ✅ `enableReinitialize` | ✅ |
+| Discriminated unions / conditional fields | ✅ `FormSwitch` | ⚠️ manual | ⚠️ manual | ⚠️ manual |
+| Typed path API (`Path<T>` / `PathValue`) | ✅ | ✅ | ⚠️ | ✅ |
+| **Agent tooling** (MCP server + `llms.txt`) | ✅ unique | ❌ | ❌ | ❌ |
+| Generics you write by hand | low | low | low | higher³ |
+| Maturity / ecosystem / community size | ⚠️ new & small | ✅ very large | ✅ large (frozen) | ⚠️ growing |
+
+<small>
+
+¹ RHF is performant, but reading `formState` or `watch()` at the root re-renders the tree;
+isolation requires `useWatch` / `Controller` / `useFormState` placed carefully.
+² Formik re-renders the whole form on each keystroke; its `FastField` escape hatch is widely
+reported as unreliable.
+³ TanStack Form is powerful but exposes many type parameters; El Form infers a single `T` from
+your schema.
+
+</small>
+
+## When to choose El Form
+
+- **You want the form to come from the schema.** `AutoForm` renders a complete, validated,
+  accessible form from a **Zod** schema with zero field wiring — no other library on this list
+  ships that. (Field *generation* introspects Zod specifically; *validation* stays
+  schema-agnostic — Zod, Yup, Valibot, or plain functions — for both AutoForm and `useForm`.)
+- **Accessibility matters and you don't want to wire it by hand.** `aria-invalid`,
+  `aria-describedby`, `aria-required`, `role="alert"` errors, and focus-on-error are on by
+  default.
+- **You have file inputs.** Native file fields, preset validators, previews, and file
+  management are first-class — the others leave this to you.
+- **Large forms that must stay responsive.** `useField` / `useFormSelector` / `useWatch`
+  subscribe to slices of state via `useSyncExternalStore`, so editing one field doesn't
+  re-render the rest — the same model TanStack Form converged on, available by default.
+- **AI agents write your forms.** El Form is the only library here with an
+  [MCP server](./tools/mcp-server.md) and [`llms.txt`](https://elform.dev/llms.txt): a schema
+  is the single source of truth, errors are plain strings, and the result is easy for an agent
+  to generate *and* self-verify with `tsc` + tests.
+
+## When **not** to choose El Form
+
+- **You want the biggest ecosystem and the most answers online.** React Hook Form wins on
+  community size, third-party integrations, and sheer search volume. If "boring and proven"
+  is the requirement, RHF is the rational pick.
+- **You need a headless core shared across frameworks.** TanStack Form's framework-agnostic
+  store is the better fit if you're standardizing across React/Vue/Solid.
+- **You're maintaining an existing Formik app and it works.** There's no urgency to move —
+  though note Formik is in patch-only maintenance, so new features aren't coming.
+
+## Library-by-library
+
+### vs React Hook Form
+
+RHF and El Form agree on a lot: typed paths, schema validation, per-field performance when
+used correctly. The differences are **what's built in**. RHF has no form-generation story,
+no first-class files, and accessibility is left to you; El Form ships all three. Conversely,
+RHF's ecosystem, maturity, and adoption dwarf El Form's. El Form also closes the historical
+RHF-parity gaps people ask about — reactive external `values` (with `keepDirtyValues`),
+`useWatch`, and `formState` submission metadata (`isSubmitted` / `isSubmitSuccessful` /
+`submitCount`). Migrating? See the [migration guide](./guides/migration.md).
+
+### vs Formik
+
+Formik popularized React forms but is **frozen in patch-only maintenance**, and its core
+performance model re-renders the entire form on every keystroke. El Form is effectively a
+modern successor: selector-based re-render isolation, schema-agnostic validation, AutoForm,
+and built-in accessibility. If you're starting new, there's little reason to pick Formik.
+
+### vs TanStack Form
+
+The closest philosophically — both are selector-first and treat subscriptions as the default.
+TanStack Form's strength is a headless, multi-framework core; its cost is a heavier generics
+surface and no schema-driven generation. El Form trades the framework-agnostic core for a
+simpler, React-focused, schema-first experience (`AutoForm`, single inferred `T`, built-in UI
+and a11y).
+
+### vs react-final-form
+
+Final Form pioneered subscription-based form state, and that idea is excellent (El Form shares
+it). But Final Form has a smaller ecosystem, no schema-agnostic validation story, and no
+Standard Schema support. El Form offers the same re-render isolation with modern schema
+integration on top.
+
+## Honest caveats
+
+El Form is young. It has far fewer downloads, GitHub stars, and battle-hours than React Hook
+Form or Formik, a smaller community, and fewer third-party integrations. If those are
+dealbreakers for your team, that's a legitimate reason to wait. What El Form offers *today* is
+a genuinely different feature set — schema-to-form generation, built-in accessibility and
+files, default re-render isolation, and agent-first tooling — for teams those things matter to.
+
+Ready to try it? Start with the [Quick Start](./quick-start.md) or generate a form instantly
+with [AutoForm](./guides/auto-form.md).

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -15,6 +15,10 @@ keywords:
 
 Welcome to **El Form** - a powerful, schema-agnostic React form library that makes building forms simple, type-safe, and flexible.
 
+:::info El Form is a React library
+El Form (npm: `el-form-react`) is for **React**. It is not affiliated with Vue Element Plus's built-in `<el-form>` component. Looking for how it stacks up against React Hook Form, Formik, or TanStack Form? See the [comparison](./comparison.md).
+:::
+
 ## What is El Form?
 
 El Form is designed to solve the real problems developers face when building forms in React applications. Whether you need a simple contact form or a complex multi-step wizard, El Form provides the tools you need without locking you into specific validation libraries or architectural patterns.

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -4,8 +4,32 @@ import path from "path";
 
 const config: Config = {
   title: "El Form",
-  tagline: "Elegant React forms, powered by Zod",
+  tagline:
+    "TypeScript-first React form library: schema-driven AutoForm + a flexible useForm hook (Zod, Yup, Valibot).",
   favicon: "img/favicon.ico",
+
+  // Structured data so search engines and LLMs can classify El Form as a
+  // developer tool. Rendered into <head> on every page.
+  headTags: [
+    {
+      tagName: "script",
+      attributes: { type: "application/ld+json" },
+      innerHTML: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        name: "El Form",
+        applicationCategory: "DeveloperApplication",
+        operatingSystem: "Web, Node.js",
+        description:
+          "TypeScript-first React form library with schema-driven AutoForm generation and a flexible useForm hook. Works with Zod, Yup, and Valibot.",
+        url: "https://elform.dev",
+        offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+        license: "https://opensource.org/licenses/MIT",
+        programmingLanguage: "TypeScript",
+        codeRepository: "https://github.com/colorpulse6/el-form",
+      }),
+    },
+  ],
 
   // Set the production url of your site here
   url: "https://elform.dev",
@@ -95,6 +119,15 @@ const config: Config = {
 
   themeConfig: {
     image: "img/docusaurus-social-card.jpg",
+    metadata: [
+      {
+        name: "keywords",
+        content:
+          "react form library, react hook form alternative, autoform, zod forms, yup, valibot, typescript forms, schema form, react forms, formik alternative, tanstack form, ai agent forms",
+      },
+      { name: "twitter:card", content: "summary_large_image" },
+      { property: "og:type", content: "website" },
+    ],
     colorMode: {
       defaultMode: "light",
       disableSwitch: false,

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -3,7 +3,7 @@ const sidebars = {
     {
       type: "category",
       label: "Getting Started",
-      items: ["intro", "installation", "quick-start", "examples"],
+      items: ["intro", "installation", "quick-start", "examples", "comparison"],
     },
     {
       type: "category",


### PR DESCRIPTION
Discoverability improvements — all in-repo, no external publishing, no package source changes.

## What
- **Comparison page** (`/docs/comparison`) — "El Form vs React Hook Form, Formik & TanStack Form." Honest feature matrix + when-to-pick-each. Targets the winnable "RHF alternative" / "el-form vs X" long-tail that LLMs-with-search and listicle authors cite.
- **Name disambiguation** (README + docs intro) — El Form (React) vs Vue Element Plus's `<el-form>`, which currently dominates the bare search term.
- **Docs meta SEO** — richer `tagline` (default meta description), `themeConfig.metadata` (keywords + twitter:card), JSON-LD `SoftwareApplication` via `headTags`.
- **Fixed** the broken CI status badge (deprecated shields `workflow/status` endpoint → `actions/workflow/status/...ci.yml`).
- **(Separately, already applied)** 15 GitHub repo topics added for topic-page / awesome-list discovery.

## Accuracy
An independent reviewer verified **every** el-form capability claim against `packages/` source and flagged one overstatement (AutoForm generation is Zod-only) and one wording bug (focus-on-error is on-by-default, not opt-in) — both fixed before commit. Competitor characterizations were checked as fair and well-hedged.

## Verification
`pnpm --filter el-form-docs build` succeeds (no broken links); sitemap includes the new page; JSON-LD + keywords present in built output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)