### PR TITLE
Docs Playground + interactive sandboxes; fix AutoForm zod-3 field generation

### DIFF
--- a/.changeset/autoform-zod3-fields.md
+++ b/.changeset/autoform-zod3-fields.md
@@ -1,0 +1,15 @@
+---
+"el-form-core": patch
+"el-form-react-components": patch
+---
+
+fix(AutoForm): generate fields with Zod 3.x
+
+AutoForm rendered **zero fields** when used with Zod 3.x — only the Submit/Reset
+buttons appeared. It read a ZodObject's shape from `getDef(schema).shape`, which in
+Zod 3 is `_def.shape`, a getter **function** (in Zod 4 the shape is already an
+object), so iterating it produced no keys. A new `getObjectShape` helper in
+`el-form-core` invokes the getter when needed and falls back to the public `.shape`,
+so AutoForm now generates fields across Zod 3 and Zod 4. (The regression dated to the
+dual Zod 3/4 introspection refactor; it was masked because the component tests resolve
+Zod 4.)

--- a/docs/docs/concepts/validation.md
+++ b/docs/docs/concepts/validation.md
@@ -10,9 +10,6 @@ keywords:
   - el form validation concepts
 ---
 
-import { Sandbox } from '@site/src/components';
-import { validationFiles } from '@site/src/sandboxes/validation';
-
 # Validation
 
 El Form's schema-agnostic validation is its core feature. Unlike other form libraries that tie you to specific validation libraries, El Form works with any validation approach.
@@ -35,11 +32,27 @@ This simple interface means El Form can work with any validation library or cust
 
 ### Zod (Recommended)
 
-Zod provides excellent TypeScript integration and runtime safety. This example
-validates on every keystroke via `validators.onChange` and surfaces
-`formState.errors` live — type an invalid email or a short password to see it:
+:::tip Try it live
+Edit this example in the [interactive Playground](/playground?example=validation).
+:::
 
-<Sandbox files={validationFiles} />
+Zod provides excellent TypeScript integration and runtime safety:
+
+```typescript
+import { z } from "zod";
+import { useForm } from "el-form-react-hooks";
+
+const schema = z.object({
+  email: z.string().email("Please enter a valid email"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+  age: z.number().min(18, "Must be 18 or older"),
+});
+
+const form = useForm({
+  validators: { onChange: schema },
+  defaultValues: { email: "", password: "", age: 18 },
+});
+```
 
 ### Yup
 

--- a/docs/docs/concepts/validation.md
+++ b/docs/docs/concepts/validation.md
@@ -10,6 +10,9 @@ keywords:
   - el form validation concepts
 ---
 
+import { Sandbox } from '@site/src/components';
+import { validationFiles } from '@site/src/sandboxes/validation';
+
 # Validation
 
 El Form's schema-agnostic validation is its core feature. Unlike other form libraries that tie you to specific validation libraries, El Form works with any validation approach.
@@ -32,23 +35,11 @@ This simple interface means El Form can work with any validation library or cust
 
 ### Zod (Recommended)
 
-Zod provides excellent TypeScript integration and runtime safety:
+Zod provides excellent TypeScript integration and runtime safety. This example
+validates on every keystroke via `validators.onChange` and surfaces
+`formState.errors` live — type an invalid email or a short password to see it:
 
-```typescript
-import { z } from "zod";
-import { useForm } from "el-form-react-hooks";
-
-const schema = z.object({
-  email: z.string().email("Please enter a valid email"),
-  password: z.string().min(8, "Password must be at least 8 characters"),
-  age: z.number().min(18, "Must be 18 or older"),
-});
-
-const form = useForm({
-  validators: { onChange: schema },
-  defaultValues: { email: "", password: "", age: 18 },
-});
-```
+<Sandbox files={validationFiles} />
 
 ### Yup
 

--- a/docs/docs/guides/array-fields.md
+++ b/docs/docs/guides/array-fields.md
@@ -9,6 +9,9 @@ keywords:
   - el form arrays
 ---
 
+import { Sandbox } from '@site/src/components';
+import { fieldArrayFiles } from '@site/src/sandboxes/fieldArray';
+
 # Array Fields Guide
 
 Array fields handle dynamic lists — line items, multiple emails, a set of
@@ -21,60 +24,7 @@ stable `id` to use as the React `key`, plus operations for reordering and
 inserting — `append`, `prepend`, `insert`, `remove`, `move`, `swap`, `update`,
 and `replace`.
 
-```tsx
-import {
-  useForm,
-  FormProvider,
-  useFormContext,
-  useFieldArray,
-} from "el-form-react-hooks";
-
-type Form = { items: { name: string; quantity: number }[] };
-
-function ItemsForm() {
-  const form = useForm<Form>({
-    defaultValues: { items: [{ name: "", quantity: 1 }] },
-  });
-
-  return (
-    <FormProvider form={form}>
-      <Items />
-    </FormProvider>
-  );
-}
-
-function Items() {
-  const { register } = useFormContext<Form>();
-  const { fields, append, remove, move } = useFieldArray<Form, "items">({
-    name: "items",
-  });
-
-  return (
-    <>
-      {fields.map((field, index) => (
-        <div key={field.id}>
-          {/* ← stable id, never the array index */}
-          <input {...register(`items.${index}.name`)} placeholder="Name" />
-          <input
-            type="number"
-            {...register(`items.${index}.quantity`)}
-            placeholder="Qty"
-          />
-          <button type="button" onClick={() => remove(index)}>
-            Remove
-          </button>
-          <button type="button" onClick={() => move(index, index - 1)}>
-            Move up
-          </button>
-        </div>
-      ))}
-      <button type="button" onClick={() => append({ name: "", quantity: 1 })}>
-        Add item
-      </button>
-    </>
-  );
-}
-```
+<Sandbox files={fieldArrayFiles} />
 
 **Why `field.id` and not the index?** Using the array index as a React `key`
 breaks the moment you insert, reorder, or remove from the middle of the list —

--- a/docs/docs/guides/array-fields.md
+++ b/docs/docs/guides/array-fields.md
@@ -48,7 +48,7 @@ function ItemsForm() {
 }
 
 function Items() {
-  const { register } = useFormContext<Form>();
+  const { register } = useFormContext<Form>().form;
   const { fields, append, remove, move } = useFieldArray<Form, "items">({
     name: "items",
   });

--- a/docs/docs/guides/array-fields.md
+++ b/docs/docs/guides/array-fields.md
@@ -9,9 +9,6 @@ keywords:
   - el form arrays
 ---
 
-import { Sandbox } from '@site/src/components';
-import { fieldArrayFiles } from '@site/src/sandboxes/fieldArray';
-
 # Array Fields Guide
 
 Array fields handle dynamic lists — line items, multiple emails, a set of
@@ -19,12 +16,69 @@ contacts — where the user can add and remove rows.
 
 ## Recommended: `useFieldArray`
 
+:::tip Try it live
+Edit this example in the [interactive Playground](/playground?example=fieldarray).
+:::
+
 `useFieldArray` is the cleanest way to build dynamic arrays. It gives each row a
 stable `id` to use as the React `key`, plus operations for reordering and
 inserting — `append`, `prepend`, `insert`, `remove`, `move`, `swap`, `update`,
 and `replace`.
 
-<Sandbox files={fieldArrayFiles} />
+```tsx
+import {
+  useForm,
+  FormProvider,
+  useFormContext,
+  useFieldArray,
+} from "el-form-react-hooks";
+
+type Form = { items: { name: string; quantity: number }[] };
+
+function ItemsForm() {
+  const form = useForm<Form>({
+    defaultValues: { items: [{ name: "", quantity: 1 }] },
+  });
+
+  return (
+    <FormProvider form={form}>
+      <Items />
+    </FormProvider>
+  );
+}
+
+function Items() {
+  const { register } = useFormContext<Form>();
+  const { fields, append, remove, move } = useFieldArray<Form, "items">({
+    name: "items",
+  });
+
+  return (
+    <>
+      {fields.map((field, index) => (
+        <div key={field.id}>
+          {/* ← stable id, never the array index */}
+          <input {...register(`items.${index}.name`)} placeholder="Name" />
+          <input
+            type="number"
+            {...register(`items.${index}.quantity`)}
+            placeholder="Qty"
+          />
+          <button type="button" onClick={() => remove(index)}>
+            Remove
+          </button>
+          <button type="button" onClick={() => move(index, index - 1)}>
+            Move up
+          </button>
+        </div>
+      ))}
+      <button type="button" onClick={() => append({ name: "", quantity: 1 })}>
+        Add item
+      </button>
+    </>
+  );
+}
+```
 
 **Why `field.id` and not the index?** Using the array index as a React `key`
 breaks the moment you insert, reorder, or remove from the middle of the list —

--- a/docs/docs/guides/auto-form.md
+++ b/docs/docs/guides/auto-form.md
@@ -13,8 +13,6 @@ keywords:
 import { InteractivePreview } from '@site/src/components';
 import { SimpleAutoFormExample } from '@site/src/components/examples';
 import { Callout } from '@site/src/components/Callout';
-import { Sandbox } from '@site/src/components';
-import { autoFormBasicFiles } from '@site/src/sandboxes/autoFormBasic';
 
 # AutoForm Guide
 
@@ -26,9 +24,33 @@ This guide covers everything you need to know to use AutoForm effectively, from 
 
 ### Basic Usage
 
+:::tip Try it live
+Open this example in the [interactive Playground](/playground?example=autoform).
+:::
+
 Generate a complete form from a Zod schema in seconds:
 
-<Sandbox files={autoFormBasicFiles} />
+```tsx
+import { AutoForm } from "el-form-react-components";
+import { z } from "zod";
+
+const userSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  email: z.string().email("Invalid email"),
+  age: z.number().min(18, "Must be 18+"),
+  role: z.enum(["admin", "user", "guest"]),
+});
+
+function UserForm() {
+  return (
+    <AutoForm
+      schema={userSchema}
+      onSubmit={(data) => console.log("Success:", data)}
+      onError={(errors) => console.log("Errors:", errors)}
+    />
+  );
+}
+```
 
 This automatically generates:
 

--- a/docs/docs/guides/auto-form.md
+++ b/docs/docs/guides/auto-form.md
@@ -13,6 +13,8 @@ keywords:
 import { InteractivePreview } from '@site/src/components';
 import { SimpleAutoFormExample } from '@site/src/components/examples';
 import { Callout } from '@site/src/components/Callout';
+import { Sandbox } from '@site/src/components';
+import { autoFormBasicFiles } from '@site/src/sandboxes/autoFormBasic';
 
 # AutoForm Guide
 
@@ -26,27 +28,7 @@ This guide covers everything you need to know to use AutoForm effectively, from 
 
 Generate a complete form from a Zod schema in seconds:
 
-```tsx
-import { AutoForm } from "el-form-react-components";
-import { z } from "zod";
-
-const userSchema = z.object({
-  name: z.string().min(1, "Name is required"),
-  email: z.string().email("Invalid email"),
-  age: z.number().min(18, "Must be 18+"),
-  role: z.enum(["admin", "user", "guest"]),
-});
-
-function UserForm() {
-  return (
-    <AutoForm
-      schema={userSchema}
-      onSubmit={(data) => console.log("Success:", data)}
-      onError={(errors) => console.log("Errors:", errors)}
-    />
-  );
-}
-```
+<Sandbox files={autoFormBasicFiles} />
 
 This automatically generates:
 

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -12,6 +12,8 @@ keywords:
 ---
 
 import { InstallCommand, CodeBlock, Callout, FeatureCard, InteractivePreview, ProgressSteps } from '@site/src/components/DocComponents';
+import { Sandbox } from '@site/src/components';
+import { useFormQuickStartFiles } from '@site/src/sandboxes/useFormQuickStart';
 
 # Quick Start
 
@@ -90,23 +92,7 @@ This generates a complete form with validation, error handling, type safety, and
 
 For custom forms with full control, use the `useForm` hook:
 
-```tsx
-import { useForm } from "el-form-react-hooks";
-
-function CustomForm() {
-  const { register, handleSubmit, formState } = useForm({
-    defaultValues: { email: "", message: "" },
-  });
-
-  return (
-    <form onSubmit={handleSubmit((data) => console.log(data))}>
-      <input {...register("email")} placeholder="Email" />
-      <textarea {...register("message")} placeholder="Message" />
-      <button type="submit">Submit</button>
-    </form>
-  );
-}
-```
+<Sandbox files={useFormQuickStartFiles} />
 
 ## Validation Options
 

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -12,8 +12,6 @@ keywords:
 ---
 
 import { InstallCommand, CodeBlock, Callout, FeatureCard, InteractivePreview, ProgressSteps } from '@site/src/components/DocComponents';
-import { Sandbox } from '@site/src/components';
-import { useFormQuickStartFiles } from '@site/src/sandboxes/useFormQuickStart';
 
 # Quick Start
 
@@ -90,9 +88,29 @@ This generates a complete form with validation, error handling, type safety, and
 
 ## Alternative: useForm Hook
 
+:::tip Try it live
+Edit this example in the [interactive Playground](/playground?example=useform).
+:::
+
 For custom forms with full control, use the `useForm` hook:
 
-<Sandbox files={useFormQuickStartFiles} />
+```tsx
+import { useForm } from "el-form-react-hooks";
+
+function CustomForm() {
+  const { register, handleSubmit, formState } = useForm({
+    defaultValues: { email: "", message: "" },
+  });
+
+  return (
+    <form onSubmit={handleSubmit((data) => console.log(data))}>
+      <input {...register("email")} placeholder="Email" />
+      <textarea {...register("message")} placeholder="Message" />
+      <button type="submit">Submit</button>
+    </form>
+  );
+}
+```
 
 ## Validation Options
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -159,6 +159,11 @@ const config: Config = {
       items: [
         // Search disabled for now
         {
+          to: "/playground",
+          label: "Playground",
+          position: "right",
+        },
+        {
           type: "html",
           position: "right",
           value:

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -1,12 +1,20 @@
 import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
 import path from "path";
+import { getElFormVersions } from "./src/sandboxes/versions";
 
 const config: Config = {
   title: "El Form",
   tagline:
     "TypeScript-first React form library: schema-driven AutoForm + a flexible useForm hook (Zod, Yup, Valibot).",
   favicon: "img/favicon.ico",
+
+  customFields: {
+    // Pinned to the current workspace versions at build time so sandboxes never
+    // go stale. main's package.json == latest published npm (Changesets bumps
+    // version and publishes atomically), so this matches `npm install`.
+    elFormVersions: getElFormVersions(path.resolve(__dirname, "../packages")),
+  },
 
   // Structured data so search engines and LLMs can classify El Form as a
   // developer tool. Rendered into <head> on every page.

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,6 +19,7 @@
     "@codesandbox/sandpack-themes": "^2.0.21",
     "@docusaurus/core": "3.8.0",
     "@docusaurus/preset-classic": "3.8.0",
+    "@docusaurus/theme-common": "3.8.0",
     "@easyops-cn/docusaurus-search-local": "^0.52.1",
     "@mdx-js/react": "^3.0.0",
     "@tailwindcss/postcss": "^4.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,9 +11,12 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids"
+    "write-heading-ids": "docusaurus write-heading-ids",
+    "test": "vitest run"
   },
   "dependencies": {
+    "@codesandbox/sandpack-react": "^2.19.0",
+    "@codesandbox/sandpack-themes": "^2.0.21",
     "@docusaurus/core": "3.8.0",
     "@docusaurus/preset-classic": "3.8.0",
     "@easyops-cn/docusaurus-search-local": "^0.52.1",
@@ -32,7 +35,8 @@
     "@docusaurus/module-type-aliases": "3.8.0",
     "@docusaurus/tsconfig": "3.8.0",
     "@docusaurus/types": "3.8.0",
-    "typescript": "~5.2.0"
+    "typescript": "~5.2.0",
+    "vitest": "^2.1.0"
   },
   "browserslist": {
     "production": [

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -3,7 +3,18 @@ const sidebars = {
     {
       type: "category",
       label: "Getting Started",
-      items: ["intro", "installation", "quick-start", "examples", "comparison"],
+      items: [
+        "intro",
+        "installation",
+        "quick-start",
+        "examples",
+        "comparison",
+        {
+          type: "link",
+          label: "Playground ↗",
+          href: "/playground",
+        },
+      ],
     },
     {
       type: "category",

--- a/docs/src/components/Playground.tsx
+++ b/docs/src/components/Playground.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useState } from "react";
+import CodeBlock from "@theme/CodeBlock";
+import { Sandbox } from "./Sandbox";
+import {
+  PLAYGROUND_EXAMPLES,
+  DEFAULT_EXAMPLE_ID,
+  findExample,
+} from "../sandboxes/registry";
+
+/**
+ * The interactive playground: a left-hand list of examples and a panel that
+ * renders the selected one. Live examples mount a <Sandbox>; static-only ones
+ * (e.g. AutoForm while its field-gen bug is open) show source. The selection is
+ * mirrored to the URL hash so doc sections can deep-link (`/playground#autoform`).
+ */
+export function Playground() {
+  const [selectedId, setSelectedId] = useState<string>(DEFAULT_EXAMPLE_ID);
+
+  useEffect(() => {
+    const fromQuery = new URLSearchParams(window.location.search).get(
+      "example"
+    );
+    if (fromQuery) setSelectedId(findExample(fromQuery).id);
+  }, []);
+
+  const select = (id: string) => {
+    setSelectedId(id);
+    if (typeof window !== "undefined") {
+      window.history.replaceState(null, "", `?example=${id}`);
+    }
+  };
+
+  const example = findExample(selectedId);
+
+  return (
+    <div className="row" style={{ margin: 0 }}>
+      <nav
+        className="col col--3"
+        aria-label="Playground examples"
+        style={{ paddingLeft: 0 }}
+      >
+        <ul
+          style={{
+            listStyle: "none",
+            padding: 0,
+            margin: 0,
+            position: "sticky",
+            top: "5rem",
+          }}
+        >
+          {PLAYGROUND_EXAMPLES.map((e) => {
+            const active = e.id === example.id;
+            return (
+              <li key={e.id}>
+                <button
+                  type="button"
+                  onClick={() => select(e.id)}
+                  aria-current={active ? "true" : undefined}
+                  className="button button--block"
+                  style={{
+                    justifyContent: "flex-start",
+                    marginBottom: 6,
+                    background: active
+                      ? "var(--ifm-color-primary)"
+                      : "transparent",
+                    color: active ? "white" : "var(--ifm-font-color-base)",
+                    border: "1px solid var(--ifm-color-emphasis-300)",
+                  }}
+                >
+                  {e.label}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+
+      <div className="col col--9">
+        <h2 style={{ marginTop: 0 }}>{example.label}</h2>
+        <p>{example.blurb}</p>
+        {example.files ? (
+          <Sandbox files={example.files} previewHeight={520} />
+        ) : (
+          <>
+            {example.note && (
+              <div
+                className="admonition admonition-info alert alert--info"
+                role="note"
+                style={{ marginBottom: 16, padding: "12px 16px" }}
+              >
+                {example.note}
+              </div>
+            )}
+            <CodeBlock language="tsx" title="App.tsx">
+              {example.staticCode}
+            </CodeBlock>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/docs/src/components/Sandbox.tsx
+++ b/docs/src/components/Sandbox.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import BrowserOnly from "@docusaurus/BrowserOnly";
+import { useColorMode } from "@docusaurus/theme-common";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import {
+  SandpackProvider,
+  SandpackLayout,
+  SandpackCodeEditor,
+  SandpackPreview,
+  type SandpackFiles,
+} from "@codesandbox/sandpack-react";
+import { githubLight, sandpackDark } from "@codesandbox/sandpack-themes";
+
+export interface SandboxProps {
+  /** Sandpack file map. At minimum an entry-point App.tsx. */
+  files: SandpackFiles;
+  /** File to focus when the sandbox loads. */
+  activeFile?: string;
+  /** Override/extend the injected dependency map (e.g. pin a peer). */
+  dependencies?: Record<string, string>;
+  /** Preview pane height in px. */
+  previewHeight?: number;
+}
+
+// Non-el-form deps the examples need. el-form versions come from customFields.
+const BASE_DEPENDENCIES: Record<string, string> = {
+  react: "18.2.0",
+  "react-dom": "18.2.0",
+  zod: "^3.23.0",
+};
+
+function SandboxInner({
+  files,
+  activeFile,
+  dependencies,
+  previewHeight = 460,
+}: SandboxProps) {
+  const { colorMode } = useColorMode();
+  const { siteConfig } = useDocusaurusContext();
+  const elFormVersions =
+    (siteConfig.customFields?.elFormVersions as Record<string, string>) ?? {};
+
+  const mergedDependencies = {
+    ...BASE_DEPENDENCIES,
+    ...elFormVersions,
+    ...dependencies,
+  };
+
+  return (
+    <div className="my-6">
+      <SandpackProvider
+        template="react-ts"
+        theme={colorMode === "dark" ? sandpackDark : githubLight}
+        files={files}
+        customSetup={{ dependencies: mergedDependencies }}
+        options={{ initMode: "lazy", ...(activeFile ? { activeFile } : {}) }}
+      >
+        <SandpackLayout>
+          <SandpackCodeEditor showLineNumbers showTabs />
+          <SandpackPreview
+            showOpenInCodeSandbox
+            style={{ height: previewHeight }}
+          />
+        </SandpackLayout>
+      </SandpackProvider>
+    </div>
+  );
+}
+
+/**
+ * Inline el-form sandbox. SSR-safe (Sandpack is client-only) and only imported by
+ * the pages that use it, so the heavy bundle is code-split onto those pages.
+ */
+export function Sandbox(props: SandboxProps) {
+  return (
+    <BrowserOnly fallback={<div className="my-6">Loading sandbox…</div>}>
+      {() => <SandboxInner {...props} />}
+    </BrowserOnly>
+  );
+}

--- a/docs/src/components/index.ts
+++ b/docs/src/components/index.ts
@@ -7,5 +7,7 @@ export { ApiReference } from "./ApiReference";
 export { InteractivePreview } from "./InteractivePreview";
 export { ProgressSteps } from "./ProgressSteps";
 
+export { Sandbox } from "./Sandbox";
+
 // Export examples
 export * from "./examples";

--- a/docs/src/pages/playground.tsx
+++ b/docs/src/pages/playground.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Layout from "@theme/Layout";
+import Link from "@docusaurus/Link";
 import { Playground } from "../components/Playground";
 
 export default function PlaygroundPage(): JSX.Element {
@@ -9,7 +10,10 @@ export default function PlaygroundPage(): JSX.Element {
       description="Edit el-form examples live — useForm, AutoForm, validation, and field arrays — and see the form update."
     >
       <main className="container margin-vert--lg">
-        <h1>Playground</h1>
+        <Link to="/docs/intro" className="button button--secondary button--sm">
+          ← Back to docs
+        </Link>
+        <h1 className="margin-top--md">Playground</h1>
         <p>
           Edit a real el-form example and watch the form update. Pick one from
           the list, tweak the schema or code, and use “Open in CodeSandbox” to

--- a/docs/src/pages/playground.tsx
+++ b/docs/src/pages/playground.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import { Playground } from "../components/Playground";
+
+export default function PlaygroundPage(): JSX.Element {
+  return (
+    <Layout
+      title="Playground"
+      description="Edit el-form examples live — useForm, AutoForm, validation, and field arrays — and see the form update."
+    >
+      <main className="container margin-vert--lg">
+        <h1>Playground</h1>
+        <p>
+          Edit a real el-form example and watch the form update. Pick one from
+          the list, tweak the schema or code, and use “Open in CodeSandbox” to
+          fork it.
+        </p>
+        <Playground />
+      </main>
+    </Layout>
+  );
+}

--- a/docs/src/sandboxes/autoFormBasic.ts
+++ b/docs/src/sandboxes/autoFormBasic.ts
@@ -1,0 +1,25 @@
+import type { SandpackFiles } from "@codesandbox/sandpack-react";
+
+const APP = `import { AutoForm } from "el-form-react-components";
+import "el-form-react-components/styles.css";
+import { z } from "zod";
+
+const schema = z.object({
+  firstName: z.string().min(1, "First name is required"),
+  email: z.string().email("Please enter a valid email"),
+  age: z.number().min(18, "Must be 18 or older"),
+});
+
+export default function App() {
+  return (
+    <div style={{ padding: 16 }}>
+      <AutoForm
+        schema={schema}
+        onSubmit={(data) => alert(JSON.stringify(data, null, 2))}
+      />
+    </div>
+  );
+}
+`;
+
+export const autoFormBasicFiles: SandpackFiles = { "/App.tsx": APP };

--- a/docs/src/sandboxes/exampleStyles.ts
+++ b/docs/src/sandboxes/exampleStyles.ts
@@ -1,0 +1,91 @@
+// Temporary shared styling for the live Playground example forms so they look
+// polished in the deployed docs. This is a stopgap until the design-presets
+// phase ships real AutoForm themes — it styles native form elements generically
+// (each Sandpack preview is an isolated document, so global selectors are safe).
+export const EXAMPLE_STYLES = `* {
+  box-sizing: border-box;
+}
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #f1f5f9;
+  color: #0f172a;
+  margin: 0;
+  padding: 28px;
+}
+form {
+  display: grid;
+  gap: 18px;
+  max-width: 440px;
+  background: #ffffff;
+  padding: 28px;
+  border-radius: 14px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04), 0 8px 24px rgba(15, 23, 42, 0.06);
+}
+label {
+  display: grid;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #334155;
+}
+input,
+textarea,
+select {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #cbd5e1;
+  border-radius: 9px;
+  font-size: 14px;
+  font-family: inherit;
+  color: #0f172a;
+  background: #fff;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+input::placeholder,
+textarea::placeholder {
+  color: #94a3b8;
+}
+input:focus,
+textarea:focus,
+select:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+}
+button {
+  padding: 10px 18px;
+  border: none;
+  border-radius: 9px;
+  background: #6366f1;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.05s ease;
+}
+button:hover {
+  background: #4f46e5;
+}
+button:active {
+  transform: translateY(1px);
+}
+button[type="button"] {
+  background: #eef2ff;
+  color: #4338ca;
+}
+button[type="button"]:hover {
+  background: #e0e7ff;
+}
+.error {
+  color: #dc2626;
+  font-size: 13px;
+  font-weight: 500;
+  margin-top: -8px;
+}
+.row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+`;

--- a/docs/src/sandboxes/fieldArray.ts
+++ b/docs/src/sandboxes/fieldArray.ts
@@ -1,0 +1,67 @@
+import type { SandpackFiles } from "@codesandbox/sandpack-react";
+
+const APP = `import {
+  useForm,
+  FormProvider,
+  useFormContext,
+  useFieldArray,
+} from "el-form-react-hooks";
+
+type Form = { items: { name: string; quantity: number }[] };
+
+export default function App() {
+  // useFieldArray reads the form from context, so wrap the fields in
+  // <FormProvider> and consume it with useFormContext inside <Items />.
+  const form = useForm<Form>({
+    defaultValues: { items: [{ name: "", quantity: 1 }] },
+  });
+
+  return (
+    <div style={{ padding: 16, fontFamily: "sans-serif", maxWidth: 420 }}>
+      <FormProvider form={form}>
+        <form
+          onSubmit={form.handleSubmit((data) =>
+            alert(JSON.stringify(data, null, 2))
+          )}
+          style={{ display: "grid", gap: 12 }}
+        >
+          <Items />
+          <button type="submit">Submit</button>
+        </form>
+      </FormProvider>
+    </div>
+  );
+}
+
+function Items() {
+  const { register } = useFormContext<Form>();
+  const { fields, append, remove } = useFieldArray<Form, "items">({
+    name: "items",
+  });
+
+  return (
+    <>
+      {fields.map((field, index) => (
+        <div key={field.id} style={{ display: "flex", gap: 8 }}>
+          {/* key is the stable field.id, never the array index */}
+          <input {...register(\`items.\${index}.name\`)} placeholder="Name" />
+          <input
+            type="number"
+            {...register(\`items.\${index}.quantity\`)}
+            placeholder="Qty"
+            style={{ width: 70 }}
+          />
+          <button type="button" onClick={() => remove(index)}>
+            Remove
+          </button>
+        </div>
+      ))}
+      <button type="button" onClick={() => append({ name: "", quantity: 1 })}>
+        Add item
+      </button>
+    </>
+  );
+}
+`;
+
+export const fieldArrayFiles: SandpackFiles = { "/App.tsx": APP };

--- a/docs/src/sandboxes/fieldArray.ts
+++ b/docs/src/sandboxes/fieldArray.ts
@@ -1,4 +1,5 @@
 import type { SandpackFiles } from "@codesandbox/sandpack-react";
+import { EXAMPLE_STYLES } from "./exampleStyles";
 
 const APP = `import {
   useForm,
@@ -6,6 +7,7 @@ const APP = `import {
   useFormContext,
   useFieldArray,
 } from "el-form-react-hooks";
+import "./styles.css";
 
 type Form = { items: { name: string; quantity: number }[] };
 
@@ -17,19 +19,16 @@ export default function App() {
   });
 
   return (
-    <div style={{ padding: 16, fontFamily: "sans-serif", maxWidth: 420 }}>
-      <FormProvider form={form}>
-        <form
-          onSubmit={form.handleSubmit((data) =>
-            alert(JSON.stringify(data, null, 2))
-          )}
-          style={{ display: "grid", gap: 12 }}
-        >
-          <Items />
-          <button type="submit">Submit</button>
-        </form>
-      </FormProvider>
-    </div>
+    <FormProvider form={form}>
+      <form
+        onSubmit={form.handleSubmit((data) =>
+          alert(JSON.stringify(data, null, 2))
+        )}
+      >
+        <Items />
+        <button type="submit">Submit</button>
+      </form>
+    </FormProvider>
   );
 }
 
@@ -42,14 +41,14 @@ function Items() {
   return (
     <>
       {fields.map((field, index) => (
-        <div key={field.id} style={{ display: "flex", gap: 8 }}>
+        <div key={field.id} className="row">
           {/* key is the stable field.id, never the array index */}
           <input {...register(\`items.\${index}.name\`)} placeholder="Name" />
           <input
             type="number"
             {...register(\`items.\${index}.quantity\`)}
             placeholder="Qty"
-            style={{ width: 70 }}
+            style={{ width: 90 }}
           />
           <button type="button" onClick={() => remove(index)}>
             Remove
@@ -64,4 +63,7 @@ function Items() {
 }
 `;
 
-export const fieldArrayFiles: SandpackFiles = { "/App.tsx": APP };
+export const fieldArrayFiles: SandpackFiles = {
+  "/App.tsx": APP,
+  "/styles.css": EXAMPLE_STYLES,
+};

--- a/docs/src/sandboxes/fieldArray.ts
+++ b/docs/src/sandboxes/fieldArray.ts
@@ -34,7 +34,7 @@ export default function App() {
 }
 
 function Items() {
-  const { register } = useFormContext<Form>();
+  const { register } = useFormContext<Form>().form;
   const { fields, append, remove } = useFieldArray<Form, "items">({
     name: "items",
   });

--- a/docs/src/sandboxes/registry.ts
+++ b/docs/src/sandboxes/registry.ts
@@ -1,0 +1,58 @@
+import type { SandpackFiles } from "@codesandbox/sandpack-react";
+import { useFormQuickStartFiles } from "./useFormQuickStart";
+import { validationFiles } from "./validation";
+import { fieldArrayFiles } from "./fieldArray";
+import { autoFormBasicFiles } from "./autoFormBasic";
+
+export interface PlaygroundExample {
+  /** URL-hash id, e.g. `/playground#useform`. */
+  id: string;
+  label: string;
+  /** One-line description shown above the example. */
+  blurb: string;
+  /** Live Sandpack files. Omit when the example is static-only. */
+  files?: SandpackFiles;
+  /** Raw source shown as a static code block when `files` is absent. */
+  staticCode?: string;
+  /** Note rendered with a static example (e.g. why it isn't live yet). */
+  note?: string;
+}
+
+// The four learning-path examples. useForm / validation / field-array run live;
+// AutoForm is shown as static source until a known field-generation bug with
+// zod 3.x is fixed in el-form-react-components (AutoForm renders no fields).
+export const PLAYGROUND_EXAMPLES: PlaygroundExample[] = [
+  {
+    id: "useform",
+    label: "useForm",
+    blurb: "Imperative form state with register + validation.",
+    files: useFormQuickStartFiles,
+  },
+  {
+    id: "validation",
+    label: "Validation",
+    blurb: "Schema-agnostic onChange validation, errors surfaced live.",
+    files: validationFiles,
+  },
+  {
+    id: "fieldarray",
+    label: "Field array",
+    blurb: "Dynamic rows with useFieldArray (append / remove).",
+    files: fieldArrayFiles,
+  },
+  {
+    id: "autoform",
+    label: "AutoForm",
+    blurb: "Generate a whole form from a Zod schema.",
+    staticCode: autoFormBasicFiles["/App.tsx"] as string,
+    note: "Static preview for now — the live AutoForm demo is paused while we fix a field-generation issue with recent Zod 3.x versions.",
+  },
+];
+
+export const DEFAULT_EXAMPLE_ID = PLAYGROUND_EXAMPLES[0].id;
+
+export function findExample(id: string | null | undefined): PlaygroundExample {
+  return (
+    PLAYGROUND_EXAMPLES.find((e) => e.id === id) ?? PLAYGROUND_EXAMPLES[0]
+  );
+}

--- a/docs/src/sandboxes/useFormQuickStart.ts
+++ b/docs/src/sandboxes/useFormQuickStart.ts
@@ -1,7 +1,9 @@
 import type { SandpackFiles } from "@codesandbox/sandpack-react";
+import { EXAMPLE_STYLES } from "./exampleStyles";
 
 const APP = `import { useForm } from "el-form-react-hooks";
 import { z } from "zod";
+import "./styles.css";
 
 const schema = z.object({
   email: z.string().email("Please enter a valid email"),
@@ -15,24 +17,21 @@ export default function App() {
   });
 
   return (
-    <form
-      onSubmit={handleSubmit((data) => alert(JSON.stringify(data, null, 2)))}
-      style={{ display: "grid", gap: 12, maxWidth: 380, fontFamily: "sans-serif" }}
-    >
-      <label style={{ display: "grid", gap: 4 }}>
+    <form onSubmit={handleSubmit((data) => alert(JSON.stringify(data, null, 2)))}>
+      <label>
         Email
-        <input {...register("email")} />
+        <input {...register("email")} placeholder="you@example.com" />
       </label>
       {formState.errors.email && (
-        <span style={{ color: "crimson" }}>{formState.errors.email}</span>
+        <span className="error">{formState.errors.email}</span>
       )}
 
-      <label style={{ display: "grid", gap: 4 }}>
+      <label>
         Message
-        <textarea {...register("message")} rows={3} />
+        <textarea {...register("message")} rows={3} placeholder="Say hello…" />
       </label>
       {formState.errors.message && (
-        <span style={{ color: "crimson" }}>{formState.errors.message}</span>
+        <span className="error">{formState.errors.message}</span>
       )}
 
       <button type="submit">Submit</button>
@@ -43,4 +42,5 @@ export default function App() {
 
 export const useFormQuickStartFiles: SandpackFiles = {
   "/App.tsx": APP,
+  "/styles.css": EXAMPLE_STYLES,
 };

--- a/docs/src/sandboxes/useFormQuickStart.ts
+++ b/docs/src/sandboxes/useFormQuickStart.ts
@@ -1,0 +1,46 @@
+import type { SandpackFiles } from "@codesandbox/sandpack-react";
+
+const APP = `import { useForm } from "el-form-react-hooks";
+import { z } from "zod";
+
+const schema = z.object({
+  email: z.string().email("Please enter a valid email"),
+  message: z.string().min(1, "Message is required"),
+});
+
+export default function App() {
+  const { register, handleSubmit, formState } = useForm({
+    validators: { onChange: schema },
+    defaultValues: { email: "", message: "" },
+  });
+
+  return (
+    <form
+      onSubmit={handleSubmit((data) => alert(JSON.stringify(data, null, 2)))}
+      style={{ display: "grid", gap: 12, maxWidth: 380, fontFamily: "sans-serif" }}
+    >
+      <label style={{ display: "grid", gap: 4 }}>
+        Email
+        <input {...register("email")} />
+      </label>
+      {formState.errors.email && (
+        <span style={{ color: "crimson" }}>{formState.errors.email}</span>
+      )}
+
+      <label style={{ display: "grid", gap: 4 }}>
+        Message
+        <textarea {...register("message")} rows={3} />
+      </label>
+      {formState.errors.message && (
+        <span style={{ color: "crimson" }}>{formState.errors.message}</span>
+      )}
+
+      <button type="submit">Submit</button>
+    </form>
+  );
+}
+`;
+
+export const useFormQuickStartFiles: SandpackFiles = {
+  "/App.tsx": APP,
+};

--- a/docs/src/sandboxes/validation.ts
+++ b/docs/src/sandboxes/validation.ts
@@ -1,0 +1,55 @@
+import type { SandpackFiles } from "@codesandbox/sandpack-react";
+
+const APP = `import { useForm } from "el-form-react-hooks";
+import { z } from "zod";
+
+// El Form is schema-agnostic — pass any validator. Here we use Zod on every
+// keystroke via validators.onChange, and surface formState.errors live.
+const schema = z.object({
+  email: z.string().email("Please enter a valid email"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+  age: z.number().min(18, "Must be 18 or older"),
+});
+
+export default function App() {
+  const { register, handleSubmit, formState } = useForm({
+    validators: { onChange: schema },
+    defaultValues: { email: "", password: "", age: 18 },
+  });
+
+  return (
+    <form
+      onSubmit={handleSubmit((data) => alert(JSON.stringify(data, null, 2)))}
+      style={{ display: "grid", gap: 12, maxWidth: 380, fontFamily: "sans-serif" }}
+    >
+      <label style={{ display: "grid", gap: 4 }}>
+        Email
+        <input {...register("email")} />
+      </label>
+      {formState.errors.email && (
+        <span style={{ color: "crimson" }}>{formState.errors.email}</span>
+      )}
+
+      <label style={{ display: "grid", gap: 4 }}>
+        Password
+        <input type="password" {...register("password")} />
+      </label>
+      {formState.errors.password && (
+        <span style={{ color: "crimson" }}>{formState.errors.password}</span>
+      )}
+
+      <label style={{ display: "grid", gap: 4 }}>
+        Age
+        <input type="number" {...register("age")} />
+      </label>
+      {formState.errors.age && (
+        <span style={{ color: "crimson" }}>{formState.errors.age}</span>
+      )}
+
+      <button type="submit">Submit</button>
+    </form>
+  );
+}
+`;
+
+export const validationFiles: SandpackFiles = { "/App.tsx": APP };

--- a/docs/src/sandboxes/validation.ts
+++ b/docs/src/sandboxes/validation.ts
@@ -1,7 +1,9 @@
 import type { SandpackFiles } from "@codesandbox/sandpack-react";
+import { EXAMPLE_STYLES } from "./exampleStyles";
 
 const APP = `import { useForm } from "el-form-react-hooks";
 import { z } from "zod";
+import "./styles.css";
 
 // El Form is schema-agnostic — pass any validator. Here we use Zod on every
 // keystroke via validators.onChange, and surface formState.errors live.
@@ -18,32 +20,29 @@ export default function App() {
   });
 
   return (
-    <form
-      onSubmit={handleSubmit((data) => alert(JSON.stringify(data, null, 2)))}
-      style={{ display: "grid", gap: 12, maxWidth: 380, fontFamily: "sans-serif" }}
-    >
-      <label style={{ display: "grid", gap: 4 }}>
+    <form onSubmit={handleSubmit((data) => alert(JSON.stringify(data, null, 2)))}>
+      <label>
         Email
-        <input {...register("email")} />
+        <input {...register("email")} placeholder="you@example.com" />
       </label>
       {formState.errors.email && (
-        <span style={{ color: "crimson" }}>{formState.errors.email}</span>
+        <span className="error">{formState.errors.email}</span>
       )}
 
-      <label style={{ display: "grid", gap: 4 }}>
+      <label>
         Password
         <input type="password" {...register("password")} />
       </label>
       {formState.errors.password && (
-        <span style={{ color: "crimson" }}>{formState.errors.password}</span>
+        <span className="error">{formState.errors.password}</span>
       )}
 
-      <label style={{ display: "grid", gap: 4 }}>
+      <label>
         Age
         <input type="number" {...register("age")} />
       </label>
       {formState.errors.age && (
-        <span style={{ color: "crimson" }}>{formState.errors.age}</span>
+        <span className="error">{formState.errors.age}</span>
       )}
 
       <button type="submit">Submit</button>
@@ -52,4 +51,7 @@ export default function App() {
 }
 `;
 
-export const validationFiles: SandpackFiles = { "/App.tsx": APP };
+export const validationFiles: SandpackFiles = {
+  "/App.tsx": APP,
+  "/styles.css": EXAMPLE_STYLES,
+};

--- a/docs/src/sandboxes/versions.test.ts
+++ b/docs/src/sandboxes/versions.test.ts
@@ -1,0 +1,27 @@
+import path from "path";
+import { describe, it, expect } from "vitest";
+import { EL_FORM_PACKAGES, getElFormVersions } from "./versions";
+
+// When run via `pnpm --filter el-form-docs test`, cwd is the docs dir.
+const PACKAGES_DIR = path.resolve(process.cwd(), "../packages");
+const SEMVER = /^\d+\.\d+\.\d+/;
+
+describe("getElFormVersions", () => {
+  it("returns a valid semver for every el-form package", () => {
+    const versions = getElFormVersions(PACKAGES_DIR);
+    for (const name of EL_FORM_PACKAGES) {
+      expect(versions[name], `${name} version`).toMatch(SEMVER);
+    }
+  });
+
+  it("covers exactly the four published react packages", () => {
+    expect([...EL_FORM_PACKAGES].sort()).toEqual(
+      [
+        "el-form-core",
+        "el-form-react",
+        "el-form-react-components",
+        "el-form-react-hooks",
+      ].sort()
+    );
+  });
+});

--- a/docs/src/sandboxes/versions.ts
+++ b/docs/src/sandboxes/versions.ts
@@ -1,0 +1,28 @@
+import fs from "fs";
+import path from "path";
+
+// The published packages whose versions Sandpack must pin to. Keeping this list
+// explicit (rather than scanning the monorepo) means a new internal package
+// can't silently leak into the sandbox dependency map.
+export const EL_FORM_PACKAGES = [
+  "el-form-react",
+  "el-form-react-hooks",
+  "el-form-react-components",
+  "el-form-core",
+] as const;
+
+/**
+ * Reads each el-form package's current version from `<packagesDir>/<name>/package.json`.
+ * Pure: the caller supplies the directory, so this works identically under the
+ * Docusaurus config loader (CJS) and Vitest (ESM). Node-only — never import from
+ * client/browser code.
+ */
+export function getElFormVersions(packagesDir: string): Record<string, string> {
+  const versions: Record<string, string> = {};
+  for (const name of EL_FORM_PACKAGES) {
+    const pkgPath = path.join(packagesDir, name, "package.json");
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8")) as { version: string };
+    versions[name] = pkg.version;
+  }
+  return versions;
+}

--- a/docs/superpowers/plans/2026-06-10-docs-sandboxes.md
+++ b/docs/superpowers/plans/2026-06-10-docs-sandboxes.md
@@ -549,3 +549,26 @@ git commit -m "fix(docs): sandbox example/wiring fixes from smoke test"
 ## Out of scope (per spec)
 
 Broad replacement of all examples, a dedicated `/playground` page, StackBlitz embeds, and a bespoke static-code fallback (only add the fallback if the smoke test shows Sandpack's error overlay is too rough).
+
+---
+
+## Revision (2026-06-10): pivot to a Playground page
+
+After the smoke test, the user pivoted the design: instead of inline sandboxes in each
+doc section, build a **dedicated `/playground` page** with a left-sidebar switcher between
+the examples, and have the doc sections link to it.
+
+- **New:** `docs/src/pages/playground.tsx` (the `/playground` route), `docs/src/components/Playground.tsx`
+  (left-sidebar list + panel; live `<Sandbox>` for an example with `files`, static `@theme/CodeBlock`
+  otherwise; selection mirrored to a `?example=<id>` query param for deep-linking),
+  `docs/src/sandboxes/registry.ts` (example registry, reuses the four data files). Navbar gains a
+  **Playground** link.
+- **Reverted:** the four doc sections go back to their original static code blocks, each with a
+  `:::tip` linking to `/playground?example=<id>`. The inline `<Sandbox>` embeds and their imports
+  are removed.
+- **AutoForm is static-only** in the playground: a **live el-form bug** was found during the smoke
+  test — `AutoForm` renders **zero fields with zod 3.x** because `AutoForm.tsx:435` reads
+  `getDef(schema).shape` (`_def.shape`, a *function* in zod 3) as an object. This is a library bug,
+  not a docs/Sandpack issue (confirmed via Node `renderToStaticMarkup` across zod versions). The
+  AutoForm playground entry shows source + a note until that's fixed and released. The fix is a
+  separate follow-up task.

--- a/docs/superpowers/plans/2026-06-10-docs-sandboxes.md
+++ b/docs/superpowers/plans/2026-06-10-docs-sandboxes.md
@@ -1,0 +1,551 @@
+# Docs Sandboxes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add inline, editable Sandpack code sandboxes for el-form examples on four learning-path docs pages, with package versions injected at build time so they never go stale.
+
+**Architecture:** A reusable `<Sandbox>` component wraps `@codesandbox/sandpack-react` (rendered inside `<BrowserOnly>`, code-split per page, lazy-init). `docusaurus.config.ts` injects the current workspace package versions via `customFields` using a pure, tested helper. Each example's source lives in a `SandpackFiles` data file. The sandbox *is* the example (no parallel static code string).
+
+**Tech Stack:** Docusaurus 3, React 18, TypeScript, `@codesandbox/sandpack-react` + `@codesandbox/sandpack-themes`, Vitest (for the version helper).
+
+**Spec:** `docs/superpowers/specs/2026-06-10-docs-sandboxes-design.md`
+
+**Branch:** `feat/docs-sandboxes` (already created).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `docs/package.json` | Add `@codesandbox/sandpack-react`, `@codesandbox/sandpack-themes` deps; `vitest` devDep + `test` script |
+| `docs/vitest.config.ts` | Minimal Vitest config (node environment) for the version-helper test |
+| `docs/src/sandboxes/versions.ts` | **Pure** helper: read the 4 workspace package versions from a given packages dir → `{ name: version }`. Node-only; never imported by client code |
+| `docs/src/sandboxes/versions.test.ts` | Vitest test: every el-form package resolves to a valid semver string |
+| `docs/docusaurus.config.ts` | Call the helper at build time → `customFields.elFormVersions` |
+| `docs/src/components/Sandbox.tsx` | The `<Sandbox>` wrapper (BrowserOnly + Sandpack + theme sync + lazy + Open-in-CSB) |
+| `docs/src/components/index.ts` | Re-export `Sandbox` |
+| `docs/src/sandboxes/useFormQuickStart.ts` | `SandpackFiles` for the useForm example |
+| `docs/src/sandboxes/autoFormBasic.ts` | `SandpackFiles` for the AutoForm example |
+| `docs/src/sandboxes/validation.ts` | `SandpackFiles` for the validation example |
+| `docs/src/sandboxes/fieldArray.ts` | `SandpackFiles` for the useFieldArray example |
+| `docs/docs/quick-start.md` | Render the useForm sandbox (replace primary static example) |
+| `docs/docs/guides/auto-form.md` | Render the AutoForm sandbox |
+| `docs/docs/concepts/validation.md` | Render the validation sandbox |
+| `docs/docs/guides/array-fields.md` | Render the field-array sandbox |
+
+**Isolation note:** `versions.ts` is Node-only (uses `fs`) and is imported **only** by `docusaurus.config.ts` and its test — never by `Sandbox.tsx` (which reads versions from `customFields` at runtime). Keep that boundary; it's what keeps Node APIs out of the browser bundle.
+
+---
+
+## Task 1: Add dependencies and the test runner
+
+**Files:**
+- Modify: `docs/package.json`
+- Create: `docs/vitest.config.ts`
+
+- [ ] **Step 1: Add the Sandpack deps and a test script**
+
+In `docs/package.json`, add to `dependencies`:
+
+```json
+"@codesandbox/sandpack-react": "^2.19.0",
+"@codesandbox/sandpack-themes": "^2.0.21"
+```
+
+Add to `devDependencies`:
+
+```json
+"vitest": "^2.1.0"
+```
+
+Add to `scripts`:
+
+```json
+"test": "vitest run"
+```
+
+- [ ] **Step 2: Create the Vitest config**
+
+Create `docs/vitest.config.ts`:
+
+```ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});
+```
+
+- [ ] **Step 3: Install**
+
+Run: `pnpm install`
+Expected: lockfile updates; `@codesandbox/sandpack-react` resolves under `docs/`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/package.json docs/vitest.config.ts pnpm-lock.yaml
+git commit -m "build(docs): add sandpack + vitest for docs sandboxes"
+```
+
+---
+
+## Task 2: Version-injection helper (TDD)
+
+This is the unit that fixes what broke the old sandbox — it must be correct and tested.
+
+**Files:**
+- Create: `docs/src/sandboxes/versions.ts`
+- Test: `docs/src/sandboxes/versions.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `docs/src/sandboxes/versions.test.ts`:
+
+```ts
+import path from "path";
+import { describe, it, expect } from "vitest";
+import { EL_FORM_PACKAGES, getElFormVersions } from "./versions";
+
+// When run via `pnpm --filter el-form-docs test`, cwd is the docs dir.
+const PACKAGES_DIR = path.resolve(process.cwd(), "../packages");
+const SEMVER = /^\d+\.\d+\.\d+/;
+
+describe("getElFormVersions", () => {
+  it("returns a valid semver for every el-form package", () => {
+    const versions = getElFormVersions(PACKAGES_DIR);
+    for (const name of EL_FORM_PACKAGES) {
+      expect(versions[name], `${name} version`).toMatch(SEMVER);
+    }
+  });
+
+  it("covers exactly the four published react packages", () => {
+    expect([...EL_FORM_PACKAGES].sort()).toEqual(
+      [
+        "el-form-core",
+        "el-form-react",
+        "el-form-react-components",
+        "el-form-react-hooks",
+      ].sort()
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter el-form-docs test`
+Expected: FAIL — `Cannot find module './versions'` (or `getElFormVersions is not a function`).
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `docs/src/sandboxes/versions.ts`:
+
+```ts
+import fs from "fs";
+import path from "path";
+
+// The published packages whose versions Sandpack must pin to. Keeping this list
+// explicit (rather than scanning the monorepo) means a new internal package
+// can't silently leak into the sandbox dependency map.
+export const EL_FORM_PACKAGES = [
+  "el-form-react",
+  "el-form-react-hooks",
+  "el-form-react-components",
+  "el-form-core",
+] as const;
+
+/**
+ * Reads each el-form package's current version from `<packagesDir>/<name>/package.json`.
+ * Pure: the caller supplies the directory, so this works identically under the
+ * Docusaurus config loader (CJS) and Vitest (ESM). Node-only — never import from
+ * client/browser code.
+ */
+export function getElFormVersions(packagesDir: string): Record<string, string> {
+  const versions: Record<string, string> = {};
+  for (const name of EL_FORM_PACKAGES) {
+    const pkgPath = path.join(packagesDir, name, "package.json");
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8")) as { version: string };
+    versions[name] = pkg.version;
+  }
+  return versions;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter el-form-docs test`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/src/sandboxes/versions.ts docs/src/sandboxes/versions.test.ts
+git commit -m "feat(docs): version-injection helper for sandboxes"
+```
+
+---
+
+## Task 3: Inject versions into the Docusaurus config
+
+**Files:**
+- Modify: `docs/docusaurus.config.ts`
+
+- [ ] **Step 1: Import the helper and set customFields**
+
+At the top of `docs/docusaurus.config.ts`, add the import (alongside the existing `import path from "path";`):
+
+```ts
+import { getElFormVersions } from "./src/sandboxes/versions";
+```
+
+Add a top-level `customFields` entry to the config object (place it near `favicon` / `url`):
+
+```ts
+  customFields: {
+    // Pinned to the current workspace versions at build time so sandboxes never
+    // go stale. main's package.json == latest published npm (Changesets bumps
+    // version and publishes atomically), so this matches `npm install`.
+    elFormVersions: getElFormVersions(path.resolve(__dirname, "../packages")),
+  },
+```
+
+- [ ] **Step 2: Verify the config still loads**
+
+Run: `pnpm --filter el-form-docs build`
+Expected: SUCCESS — "Generated static files in build". (Confirms the helper runs under the Docusaurus CJS loader and `__dirname` resolves the packages dir.)
+
+- [ ] **Step 3: Confirm versions reached the built output**
+
+Run: `grep -o '"elFormVersions":{[^}]*}' docs/build/index.html | head -1`
+Expected: a JSON object containing `el-form-react`, `el-form-react-hooks`, `el-form-react-components`, `el-form-core` with semver values.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/docusaurus.config.ts
+git commit -m "feat(docs): inject el-form versions via customFields"
+```
+
+---
+
+## Task 4: The `<Sandbox>` component
+
+**Files:**
+- Create: `docs/src/components/Sandbox.tsx`
+- Modify: `docs/src/components/index.ts`
+
+- [ ] **Step 1: Write the component**
+
+Create `docs/src/components/Sandbox.tsx`:
+
+```tsx
+import React from "react";
+import BrowserOnly from "@docusaurus/BrowserOnly";
+import { useColorMode } from "@docusaurus/theme-common";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import {
+  SandpackProvider,
+  SandpackLayout,
+  SandpackCodeEditor,
+  SandpackPreview,
+  type SandpackFiles,
+} from "@codesandbox/sandpack-react";
+import { githubLight, sandpackDark } from "@codesandbox/sandpack-themes";
+
+export interface SandboxProps {
+  /** Sandpack file map. At minimum an entry-point App.tsx. */
+  files: SandpackFiles;
+  /** File to focus when the sandbox loads. */
+  activeFile?: string;
+  /** Override/extend the injected dependency map (e.g. pin a peer). */
+  dependencies?: Record<string, string>;
+  /** Preview pane height in px. */
+  previewHeight?: number;
+}
+
+// Non-el-form deps the examples need. el-form versions come from customFields.
+const BASE_DEPENDENCIES: Record<string, string> = {
+  react: "18.2.0",
+  "react-dom": "18.2.0",
+  zod: "^3.23.0",
+};
+
+function SandboxInner({
+  files,
+  activeFile,
+  dependencies,
+  previewHeight = 460,
+}: SandboxProps) {
+  const { colorMode } = useColorMode();
+  const { siteConfig } = useDocusaurusContext();
+  const elFormVersions =
+    (siteConfig.customFields?.elFormVersions as Record<string, string>) ?? {};
+
+  const mergedDependencies = {
+    ...BASE_DEPENDENCIES,
+    ...elFormVersions,
+    ...dependencies,
+  };
+
+  return (
+    <div className="my-6">
+      <SandpackProvider
+        template="react-ts"
+        theme={colorMode === "dark" ? sandpackDark : githubLight}
+        files={files}
+        customSetup={{ dependencies: mergedDependencies }}
+        options={{ initMode: "lazy", ...(activeFile ? { activeFile } : {}) }}
+      >
+        <SandpackLayout>
+          <SandpackCodeEditor showLineNumbers showTabs />
+          <SandpackPreview
+            showOpenInCodeSandbox
+            style={{ height: previewHeight }}
+          />
+        </SandpackLayout>
+      </SandpackProvider>
+    </div>
+  );
+}
+
+/**
+ * Inline el-form sandbox. SSR-safe (Sandpack is client-only) and only imported by
+ * the pages that use it, so the heavy bundle is code-split onto those pages.
+ */
+export function Sandbox(props: SandboxProps) {
+  return (
+    <BrowserOnly fallback={<div className="my-6">Loading sandbox…</div>}>
+      {() => <SandboxInner {...props} />}
+    </BrowserOnly>
+  );
+}
+```
+
+- [ ] **Step 2: Export it**
+
+In `docs/src/components/index.ts`, add:
+
+```ts
+export { Sandbox } from "./Sandbox";
+```
+
+- [ ] **Step 3: Verify it compiles (no sandbox wired into a page yet)**
+
+Run: `pnpm --filter el-form-docs build`
+Expected: SUCCESS. (Type-checks the component and confirms imports resolve.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/src/components/Sandbox.tsx docs/src/components/index.ts
+git commit -m "feat(docs): Sandbox component (sandpack, lazy, theme-synced)"
+```
+
+---
+
+## Task 5: First example + wire into quick-start (proves the pattern end-to-end)
+
+**Files:**
+- Create: `docs/src/sandboxes/useFormQuickStart.ts`
+- Modify: `docs/docs/quick-start.md`
+
+- [ ] **Step 1: Write the example data file**
+
+Create `docs/src/sandboxes/useFormQuickStart.ts`. (Code mirrors the verified pattern in `docs/docs/intro.md` — `useForm` + `validators.onChange` Zod schema + `register` + `formState.errors`.)
+
+```ts
+import type { SandpackFiles } from "@codesandbox/sandpack-react";
+
+const APP = `import { useForm } from "el-form-react-hooks";
+import { z } from "zod";
+
+const schema = z.object({
+  email: z.string().email("Please enter a valid email"),
+  message: z.string().min(1, "Message is required"),
+});
+
+export default function App() {
+  const { register, handleSubmit, formState } = useForm({
+    validators: { onChange: schema },
+    defaultValues: { email: "", message: "" },
+  });
+
+  return (
+    <form
+      onSubmit={handleSubmit((data) => alert(JSON.stringify(data, null, 2)))}
+      style={{ display: "grid", gap: 12, maxWidth: 380, fontFamily: "sans-serif" }}
+    >
+      <label style={{ display: "grid", gap: 4 }}>
+        Email
+        <input {...register("email")} />
+      </label>
+      {formState.errors.email && (
+        <span style={{ color: "crimson" }}>{formState.errors.email}</span>
+      )}
+
+      <label style={{ display: "grid", gap: 4 }}>
+        Message
+        <textarea {...register("message")} rows={3} />
+      </label>
+      {formState.errors.message && (
+        <span style={{ color: "crimson" }}>{formState.errors.message}</span>
+      )}
+
+      <button type="submit">Submit</button>
+    </form>
+  );
+}
+`;
+
+export const useFormQuickStartFiles: SandpackFiles = {
+  "/App.tsx": APP,
+};
+```
+
+- [ ] **Step 2: Wire it into the page**
+
+In `docs/docs/quick-start.md`, add imports just below the frontmatter (Docusaurus MDX):
+
+```md
+import { Sandbox } from '@site/src/components';
+import { useFormQuickStartFiles } from '@site/src/sandboxes/useFormQuickStart';
+```
+
+Replace the page's **primary** useForm static code block with:
+
+```md
+<Sandbox files={useFormQuickStartFiles} />
+```
+
+(Leave the surrounding prose and any secondary snippets intact.)
+
+- [ ] **Step 3: Build and confirm the page renders**
+
+Run: `pnpm --filter el-form-docs build`
+Expected: SUCCESS, no broken-link/MDX errors.
+
+- [ ] **Step 4: Manual smoke (the real test for Sandpack UI)**
+
+Run: `pnpm --filter el-form-docs start` and open `/docs/quick-start`.
+Confirm: editor + live form render; typing an invalid email shows the error; "Open in CodeSandbox" opens a working fork; toggling site dark mode re-themes the editor. Stop the dev server.
+
+> If the example fails to bundle (wrong import path, missing peer, etc.), fix the
+> example source here — this is the "iron out in testing" step from the spec
+> (umbrella vs sub-package imports, etc.).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/src/sandboxes/useFormQuickStart.ts docs/docs/quick-start.md
+git commit -m "feat(docs): useForm quick-start sandbox"
+```
+
+---
+
+## Task 6: Remaining three examples + pages
+
+Repeat the Task 5 pattern for each. Build after each; manual-smoke at the end (Task 7).
+
+**Files:**
+- Create: `docs/src/sandboxes/autoFormBasic.ts` → wire into `docs/docs/guides/auto-form.md`
+- Create: `docs/src/sandboxes/validation.ts` → wire into `docs/docs/concepts/validation.md`
+- Create: `docs/src/sandboxes/fieldArray.ts` → wire into `docs/docs/guides/array-fields.md`
+
+- [ ] **Step 1: AutoForm example**
+
+Create `docs/src/sandboxes/autoFormBasic.ts` — `AutoForm` from a Zod schema. The App **must** import the styles: `import "el-form-react-components/styles.css";`. Base it on the canonical snippet in `docs/docs/intro.md`:
+
+```ts
+import type { SandpackFiles } from "@codesandbox/sandpack-react";
+
+const APP = `import { AutoForm } from "el-form-react-components";
+import "el-form-react-components/styles.css";
+import { z } from "zod";
+
+const schema = z.object({
+  firstName: z.string().min(1, "First name is required"),
+  email: z.string().email("Please enter a valid email"),
+  age: z.number().min(18, "Must be 18 or older"),
+});
+
+export default function App() {
+  return (
+    <div style={{ padding: 16 }}>
+      <AutoForm
+        schema={schema}
+        onSubmit={(data) => alert(JSON.stringify(data, null, 2))}
+      />
+    </div>
+  );
+}
+`;
+
+export const autoFormBasicFiles: SandpackFiles = { "/App.tsx": APP };
+```
+
+Wire into `docs/docs/guides/auto-form.md` (imports + `<Sandbox files={autoFormBasicFiles} />`, replacing the primary AutoForm static block).
+
+- [ ] **Step 2: Validation example**
+
+Create `docs/src/sandboxes/validation.ts` — a `useForm` example demonstrating schema-agnostic `onChange` validation (Zod), surfacing `formState.errors` live. Wire into `docs/docs/concepts/validation.md` (replace the primary example).
+
+- [ ] **Step 3: Field-array example**
+
+Create `docs/src/sandboxes/fieldArray.ts` — `useFieldArray` with append/remove of a small row shape. Wire into `docs/docs/guides/array-fields.md` (replace the primary example).
+
+- [ ] **Step 4: Build after wiring all three**
+
+Run: `pnpm --filter el-form-docs build`
+Expected: SUCCESS, no MDX/broken-link errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/src/sandboxes/autoFormBasic.ts docs/src/sandboxes/validation.ts docs/src/sandboxes/fieldArray.ts \
+        docs/docs/guides/auto-form.md docs/docs/concepts/validation.md docs/docs/guides/array-fields.md
+git commit -m "feat(docs): AutoForm, validation, and field-array sandboxes"
+```
+
+---
+
+## Task 7: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Test suite passes**
+
+Run: `pnpm --filter el-form-docs test`
+Expected: PASS (version helper).
+
+- [ ] **Step 2: Production build clean**
+
+Run: `pnpm --filter el-form-docs build`
+Expected: SUCCESS, zero broken links/MDX errors.
+
+- [ ] **Step 3: Manual smoke across all four pages**
+
+Run: `pnpm --filter el-form-docs start`. For `/docs/quick-start`, `/docs/guides/auto-form`, `/docs/concepts/validation`, `/docs/guides/array-fields`:
+- editor + live form render;
+- the form behaves (validation errors, array add/remove, AutoForm submit);
+- "Open in CodeSandbox" works;
+- dark-mode toggle re-themes the editor;
+- pages **without** a sandbox (e.g. `/docs/intro`) don't load the Sandpack bundle (Network tab: no sandpack chunk).
+Stop the dev server.
+
+- [ ] **Step 4: Final commit (if smoke required fixes)**
+
+```bash
+git add -A
+git commit -m "fix(docs): sandbox example/wiring fixes from smoke test"
+```
+
+---
+
+## Out of scope (per spec)
+
+Broad replacement of all examples, a dedicated `/playground` page, StackBlitz embeds, and a bespoke static-code fallback (only add the fallback if the smoke test shows Sandpack's error overlay is too rough).

--- a/docs/superpowers/plans/2026-06-10-docs-sandboxes.md
+++ b/docs/superpowers/plans/2026-06-10-docs-sandboxes.md
@@ -416,13 +416,13 @@ import { Sandbox } from '@site/src/components';
 import { useFormQuickStartFiles } from '@site/src/sandboxes/useFormQuickStart';
 ```
 
-Replace the page's **primary** useForm static code block with:
+Replace the useForm static code block under the `## Alternative: useForm Hook` heading with:
 
 ```md
 <Sandbox files={useFormQuickStartFiles} />
 ```
 
-(Leave the surrounding prose and any secondary snippets intact.)
+(That page's AutoForm block is its headline example; the sandbox replaces the **useForm** block specifically. Leave the surrounding prose and the AutoForm snippet intact.)
 
 - [ ] **Step 3: Build and confirm the page renders**
 
@@ -496,7 +496,7 @@ Create `docs/src/sandboxes/validation.ts` — a `useForm` example demonstrating 
 
 - [ ] **Step 3: Field-array example**
 
-Create `docs/src/sandboxes/fieldArray.ts` — `useFieldArray` with append/remove of a small row shape. Wire into `docs/docs/guides/array-fields.md` (replace the primary example).
+Create `docs/src/sandboxes/fieldArray.ts` — `useFieldArray` with append/remove of a small row shape. **Important:** `useFieldArray` reads the form from context, so the App must either wrap the fields in `FormProvider` and consume via `useFormContext` (base it on the "Recommended" snippet in `docs/docs/guides/array-fields.md`, L24-78) **or** pass the form explicitly, e.g. `useFieldArray({ name: "items", form })`. A naive single-component `App.tsx` that calls `useFieldArray` with no form/context will not work. Wire into `docs/docs/guides/array-fields.md` (replace the primary `useFieldArray` example).
 
 - [ ] **Step 4: Build after wiring all three**
 

--- a/docs/superpowers/specs/2026-06-10-docs-sandboxes-design.md
+++ b/docs/superpowers/specs/2026-06-10-docs-sandboxes-design.md
@@ -1,0 +1,147 @@
+# Docs sandboxes — design (2026-06-10)
+
+Inline, editable code sandboxes for quick el-form examples in the Docusaurus docs.
+
+## Goal
+
+Let a reader **edit a real el-form example and see the form update**, inline on the docs page —
+on the key learning-path pages, without leaving the site. This is the "sandboxes" roadmap item,
+restarted fresh (the old `docs-sandbox` branch / PR #55 is closed and used only for direction).
+
+## Context
+
+- **Today** the docs already render *live* forms via `InteractivePreview`
+  (`docs/src/components/InteractivePreview.tsx`): a real, running el-form (the docs alias
+  `el-form-react*` to local source) with a "Show Code" toggle. But the shown code is a **static
+  string** — read-only, and it can drift from the rendered component. These curated demos stay.
+- **The old attempt** (`docs-sandbox`, PR #55, closed) used Sandpack but **pinned
+  `el-form-react@4.1.2` from npm**. That pin is the core reason it went stale and "sucked":
+  the docs froze on an old version and required manual bumps. The new design must not repeat it.
+- **How the field does it:** TanStack Form and React Hook Form keep docs prose light (static
+  code) and link *out* to StackBlitz/CodeSandbox examples maintained in their repos. react.dev
+  (the gold standard for *inline* editing) uses Sandpack, but judiciously — on tutorial/learn
+  pages, not everywhere. Nobody does broad inline-IDE replacement; it's a perf trap.
+
+## Decisions (locked with the user)
+
+1. **Tech: inline Sandpack** (`@codesandbox/sandpack-react`, `react-ts` template) — full multi-file
+   editor with real imports + TypeScript, not a lightweight react-live snippet.
+2. **Versioning: build-time injection** of the current workspace package versions (not a pinned
+   string, not `latest`).
+3. **Scope: a few inline sandboxes on the learning path** (react.dev's judicious pattern), not a
+   broad replacement and not a single dedicated playground page. Existing `InteractivePreview`
+   demos are left untouched.
+
+## Architecture
+
+Three small, independent units:
+
+### Unit A — `<Sandbox>` component (`docs/src/components/Sandbox.tsx`)
+
+One purpose: render one Sandpack instance configured for el-form.
+
+- Wraps `SandpackProvider` + `SandpackLayout` + `SandpackCodeEditor` + `SandpackPreview`.
+- **SSR-safe:** rendered inside `@docusaurus/BrowserOnly` (Sandpack is client-only). Because it's
+  only imported by the 4 MDX pages that use it, Docusaurus **code-splits** the heavy Sandpack
+  bundle onto those pages only — pages without a sandbox never load it.
+- **Theme:** Sandpack theme follows Docusaurus light/dark via `useColorMode`
+  (`githubLight` / `sandpackDark` from `@codesandbox/sandpack-themes`).
+- **Lazy:** `options.initMode: "lazy"` so the bundle/iframe initializes when scrolled near, not
+  on page load.
+- **Open in CodeSandbox:** enabled (Sandpack ships this for free) — gives the same "fork it
+  externally" escape hatch TanStack/RHF rely on, *in addition to* inline editing.
+- **Props:** `files: SandpackFiles`, `activeFile?: string`, `dependencies?: Record<string,string>`
+  (override/extend the el-form deps), `previewHeight?: number`.
+- **Dependencies:** built from injected versions (Unit C) — `react`, `react-dom`, the el-form
+  packages the example imports, `zod`, plus `@types/*` and `typescript`.
+
+### Unit B — example data files (`docs/src/sandboxes/*.ts`)
+
+One file per example, each exporting a `SandpackFiles` map (e.g. `App.tsx` + `styles.css`). One
+purpose: be the canonical source of that example. The sandbox **is** the example — no parallel
+static code string to drift. Initial set:
+
+- `useFormQuickStart.ts` — `useForm` + `register` + `handleSubmit`.
+- `autoFormBasic.ts` — `AutoForm` from a Zod schema (imports `el-form-react-components/styles.css`).
+- `validation.ts` — schema-agnostic `onChange` validation.
+- `fieldArray.ts` — `useFieldArray` add/remove.
+
+### Unit C — build-time version injection (`docs/docusaurus.config.ts`)
+
+`require()` the `version` field from each workspace package
+(`el-form-react`, `el-form-react-hooks`, `el-form-react-components`, `el-form-core`) at config
+eval time and expose them under `customFields.elFormVersions`. `<Sandbox>` reads them via
+`useDocusaurusContext().siteConfig.customFields`.
+
+**Why this is correct, not stale:** el-form releases via Changesets — feature PRs only add
+changeset files; the `version` in `package.json` bumps **and** publishes to npm atomically when
+the "Version Packages" PR merges. So on `main`, each `package.json` version equals the latest
+published npm version, and the docs (built/deployed from `main`) always match what
+`npm install` returns.
+
+## Data flow
+
+```
+package.json versions ──(build time, require)──▶ customFields.elFormVersions
+                                                          │
+MDX page imports <Sandbox files={exampleFiles} />         │ (runtime, context)
+        │                                                 ▼
+        └──▶ <BrowserOnly> ▶ <Sandbox> ─builds deps map─▶ SandpackProvider
+                                                                  │
+                                              (user-visible) bundles el-form@<version> from CDN
+                                                                  ▼
+                                                  editor pane │ live form preview
+```
+
+## Placement
+
+Four learning-path pages; on each, the page's **primary** example becomes the sandbox while
+other snippets/previews on the page stay as-is:
+
+- `docs/docs/quick-start.md` → `useForm` quick start
+- `docs/docs/guides/auto-form.md` → AutoForm
+- `docs/docs/concepts/validation.md` → schema-agnostic validation
+- `docs/docs/guides/array-fields.md` → `useFieldArray`
+
+## Error handling
+
+- Bundler/runtime errors surface in Sandpack's built-in error overlay; the reader still sees and
+  can edit the source.
+- **Transient release window:** for the few seconds between a release deploy updating the docs and
+  npm finishing the publish, the CDN may not yet resolve the just-bumped version. Sandpack shows
+  its resolve error; it self-heals on reload. Acceptable; documented, not engineered around.
+- Optional (deferred): a static-code fallback rendered if Sandpack fails — only if testing shows
+  the bare error overlay is too rough.
+
+## Testing / verification
+
+- `pnpm --filter el-form-docs build` must succeed (component compiles, SSR-safe, no broken links).
+- A unit test asserting `customFields.elFormVersions` injects a non-empty semver string for all
+  four packages (guards the versioning mechanism — the thing that broke the old one).
+- Manual smoke per page: editor + live form render, the form actually works, light/dark theme
+  follows the site, "Open in CodeSandbox" opens a working fork.
+
+## Non-goals / deferred
+
+- **Broad replacement** of all docs examples with sandboxes (perf trap; not even what the leaders
+  do).
+- **Dedicated `/playground` page** — viable later; out of scope here.
+- **StackBlitz embeds** — Sandpack's "Open in CodeSandbox" covers the external-fork need.
+
+## To iron out during implementation/testing
+
+- Final page list (the four above are the starting set; may adjust once we see them in context).
+- Whether examples import from the umbrella `el-form-react` or the specific sub-packages
+  (`el-form-react-hooks` / `el-form-react-components`). Leaning sub-packages to match the
+  canonical docs snippets and to keep the injected-dependency mapping explicit, but we'll confirm
+  against what actually bundles cleanly in Sandpack.
+- Exact `previewHeight` and whether a "click to load" poster is needed on top of `initMode: "lazy"`
+  if the lazy default still feels heavy.
+
+## Risks
+
+- **Sandpack bundle weight** — mitigated by per-page code-splitting + `initMode: "lazy"` + one
+  sandbox per page.
+- **Network dependency** — Sandpack needs the CDN to bundle; offline docs reading won't run the
+  sandbox (the curated `InteractivePreview` demos, which use local source, still render).
+- **Version-resolve race** — the transient release window above.

--- a/docs/vitest.config.ts
+++ b/docs/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/el-form-core/src/__tests__/zodHelpers.objectShape.test.ts
+++ b/packages/el-form-core/src/__tests__/zodHelpers.objectShape.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { getObjectShape } from "../zodHelpers";
+
+// Regression guard for AutoForm rendering zero fields with Zod 3.x: in Zod 3 a
+// ZodObject's `_def.shape` is a getter *function*, while in Zod 4 the shape on
+// `_zod.def` is already an object. Reading it without invoking the function
+// yields no keys, so AutoForm generated no fields for Zod-3 users.
+describe("getObjectShape", () => {
+  it("invokes the shape getter when `_def.shape` is a function (Zod 3 style)", () => {
+    const v3like = { _def: { shape: () => ({ a: 1, b: 2 }) } } as any;
+    expect(Object.keys(getObjectShape(v3like) ?? {})).toEqual(["a", "b"]);
+  });
+
+  it("uses the shape directly when it is already an object (Zod 4 style)", () => {
+    const v4like = { _zod: { def: { shape: { a: 1, b: 2 } } } } as any;
+    expect(Object.keys(getObjectShape(v4like) ?? {})).toEqual(["a", "b"]);
+  });
+
+  it("reads a real z.object shape regardless of the installed Zod major", () => {
+    const shape = getObjectShape(
+      z.object({ firstName: z.string(), email: z.string() })
+    );
+    expect(Object.keys(shape ?? {})).toEqual(["firstName", "email"]);
+  });
+
+  it("returns undefined for a non-object schema", () => {
+    expect(getObjectShape(z.string())).toBeUndefined();
+  });
+});

--- a/packages/el-form-core/src/zodHelpers.ts
+++ b/packages/el-form-core/src/zodHelpers.ts
@@ -15,6 +15,22 @@ export function getDef(schema: AnyZodSchema): any {
   return anySchema?._zod?.def ?? anySchema?.def ?? anySchema?._def;
 }
 
+// Returns a ZodObject's field shape as a plain record, across Zod majors.
+// In Zod 3 the shape on `_def.shape` is a getter *function* (you must call it);
+// in Zod 4 the shape on `_zod.def` is already an object. Reading it without
+// invoking the v3 function yields no keys — that's the bug that made AutoForm
+// render zero fields for Zod-3 users. Falls back to the public `.shape` getter.
+export function getObjectShape(
+  schema: AnyZodSchema
+): Record<string, AnyZodSchema> | undefined {
+  const raw = getDef(schema)?.shape ?? (schema as any)?.shape;
+  if (raw == null) return undefined;
+  return (typeof raw === "function" ? raw() : raw) as Record<
+    string,
+    AnyZodSchema
+  >;
+}
+
 export function getTypeName(schema: AnyZodSchema): string | undefined {
   const def = getDef(schema);
   if (!def) return undefined;

--- a/packages/el-form-react-components/src/AutoForm.tsx
+++ b/packages/el-form-react-components/src/AutoForm.tsx
@@ -19,6 +19,7 @@ import {
   getArrayElementType,
   getStringChecks,
   getDef,
+  getObjectShape,
 } from "el-form-core";
 import { FormSwitch, FormCase } from "./Form";
 import { fieldAriaProps } from "./fieldAria";
@@ -432,7 +433,7 @@ function generateFieldsFromSchema<T extends z.ZodTypeAny>(
 
   if (getTypeName(schema as any) !== "ZodObject") return [];
 
-  const shape = getDef(schema as any)?.shape as Record<string, z.ZodTypeAny>;
+  const shape = getObjectShape(schema as any) as Record<string, z.ZodTypeAny>;
   const fields: AutoFormFieldConfig[] = [];
   for (const key in shape) {
     if (!Object.prototype.hasOwnProperty.call(shape, key)) continue;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@docusaurus/preset-classic':
         specifier: 3.8.0
         version: 3.8.0(@algolia/client-search@5.27.0)(@mdx-js/react@3.1.0)(@types/react@18.3.23)(acorn@8.15.0)(esbuild@0.25.5)(react-dom@18.3.1)(react@18.3.1)(search-insights@2.17.3)(typescript@5.2.2)
+      '@docusaurus/theme-common':
+        specifier: 3.8.0
+        version: 3.8.0(@docusaurus/plugin-content-docs@3.8.0)(acorn@8.15.0)(esbuild@0.25.5)(react-dom@18.3.1)(react@18.3.1)
       '@easyops-cn/docusaurus-search-local':
         specifier: ^0.52.1
         version: 0.52.1(@docusaurus/theme-common@3.8.0)(@mdx-js/react@3.1.0)(acorn@8.15.0)(esbuild@0.25.5)(eslint@8.57.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
@@ -3605,38 +3608,6 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-common@3.8.0(@docusaurus/plugin-content-docs@3.6.3)(acorn@8.15.0)(esbuild@0.25.5)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-YqV2vAWpXGLA+A3PMLrOMtqgTHJLDcT+1Caa6RF7N4/IWgrevy5diY8oIHFkXR/eybjcrFFjUPrHif8gSGs3Tw==}
-    engines: {node: '>=18.0'}
-    peerDependencies:
-      '@docusaurus/plugin-content-docs': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    dependencies:
-      '@docusaurus/mdx-loader': 3.8.0(acorn@8.15.0)(esbuild@0.25.5)(react-dom@18.3.1)(react@18.3.1)
-      '@docusaurus/module-type-aliases': 3.8.0(acorn@8.15.0)(esbuild@0.25.5)(react-dom@18.3.1)(react@18.3.1)
-      '@docusaurus/plugin-content-docs': 3.6.3(@mdx-js/react@3.1.0)(acorn@8.15.0)(debug@4.4.1)(esbuild@0.25.5)(eslint@8.57.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/utils': 3.8.0(acorn@8.15.0)(esbuild@0.25.5)(react-dom@18.3.1)(react@18.3.1)
-      '@docusaurus/utils-common': 3.8.0(acorn@8.15.0)(esbuild@0.25.5)(react-dom@18.3.1)(react@18.3.1)
-      '@types/history': 4.7.11
-      '@types/react': 18.3.23
-      '@types/react-router-config': 5.0.11
-      clsx: 2.1.1
-      parse-numeric-range: 1.3.0
-      prism-react-renderer: 2.4.1(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      tslib: 2.8.1
-      utility-types: 3.11.0
-    transitivePeerDependencies:
-      - '@swc/core'
-      - acorn
-      - esbuild
-      - supports-color
-      - uglify-js
-      - webpack-cli
-    dev: false
-
   /@docusaurus/theme-common@3.8.0(@docusaurus/plugin-content-docs@3.8.0)(acorn@8.15.0)(esbuild@0.25.5)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-YqV2vAWpXGLA+A3PMLrOMtqgTHJLDcT+1Caa6RF7N4/IWgrevy5diY8oIHFkXR/eybjcrFFjUPrHif8gSGs3Tw==}
     engines: {node: '>=18.0'}
@@ -3958,7 +3929,7 @@ packages:
       react-dom: ^16.14.0 || 17 || ^18 || ^19
     dependencies:
       '@docusaurus/plugin-content-docs': 3.6.3(@mdx-js/react@3.1.0)(acorn@8.15.0)(debug@4.4.1)(esbuild@0.25.5)(eslint@8.57.1)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-common': 3.8.0(@docusaurus/plugin-content-docs@3.6.3)(acorn@8.15.0)(esbuild@0.25.5)(react-dom@18.3.1)(react@18.3.1)
+      '@docusaurus/theme-common': 3.8.0(@docusaurus/plugin-content-docs@3.8.0)(acorn@8.15.0)(esbuild@0.25.5)(react-dom@18.3.1)(react@18.3.1)
       '@docusaurus/theme-translations': 3.6.3
       '@docusaurus/utils': 3.6.3(acorn@8.15.0)(esbuild@0.25.5)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/utils-common': 3.6.3(acorn@8.15.0)(esbuild@0.25.5)(react-dom@18.3.1)(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,12 @@ importers:
 
   docs:
     dependencies:
+      '@codesandbox/sandpack-react':
+        specifier: ^2.19.0
+        version: 2.20.0(react-dom@18.3.1)(react@18.3.1)
+      '@codesandbox/sandpack-themes':
+        specifier: ^2.0.21
+        version: 2.0.21
       '@docusaurus/core':
         specifier: 3.8.0
         version: 3.8.0(@mdx-js/react@3.1.0)(acorn@8.15.0)(esbuild@0.25.5)(react-dom@18.3.1)(react@18.3.1)(typescript@5.2.2)
@@ -130,6 +136,9 @@ importers:
       typescript:
         specifier: ~5.2.0
         version: 5.2.2
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(jsdom@24.1.3)
 
   examples/react:
     dependencies:
@@ -195,70 +204,6 @@ importers:
         specifier: ^5.2.0
         version: 5.4.19(@types/node@22.19.19)
 
-  examples/showcase:
-    dependencies:
-      el-form-core:
-        specifier: workspace:^
-        version: link:../../packages/el-form-core
-      el-form-react-components:
-        specifier: workspace:^
-        version: link:../../packages/el-form-react-components
-      el-form-react-hooks:
-        specifier: workspace:^
-        version: link:../../packages/el-form-react-hooks
-      react:
-        specifier: ^18.2.0
-        version: 18.3.1
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
-      react-router-dom:
-        specifier: ^6.23.1
-        version: 6.30.1(react-dom@18.3.1)(react@18.3.1)
-      zod:
-        specifier: ^4.0.17
-        version: 4.0.17
-    devDependencies:
-      '@types/react':
-        specifier: ^18.2.66
-        version: 18.3.23
-      '@types/react-dom':
-        specifier: ^18.2.22
-        version: 18.3.7(@types/react@18.3.23)
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^7.2.0
-        version: 7.18.0(@typescript-eslint/parser@7.18.0)(eslint@8.57.1)(typescript@5.2.2)
-      '@typescript-eslint/parser':
-        specifier: ^7.2.0
-        version: 7.18.0(eslint@8.57.1)(typescript@5.2.2)
-      '@vitejs/plugin-react':
-        specifier: ^4.2.1
-        version: 4.5.1(vite@5.4.19)
-      autoprefixer:
-        specifier: ^10.4.19
-        version: 10.4.21(postcss@8.5.6)
-      eslint:
-        specifier: ^8.57.0
-        version: 8.57.1
-      eslint-plugin-react-hooks:
-        specifier: ^4.6.0
-        version: 4.6.2(eslint@8.57.1)
-      eslint-plugin-react-refresh:
-        specifier: ^0.4.6
-        version: 0.4.20(eslint@8.57.1)
-      postcss:
-        specifier: ^8.4.38
-        version: 8.5.6
-      tailwindcss:
-        specifier: ^3.4.3
-        version: 3.4.17
-      typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
-      vite:
-        specifier: ^5.2.0
-        version: 5.4.19(@types/node@22.19.19)
-
   packages/el-form-core:
     dependencies:
       zod:
@@ -273,13 +218,13 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9
+        version: 2.1.9(jsdom@24.1.3)
 
   packages/el-form-mcp:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
-        version: 1.29.0(zod@4.0.17)
+        version: 1.29.0(zod@3.25.76)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -323,7 +268,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9
+        version: 2.1.9(jsdom@24.1.3)
 
   packages/el-form-react-components:
     dependencies:
@@ -610,7 +555,7 @@ packages:
       '@babel/traverse': 7.27.4
       '@babel/types': 7.27.6
       convert-source-map: 2.0.0
-      debug: 4.4.1
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -682,7 +627,7 @@ packages:
       '@babel/core': 7.27.4
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.1
+      debug: 4.4.3
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -1769,7 +1714,7 @@ packages:
       '@babel/parser': 7.27.5
       '@babel/template': 7.27.2
       '@babel/types': 7.27.6
-      debug: 4.4.1
+      debug: 4.4.3
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -1959,6 +1904,145 @@ packages:
       human-id: 4.1.1
       prettier: 2.8.8
     dev: true
+
+  /@codemirror/autocomplete@6.20.3:
+    resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+    dev: false
+
+  /@codemirror/commands@6.10.3:
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+    dev: false
+
+  /@codemirror/lang-css@6.3.1:
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+    dev: false
+
+  /@codemirror/lang-html@6.4.11:
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+      '@lezer/html': 1.3.13
+    dev: false
+
+  /@codemirror/lang-javascript@6.2.5:
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.7
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+    dev: false
+
+  /@codemirror/language@6.12.3:
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+    dev: false
+
+  /@codemirror/lint@6.9.7:
+    resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      crelt: 1.0.6
+    dev: false
+
+  /@codemirror/state@6.6.0:
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+    dev: false
+
+  /@codemirror/view@6.43.1:
+    resolution: {integrity: sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw==}
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+    dev: false
+
+  /@codesandbox/nodebox@0.1.8:
+    resolution: {integrity: sha512-2VRS6JDSk+M+pg56GA6CryyUSGPjBEe8Pnae0QL3jJF1mJZJVMDKr93gJRtBbLkfZN6LD/DwMtf+2L0bpWrjqg==}
+    dependencies:
+      outvariant: 1.4.0
+      strict-event-emitter: 0.4.6
+    dev: false
+
+  /@codesandbox/sandpack-client@2.19.8:
+    resolution: {integrity: sha512-CMV4nr1zgKzVpx4I3FYvGRM5YT0VaQhALMW9vy4wZRhEyWAtJITQIqZzrTGWqB1JvV7V72dVEUCUPLfYz5hgJQ==}
+    dependencies:
+      '@codesandbox/nodebox': 0.1.8
+      buffer: 6.0.3
+      dequal: 2.0.3
+      mime-db: 1.54.0
+      outvariant: 1.4.0
+      static-browser-server: 1.0.3
+    dev: false
+
+  /@codesandbox/sandpack-react@2.20.0(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-takd1YpW/PMQ6KPQfvseWLHWklJovGY8QYj8MtWnskGKbjOGJ6uZfyZbcJ6aCFLQMpNyjTqz9AKNbvhCOZ1TUQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+      react-dom: ^16.8.0 || ^17 || ^18 || ^19
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/commands': 6.10.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      '@codesandbox/sandpack-client': 2.19.8
+      '@lezer/highlight': 1.2.3
+      '@react-hook/intersection-observer': 3.1.2(react@18.3.1)
+      '@stitches/core': 1.2.8
+      anser: 2.3.5
+      clean-set: 1.1.2
+      dequal: 2.0.3
+      escape-carriage: 1.3.1
+      lz-string: 1.5.0
+      react: 18.3.1
+      react-devtools-inline: 4.4.0
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 17.0.2
+    dev: false
+
+  /@codesandbox/sandpack-themes@2.0.21:
+    resolution: {integrity: sha512-CMH/MO/dh6foPYb/3eSn2Cu/J3+1+/81Fsaj7VggICkCrmRk0qG5dmgjGAearPTnRkOGORIPHuRqwNXgw0E6YQ==}
+    dev: false
 
   /@colors/colors@1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -4364,7 +4448,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1
+      debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -4402,7 +4486,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.1
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -4486,6 +4570,46 @@ packages:
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
     dev: false
 
+  /@lezer/common@1.5.2:
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+    dev: false
+
+  /@lezer/css@1.3.3:
+    resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+    dev: false
+
+  /@lezer/highlight@1.2.3:
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+    dependencies:
+      '@lezer/common': 1.5.2
+    dev: false
+
+  /@lezer/html@1.3.13:
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+    dev: false
+
+  /@lezer/javascript@1.5.4:
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+    dev: false
+
+  /@lezer/lr@1.4.10:
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+    dependencies:
+      '@lezer/common': 1.5.2
+    dev: false
+
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
@@ -4505,6 +4629,10 @@ packages:
       globby: 11.1.0
       read-yaml-file: 1.1.0
     dev: true
+
+  /@marijn/find-cluster-break@1.0.2:
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
+    dev: false
 
   /@mdx-js/mdx@3.1.0(acorn@8.15.0):
     resolution: {integrity: sha512-/QxEhPAvGwbQmy1Px8F899L5Uc2KZ6JtXwlCgJmjSTBedwOZkByYcBG4GceIGPXRDsmfxhHazuS+hlOShRLeDw==}
@@ -4548,7 +4676,7 @@ packages:
       react: 18.3.1
     dev: false
 
-  /@modelcontextprotocol/sdk@1.29.0(zod@4.0.17):
+  /@modelcontextprotocol/sdk@1.29.0(zod@3.25.76):
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -4573,8 +4701,8 @@ packages:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.0.17
-      zod-to-json-schema: 3.25.2(zod@4.0.17)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4754,6 +4882,10 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  /@open-draft/deferred-promise@2.2.0:
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+    dev: false
+
   /@parcel/watcher-android-arm64@2.5.1:
     resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
     engines: {node: '>= 10.0.0'}
@@ -4928,9 +5060,22 @@ packages:
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
     dev: false
 
-  /@remix-run/router@1.23.0:
-    resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
-    engines: {node: '>=14.0.0'}
+  /@react-hook/intersection-observer@3.1.2(react@18.3.1):
+    resolution: {integrity: sha512-mWU3BMkmmzyYMSuhO9wu3eJVP21N8TcgYm9bZnTrMwuM818bEk+0NRM3hP+c/TqA9Ln5C7qE53p1H0QMtzYdvQ==}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@react-hook/passive-layout-effect': 1.2.1(react@18.3.1)
+      intersection-observer: 0.10.0
+      react: 18.3.1
+    dev: false
+
+  /@react-hook/passive-layout-effect@1.2.1(react@18.3.1):
+    resolution: {integrity: sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      react: 18.3.1
     dev: false
 
   /@rolldown/pluginutils@1.0.0-beta.9:
@@ -5141,6 +5286,10 @@ packages:
       micromark-factory-space: 1.1.0
       micromark-util-character: 1.2.0
       micromark-util-symbol: 1.1.0
+    dev: false
+
+  /@stitches/core@1.2.8:
+    resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
     dev: false
 
   /@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.27.4):
@@ -6007,33 +6156,6 @@ packages:
       '@types/yargs-parser': 21.0.3
     dev: false
 
-  /@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0)(eslint@8.57.1)(typescript@5.2.2):
-    resolution: {integrity: sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^7.0.0
-      eslint: ^8.56.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.2.2)
-      '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/type-utils': 7.18.0(eslint@8.57.1)(typescript@5.2.2)
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.2.2)
-      '@typescript-eslint/visitor-keys': 7.18.0
-      eslint: 8.57.1
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      natural-compare: 1.4.0
-      ts-api-utils: 1.4.3(typescript@5.2.2)
-      typescript: 5.2.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0)(eslint@8.57.1)(typescript@5.8.3):
     resolution: {integrity: sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -6085,27 +6207,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.2.2):
-    resolution: {integrity: sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      eslint: ^8.56.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.2.2)
-      '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.1
-      eslint: 8.57.1
-      typescript: 5.2.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3):
     resolution: {integrity: sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -6153,7 +6254,7 @@ packages:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.33.1(typescript@5.8.3)
       '@typescript-eslint/types': 8.33.1
-      debug: 4.4.1
+      debug: 4.4.3
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -6184,26 +6285,6 @@ packages:
       typescript: 5.8.3
     dev: true
 
-  /@typescript-eslint/type-utils@7.18.0(eslint@8.57.1)(typescript@5.2.2):
-    resolution: {integrity: sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      eslint: ^8.56.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.2.2)
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.2.2)
-      debug: 4.4.1
-      eslint: 8.57.1
-      ts-api-utils: 1.4.3(typescript@5.2.2)
-      typescript: 5.2.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/type-utils@7.18.0(eslint@8.57.1)(typescript@5.8.3):
     resolution: {integrity: sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -6216,7 +6297,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.8.3)
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.8.3)
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.57.1
       ts-api-utils: 1.4.3(typescript@5.8.3)
       typescript: 5.8.3
@@ -6233,7 +6314,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.33.1(typescript@5.8.3)
       '@typescript-eslint/utils': 8.33.1(eslint@8.57.1)(typescript@5.8.3)
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.57.1
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
@@ -6251,28 +6332,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@7.18.0(typescript@5.2.2):
-    resolution: {integrity: sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.1
-      globby: 11.1.0
-      is-glob: 4.0.3
-      minimatch: 9.0.5
-      semver: 7.7.2
-      ts-api-utils: 1.4.3(typescript@5.2.2)
-      typescript: 5.2.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/typescript-estree@7.18.0(typescript@5.8.3):
     resolution: {integrity: sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -6284,7 +6343,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.1
+      debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -6305,7 +6364,7 @@ packages:
       '@typescript-eslint/tsconfig-utils': 8.33.1(typescript@5.8.3)
       '@typescript-eslint/types': 8.33.1
       '@typescript-eslint/visitor-keys': 8.33.1
-      debug: 4.4.1
+      debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -6314,22 +6373,6 @@ packages:
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.2.2):
-    resolution: {integrity: sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      eslint: ^8.56.0
-    dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.2.2)
-      eslint: 8.57.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
     dev: true
 
   /@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.8.3):
@@ -6705,6 +6748,10 @@ packages:
       '@algolia/requester-node-http': 5.27.0
     dev: false
 
+  /anser@2.3.5:
+    resolution: {integrity: sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==}
+    dev: false
+
   /ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
     dependencies:
@@ -6761,9 +6808,11 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+    dev: false
 
   /arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+    dev: false
 
   /argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -6992,6 +7041,10 @@ packages:
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  /base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: false
+
   /batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
     dev: false
@@ -7010,6 +7063,7 @@ packages:
   /binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+    dev: false
 
   /body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
@@ -7118,6 +7172,13 @@ packages:
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  /buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    dev: false
+
   /bundle-require@5.1.0(esbuild@0.25.5):
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -7194,11 +7255,6 @@ packages:
       pascal-case: 3.1.2
       tslib: 2.8.1
     dev: false
-
-  /camelcase-css@2.0.1:
-    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
-    engines: {node: '>= 6'}
-    dev: true
 
   /camelcase-keys@6.2.2:
     resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
@@ -7342,6 +7398,7 @@ packages:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+    dev: false
 
   /chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -7367,6 +7424,10 @@ packages:
     engines: {node: '>= 10.0'}
     dependencies:
       source-map: 0.6.1
+    dev: false
+
+  /clean-set@1.1.2:
+    resolution: {integrity: sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==}
     dev: false
 
   /clean-stack@2.2.0:
@@ -7646,6 +7707,10 @@ packages:
       typescript: 5.2.2
     dev: false
 
+  /crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+    dev: false
+
   /cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -7809,6 +7874,7 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: false
 
   /cssnano-preset-advanced@6.1.2(postcss@8.5.6):
     resolution: {integrity: sha512-Nhao7eD8ph2DoHolEzQs5CfRpiEP0xa1HBdnFZ82kvqdmbwVBUr2r1QuQ4t1pi+D1ZpqpcO4T+wy/7RxzJ/WPQ==}
@@ -7902,6 +7968,14 @@ packages:
 
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  /d@1.0.2:
+    resolution: {integrity: sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==}
+    engines: {node: '>=0.12'}
+    dependencies:
+      es5-ext: 0.10.64
+      type: 2.7.3
+    dev: false
 
   /data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
@@ -8153,7 +8227,7 @@ packages:
     hasBin: true
     dependencies:
       address: 1.2.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8162,10 +8236,6 @@ packages:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
     dependencies:
       dequal: 2.0.3
-
-  /didyoumean@1.2.2:
-    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
-    dev: true
 
   /diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -8177,10 +8247,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
-
-  /dlv@1.1.3:
-    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
-    dev: true
 
   /dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
@@ -8274,6 +8340,11 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       is-obj: 2.0.0
+    dev: false
+
+  /dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
     dev: false
 
   /dunder-proto@1.0.1:
@@ -8506,6 +8577,33 @@ packages:
       is-symbol: 1.1.1
     dev: true
 
+  /es5-ext@0.10.64:
+    resolution: {integrity: sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==}
+    engines: {node: '>=0.10'}
+    requiresBuild: true
+    dependencies:
+      es6-iterator: 2.0.3
+      es6-symbol: 3.1.4
+      esniff: 2.0.1
+      next-tick: 1.1.0
+    dev: false
+
+  /es6-iterator@2.0.3:
+    resolution: {integrity: sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==}
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+      es6-symbol: 3.1.4
+    dev: false
+
+  /es6-symbol@3.1.4:
+    resolution: {integrity: sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==}
+    engines: {node: '>=0.12'}
+    dependencies:
+      d: 1.0.2
+      ext: 1.7.0
+    dev: false
+
   /esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
     dependencies:
@@ -8588,6 +8686,10 @@ packages:
   /escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  /escape-carriage@1.3.1:
+    resolution: {integrity: sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw==}
+    dev: false
 
   /escape-goat@4.0.0:
     resolution: {integrity: sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==}
@@ -8744,6 +8846,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /esniff@2.0.1:
+    resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+      event-emitter: 0.3.5
+      type: 2.7.3
+    dev: false
+
   /espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -8845,6 +8957,13 @@ packages:
       require-like: 0.1.2
     dev: false
 
+  /event-emitter@0.3.5:
+    resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+    dev: false
+
   /eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
     dev: false
@@ -8944,7 +9063,7 @@ packages:
       content-type: 1.0.5
       cookie: 0.7.1
       cookie-signature: 1.2.2
-      debug: 4.4.1
+      debug: 4.4.3
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -8968,6 +9087,12 @@ packages:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /ext@1.7.0:
+    resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
+    dependencies:
+      type: 2.7.3
     dev: false
 
   /extend-shallow@2.0.1:
@@ -9105,7 +9230,7 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -9904,7 +10029,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9952,7 +10077,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9993,6 +10118,10 @@ packages:
       postcss: ^8.1.0
     dependencies:
       postcss: 8.5.6
+    dev: false
+
+  /ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
     dev: false
 
   /ignore@5.3.2:
@@ -10091,6 +10220,11 @@ packages:
     engines: {node: '>= 0.10'}
     dev: false
 
+  /intersection-observer@0.10.0:
+    resolution: {integrity: sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==}
+    deprecated: The Intersection Observer polyfill is no longer needed and can safely be removed. Intersection Observer has been Baseline since 2019.
+    dev: false
+
   /invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
     dependencies:
@@ -10168,6 +10302,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       binary-extensions: 2.3.0
+    dev: false
 
   /is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
@@ -10543,6 +10678,7 @@ packages:
   /jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
+    dev: false
 
   /jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
@@ -10964,7 +11100,6 @@ packages:
   /lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
-    dev: true
 
   /magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -11612,7 +11747,7 @@ packages:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.1
+      debug: 4.4.3
       decode-named-character-reference: 1.1.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -11821,6 +11956,10 @@ packages:
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
+  /next-tick@1.1.0:
+    resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
+    dev: false
+
   /no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
@@ -11872,6 +12011,7 @@ packages:
   /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+    dev: false
 
   /normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
@@ -11917,11 +12057,6 @@ packages:
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-
-  /object-hash@3.0.0:
-    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
-    engines: {node: '>= 6'}
-    dev: true
 
   /object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -12041,6 +12176,10 @@ packages:
   /outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
     dev: true
+
+  /outvariant@1.4.0:
+    resolution: {integrity: sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==}
+    dev: false
 
   /own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
@@ -12322,11 +12461,6 @@ packages:
   /picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
-    dev: true
-
-  /pify@2.3.0:
-    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
-    engines: {node: '>=0.10.0'}
     dev: true
 
   /pify@4.0.1:
@@ -12625,28 +12759,6 @@ packages:
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-import@15.1.0(postcss@8.5.6):
-    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      postcss: ^8.0.0
-    dependencies:
-      postcss: 8.5.6
-      postcss-value-parser: 4.2.0
-      read-cache: 1.0.0
-      resolve: 1.22.10
-    dev: true
-
-  /postcss-js@4.0.1(postcss@8.5.6):
-    resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
-    engines: {node: ^12 || ^14 || >= 16}
-    peerDependencies:
-      postcss: ^8.4.21
-    dependencies:
-      camelcase-css: 2.0.1
-      postcss: 8.5.6
-    dev: true
-
   /postcss-lab-function@7.0.10(postcss@8.5.6):
     resolution: {integrity: sha512-tqs6TCEv9tC1Riq6fOzHuHcZyhg4k3gIAMB8GGY/zA1ssGdm6puHMVE7t75aOSoFg7UD2wyrFFhbldiCMyyFTQ==}
     engines: {node: '>=18'}
@@ -12660,23 +12772,6 @@ packages:
       '@csstools/utilities': 2.0.0(postcss@8.5.6)
       postcss: 8.5.6
     dev: false
-
-  /postcss-load-config@4.0.2(postcss@8.5.6):
-    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
-    engines: {node: '>= 14'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 3.1.3
-      postcss: 8.5.6
-      yaml: 2.8.1
-    dev: true
 
   /postcss-load-config@6.0.1(postcss@8.5.4):
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
@@ -12845,16 +12940,6 @@ packages:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
     dev: false
-
-  /postcss-nested@6.2.0(postcss@8.5.6):
-    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
-    engines: {node: '>=12.0'}
-    peerDependencies:
-      postcss: ^8.2.14
-    dependencies:
-      postcss: 8.5.6
-      postcss-selector-parser: 6.1.2
-    dev: true
 
   /postcss-nesting@13.0.1(postcss@8.5.6):
     resolution: {integrity: sha512-VbqqHkOBOt4Uu3G8Dm8n6lU5+9cJFxiuty9+4rcoyRPO9zZS1JIs6td49VIoix3qYqELHlJIn46Oih9SAKo+yQ==}
@@ -13144,6 +13229,7 @@ packages:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
+    dev: false
 
   /postcss-selector-parser@7.1.0:
     resolution: {integrity: sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==}
@@ -13451,6 +13537,12 @@ packages:
       - vue-template-compiler
     dev: false
 
+  /react-devtools-inline@4.4.0:
+    resolution: {integrity: sha512-ES0GolSrKO8wsKbsEkVeiR/ZAaHQTY4zDh1UW8DImVmm8oaGLl3ijJDvSGe+qDRKPZdPRnDtWWnSvvrgxXdThQ==}
+    dependencies:
+      es6-symbol: 3.1.4
+    dev: false
+
   /react-dom@18.3.1(react@18.3.1):
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
@@ -13498,7 +13590,6 @@ packages:
 
   /react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
-    dev: true
 
   /react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -13556,19 +13647,6 @@ packages:
       tiny-warning: 1.0.3
     dev: false
 
-  /react-router-dom@6.30.1(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-    dependencies:
-      '@remix-run/router': 1.23.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.30.1(react@18.3.1)
-    dev: false
-
   /react-router@5.3.4(react@18.3.1):
     resolution: {integrity: sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==}
     peerDependencies:
@@ -13586,27 +13664,11 @@ packages:
       tiny-warning: 1.0.3
     dev: false
 
-  /react-router@6.30.1(react@18.3.1):
-    resolution: {integrity: sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
-    dependencies:
-      '@remix-run/router': 1.23.0
-      react: 18.3.1
-    dev: false
-
   /react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
-
-  /read-cache@1.0.0:
-    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
-    dependencies:
-      pify: 2.3.0
-    dev: true
 
   /read-pkg-up@7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
@@ -13663,6 +13725,7 @@ packages:
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.1
+    dev: false
 
   /readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -14020,7 +14083,7 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -14525,7 +14588,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -14539,7 +14602,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -14559,6 +14622,15 @@ packages:
   /stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
+
+  /static-browser-server@1.0.3:
+    resolution: {integrity: sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==}
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      dotenv: 16.6.1
+      mime-db: 1.54.0
+      outvariant: 1.4.0
+    dev: false
 
   /statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
@@ -14585,6 +14657,10 @@ packages:
       es-errors: 1.3.0
       internal-slot: 1.1.0
     dev: true
+
+  /strict-event-emitter@0.4.6:
+    resolution: {integrity: sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==}
+    dev: false
 
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -14730,6 +14806,10 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  /style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+    dev: false
+
   /style-to-js@1.1.16:
     resolution: {integrity: sha512-/Q6ld50hKYPH3d/r6nr117TZkHR0w0kGGIVfpG9N6D8NymRPM9RqCUv4pRpJ62E5DqOYx2AFpbZMyCPnjQCnOw==}
     dependencies:
@@ -14809,37 +14889,6 @@ packages:
 
   /symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
-    dev: true
-
-  /tailwindcss@3.4.17:
-    resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.3
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.7
-      lilconfig: 3.1.3
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-import: 15.1.0(postcss@8.5.6)
-      postcss-js: 4.0.1(postcss@8.5.6)
-      postcss-load-config: 4.0.2(postcss@8.5.6)
-      postcss-nested: 6.2.0(postcss@8.5.6)
-      postcss-selector-parser: 6.1.2
-      resolve: 1.22.10
-      sucrase: 3.35.0
-    transitivePeerDependencies:
-      - ts-node
     dev: true
 
   /tailwindcss@4.0.0:
@@ -15032,15 +15081,6 @@ packages:
   /trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
-  /ts-api-utils@1.4.3(typescript@5.2.2):
-    resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      typescript: '>=4.2.0'
-    dependencies:
-      typescript: 5.2.2
-    dev: true
-
   /ts-api-utils@1.4.3(typescript@5.8.3):
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
     engines: {node: '>=16'}
@@ -15180,6 +15220,10 @@ packages:
       content-type: 2.0.0
       media-typer: 1.1.0
       mime-types: 3.0.2
+    dev: false
+
+  /type@2.7.3:
+    resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
     dev: false
 
   /typed-array-buffer@1.0.3:
@@ -15426,6 +15470,7 @@ packages:
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: false
 
   /utila@0.4.0:
     resolution: {integrity: sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==}
@@ -15479,28 +15524,6 @@ packages:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
-
-  /vite-node@2.1.9:
-    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 1.1.2
-      vite: 5.4.19(@types/node@22.19.19)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
 
   /vite-node@2.1.9(@types/node@22.19.19):
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -15561,63 +15584,6 @@ packages:
       rollup: 4.42.0
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
-
-  /vitest@2.1.9:
-    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.9
-      '@vitest/ui': 2.1.9
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.19)
-      '@vitest/pretty-format': 2.1.9
-      '@vitest/runner': 2.1.9
-      '@vitest/snapshot': 2.1.9
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
-      chai: 5.2.1
-      debug: 4.4.1
-      expect-type: 1.2.2
-      magic-string: 0.30.17
-      pathe: 1.1.2
-      std-env: 3.9.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinypool: 1.1.1
-      tinyrainbow: 1.2.0
-      vite: 5.4.19(@types/node@22.19.19)
-      vite-node: 2.1.9
-      why-is-node-running: 2.3.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
     dev: true
 
   /vitest@2.1.9(@types/node@22.19.19):
@@ -15722,7 +15688,7 @@ packages:
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
       vite: 5.4.19(@types/node@22.19.19)
-      vite-node: 2.1.9
+      vite-node: 2.1.9(@types/node@22.19.19)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - less
@@ -15735,6 +15701,10 @@ packages:
       - supports-color
       - terser
     dev: true
+
+  /w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+    dev: false
 
   /w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -16153,12 +16123,6 @@ packages:
     engines: {node: '>= 6'}
     dev: false
 
-  /yaml@2.8.1:
-    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-    dev: true
-
   /yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
@@ -16173,12 +16137,12 @@ packages:
     engines: {node: '>=12.20'}
     dev: false
 
-  /zod-to-json-schema@3.25.2(zod@4.0.17):
+  /zod-to-json-schema@3.25.2(zod@3.25.76):
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
       zod: ^3.25.28 || ^4
     dependencies:
-      zod: 4.0.17
+      zod: 3.25.76
     dev: false
 
   /zod@3.25.76:


### PR DESCRIPTION
## What

**Docs:**
- New **`/playground`** page — left-sidebar switcher between live, editable Sandpack examples (useForm, validation, field array), deep-linkable via `?example=<id>`. Navbar + docs-sidebar links; "← Back to docs" button.
- Doc sections (quick-start, auto-form, validation, array-fields) keep static code + a `:::tip` linking to the matching Playground example.
- Build-time **version injection** (`customFields.elFormVersions`) so sandboxes always pin the current published versions — no stale pins.
- Temporary shared styling for the example forms (stopgap before design presets).

**Library fix (user-facing):**
- **`fix(AutoForm)`: generate fields with Zod 3.x.** AutoForm rendered **zero fields** under Zod 3 — it read a ZodObject's shape from `getDef(schema).shape`, which is `_def.shape`, a getter *function* in Zod 3 (an object in Zod 4), so iteration produced no keys. New `getObjectShape()` in `el-form-core` handles both. TDD (`zodHelpers.objectShape.test.ts`); verified end-to-end (built dist + zod 3.25.76 renders all fields, was 0). Changeset → patch bump `el-form-core` + `el-form-react-components`. The regression was masked because component tests resolve Zod 4.
- **`fix(docs)`: field-array `register`** — example read `register` straight from `useFormContext()` (returns `{ form }`); corrected to `.form`.

## Verification
- `el-form-core` 74 tests, `el-form-react-components` 26 tests, docs version-helper 2 tests — all pass. Lint clean. Docs build clean.
- Live examples confirmed rendering in-browser; AutoForm fix proven with a zod-3 client render.

## Note
The Playground's AutoForm entry stays **static** until the `el-form-react-components` patch publishes (the sandbox bundles the published package). After the release, a one-line change in `registry.ts` flips it live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)