### PR TITLE
docs: reflect recent changes (audit fixes)

### DIFF
--- a/docs/docs/api/overview.md
+++ b/docs/docs/api/overview.md
@@ -126,12 +126,9 @@ const {
   isValid, // Overall form validity
   isDirty, // Form has been modified
   isSubmitting, // Form submission in progress
-  isSubmitted, // Form has been submitted at least once
-  submitCount, // Number of submission attempts
-  isValidating, // Async validation in progress
-  defaultValues, // Original default values
-  isLoading, // Initial form loading state
-  dirtyFields, // Which specific fields are dirty
+  isSubmitted, // True after the first submit attempt
+  isSubmitSuccessful, // True when the last submit passed validation and the handler ran without throwing
+  submitCount, // Number of submit attempts
 } = formState;
 ```
 
@@ -514,27 +511,26 @@ The `formState` object contains all form state information:
 interface FormState<T extends Record<string, any>> {
   // Current Values
   values: Partial<T>; // Current form field values
-  defaultValues: T; // Original default values
 
   // Validation State
-  errors: Partial<Record<keyof T, string>>; // Current validation errors
+  errors: Partial<Record<keyof T, string>>; // Current validation errors (string per field)
   isValid: boolean; // Overall form validity
-  isValidating: boolean; // Async validation in progress
 
   // User Interaction State
   touched: Partial<Record<keyof T, boolean>>; // Fields user has interacted with
-  dirtyFields: Partial<Record<keyof T, boolean>>; // Which fields have been modified
   isDirty: boolean; // Form has been modified from defaults
 
   // Submission State
   isSubmitting: boolean; // Form submission in progress
-  isSubmitted: boolean; // Form has been submitted at least once
-  submitCount: number; // Number of submission attempts
-
-  // Loading State
-  isLoading: boolean; // Initial form loading state
+  isSubmitted: boolean; // True after the first submit attempt; reset by reset()
+  isSubmitSuccessful: boolean; // True when the last submit passed validation and the handler ran without throwing; reset by reset()
+  submitCount: number; // Number of submit attempts; reset by reset()
 }
 ```
+
+> Per-field dirty/touched maps are available via the `getDirtyFields()` /
+> `getTouchedFields()` methods on the form return value — they are not fields on
+> `formState`.
 
 ## Quick Usage Examples
 
@@ -614,6 +610,11 @@ El Form is organized into focused packages:
 - **`useForm`** - Main form hook (everything above)
 - **`FormProvider`** - Context provider for sharing form state
 - **`useFormContext`** - Hook to access form context
+- **`useField`** - Subscribe to a single field's `value` + `error` + `touched`
+- **`useFormSelector`** - Subscribe to an arbitrary derived slice of form state
+- **`useWatch`** - Reactively watch form value(s) by path (values only)
+- **`useFieldArray`** - Manage dynamic array fields with stable row ids
+- **`shallowEqual`** - Equality helper for selector subscriptions
 
 ### `el-form-react-components`
 

--- a/docs/docs/api/use-form.md
+++ b/docs/docs/api/use-form.md
@@ -35,6 +35,8 @@ interface UseFormOptions<T extends Record<string, any>> {
   mode?: "onChange" | "onBlur" | "onSubmit" | "all";
   validateOn?: "onChange" | "onBlur" | "onSubmit" | "manual";
   shouldFocusError?: boolean; // default true
+  values?: Partial<T>; // reactive external values (props/server data)
+  keepDirtyValues?: boolean; // keep mid-edit fields when reactive values change
 }
 ```
 
@@ -208,6 +210,55 @@ const form = useForm({
 Focus-on-error relies on the `ref` that `register` returns — make sure each field is
 registered with `{...register("name")}` so its DOM node can be focused.
 
+#### values
+
+**Type:** `Partial<T>`  
+**Optional:** Yes
+
+Reactive external values for forms backed by **props or server data**. When this
+object's _content_ changes, the form re-syncs to it. The comparison is a deep
+compare, so re-rendering with a brand-new object of the same content is a no-op — you
+don't have to memoize it. When present, `values` takes precedence over
+`defaultValues` for the form's initial state.
+
+This is the el-form equivalent of React Hook Form's `values` prop and Formik's
+`enableReinitialize`.
+
+```typescript
+const form = useForm({
+  values: serverData, // re-syncs whenever serverData's content changes
+});
+```
+
+**Caveats:**
+
+- `values` replaces the **whole** value object — provide the full shape, not a
+  partial patch. Omitted keys are dropped.
+- `isDirty` is still measured against the original `defaultValues`, not the latest
+  synced `values`.
+- Don't put `File`/`Blob` instances in reactive `values`; the deep compare can't tell
+  two files apart, so a file swap won't trigger a re-sync.
+
+#### keepDirtyValues
+
+**Type:** `boolean`  
+**Optional:** Yes — **default `false`**
+
+Pairs with reactive [`values`](#values). When the `values` object changes, fields the
+user is **mid-editing** (dirty) are preserved instead of being overwritten; untouched
+fields still sync to the incoming data. The default (`false`) overwrites everything,
+matching React Hook Form's default.
+
+```typescript
+const form = useForm({
+  values: serverData,
+  keepDirtyValues: true, // don't clobber what the user is typing
+});
+```
+
+This is the equivalent of React Hook Form's `values` prop combined with
+`resetOptions: { keepDirtyValues: true }`.
+
 #### validationDebounceMs
 
 **Type:** `number`  
@@ -366,6 +417,9 @@ interface FormState<T> {
   isSubmitting: boolean; // Form submission in progress
   isValid: boolean; // Overall form validity
   isDirty: boolean; // Form has been modified
+  isSubmitted: boolean; // True after the first submit attempt; reset by reset()
+  isSubmitSuccessful: boolean; // True when the last submit passed validation and the handler ran without throwing; reset by reset()
+  submitCount: number; // Number of submit attempts; reset by reset()
 }
 ```
 
@@ -381,6 +435,9 @@ console.log(formState.touched); // Which fields have been touched
 console.log(formState.isValid); // Is the entire form valid?
 console.log(formState.isDirty); // Has the form been modified?
 console.log(formState.isSubmitting); // Is submission in progress?
+console.log(formState.isSubmitted); // Has a submit been attempted?
+console.log(formState.isSubmitSuccessful); // Did the last submit succeed?
+console.log(formState.submitCount); // How many submit attempts?
 
 // Conditional rendering based on state
 {
@@ -517,6 +574,66 @@ useEffect(() => {
   console.log("Form changed:", values);
 }, [values]);
 ```
+
+### useWatch
+
+`useWatch` is a standalone hook (exported from `el-form-react-hooks`) that reactively
+subscribes to form value(s) by path — a reactive mirror of `form.watch()`. It is built
+on the selector store, so each watcher re-renders in isolation. **It must be used
+inside a `<FormProvider>`** and returns **values only** (use
+[`useField`](../concepts/performance.md#usefield--subscribe-to-one-field) when you
+also need `error` + `touched`, or
+[`useFormSelector`](../concepts/performance.md#useformselector--subscribe-to-a-derived-slice)
+for an arbitrary derived slice).
+
+```typescript
+import { useWatch } from "el-form-react-hooks";
+
+// Single path — returns that value
+useWatch<T, Name extends Path<T>>(name: Name): PathValue<T, Name>;
+
+// Multiple paths — returns an object keyed by each path
+useWatch<T, Names extends Path<T>>(names: Names[]): { [K in Names]: PathValue<T, K> };
+
+// No argument — returns all values
+useWatch<T>(): Partial<T>;
+```
+
+**Example:**
+
+```tsx
+import { FormProvider, useForm, useWatch } from "el-form-react-hooks";
+
+function CountryFields() {
+  // Re-renders only when `country` changes
+  const country = useWatch<FormValues, "country">("country");
+  return country === "US" ? <StateSelect /> : null;
+}
+
+function App() {
+  const form = useForm<FormValues>({ defaultValues: { country: "" } });
+  return (
+    <FormProvider form={form}>
+      <CountryFields />
+    </FormProvider>
+  );
+}
+```
+
+```tsx
+// Multiple paths -> object keyed by path name
+const { firstName, lastName } = useWatch<FormValues, "firstName" | "lastName">([
+  "firstName",
+  "lastName",
+]);
+
+// All values
+const all = useWatch<FormValues>(); // Partial<FormValues>
+```
+
+Use `useWatch` to react to value changes in a child component **without** calling
+`register` there. The imperative `form.watch()` is unchanged and still works for reading
+values inside the component that owns the form.
 
 #### Reset Operations
 
@@ -1176,7 +1293,6 @@ function RegistrationForm() {
     <form onSubmit={onSubmit}>
       <div>
         <input {...register("username")} placeholder="Username" />
-        {formState.isValidating && <span>Checking availability...</span>}
         {formState.errors.username && (
           <span className="error">{formState.errors.username}</span>
         )}
@@ -1334,9 +1450,6 @@ const form = useForm();
 // Show loading during async operations
 {
   form.formState.isSubmitting && <LoadingSpinner />;
-}
-{
-  form.formState.isValidating && <span>Validating...</span>;
 }
 
 // Disable form during submission

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -14,6 +14,79 @@ All notable changes to the el-form project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.15.0] - 2026-06-09
+
+Released: `el-form-react-hooks@3.15.0`, `el-form-react-components@4.7.2`,
+`el-form-react@4.1.14`.
+
+### ✨ New `formState` fields — `el-form-react-hooks@3.15.0`
+
+- **Submit-status metadata, for React Hook Form parity.** `formState` gains three additive fields, all set consistently across `handleSubmit`, `submit()`, and `submitAsync()`, and all reset by `reset()`:
+  - **`isSubmitted: boolean`** — `true` after the first submit attempt.
+  - **`isSubmitSuccessful: boolean`** — `true` when the last submit passed validation and the submit handler ran without throwing.
+  - **`submitCount: number`** — number of submit attempts.
+- Purely additive — existing forms are unaffected.
+
+## [3.14.0] - 2026-06-09
+
+Released: `el-form-react-hooks@3.14.0`, `el-form-react-components@4.7.1`,
+`el-form-react@4.1.13`.
+
+### ✨ New Feature — reactive `values` + `keepDirtyValues`
+
+- **`useForm({ values })`**: a reactive external-values option for forms backed by props or server data. When the `values` object's _content_ changes, the form re-syncs to it (deep-compared, so a new-object/same-content render is a no-op — no memoization required). It takes precedence over `defaultValues` for the initial state. This is the el-form equivalent of React Hook Form's `values` prop and Formik's `enableReinitialize`.
+- **`keepDirtyValues: true`**: pair it with reactive `values` to preserve fields the user is mid-editing (dirty) while untouched fields still sync — the equivalent of RHF's `values` + `resetOptions: { keepDirtyValues: true }`.
+- Additive — existing forms are unaffected. Notes: `values` replaces the **whole** value object (provide the full shape, not a partial patch — omitted keys are dropped); `isDirty` is still measured against the original `defaultValues`, not the latest synced `values`; and don't put `File`/`Blob` instances in reactive `values` (the deep-compare can't tell two files apart, so a file swap won't re-sync).
+
+## [3.13.0] - 2026-06-09
+
+Released: `el-form-react-hooks@3.13.0`, `el-form-react-components@4.7.0`,
+`el-form-react@4.1.12`.
+
+### ⚡ TypeScript performance win — `Path<T>`
+
+- **`Path<T>` no longer emits the duplicate bracket (`items[0]`) array-path forms**, which doubled the path union at every nesting level. Type instantiations drop ~7.8× at depth 6 (≈992K → ≈127K), and el-form now type-checks **faster than React Hook Form** on realistic nested schemas (≤ RHF at every depth, strictly faster at depth ≥ 4).
+
+### ⚠️ Breaking (types only)
+
+- **Bracket-index path notation is no longer type-checked** — it becomes a `tsc` error. This affects `Path<T>`-typed APIs in both packages: `register("items[0].name")` / `useField` / `useWatch` (hooks), and the `name` prop of `TextField` / `SelectField` / `TextareaField` / `BaseFieldProps` (components).
+- **Runtime is unaffected** — bracket paths are still normalized internally and `PathValue` still resolves them. The fix is to switch the _type_ to **dot notation**: `items[0].name` → `items.0.name`, and `` `items[${i}]` `` → `` `items.${i}` ``. Dot notation was already the form used throughout el-form's docs and examples.
+
+## [3.12.0] - 2026-06-09
+
+Released: `el-form-react-hooks@3.12.0`, `el-form-react-components@4.6.1`,
+`el-form-react@4.1.11`.
+
+### ✨ New Hook — `useWatch`
+
+- **`useWatch`**: a reactive hook for subscribing to form value(s) by path, for React Hook Form parity. A reactive mirror of `form.watch()`'s overloads, built on the selector store so each watcher re-renders in isolation:
+
+  ```ts
+  const all = useWatch<MyForm>(); // Partial<MyForm>
+  const email = useWatch<MyForm, "email">("email"); // string
+  const pair = useWatch<MyForm, "a" | "b">(["a", "b"]); // { a: ...; b: ... }
+  ```
+
+  Must be used within a `<FormProvider>`. Returns **values only** — use `useField` for `value + error + touched`, or `useFormSelector` for an arbitrary derived slice. The imperative `form.watch()` is unchanged. See the [useForm API → `useWatch`](./api/use-form.md#usewatch).
+
+## [3.11.4] - 2026-06-08
+
+Released: `el-form-react-hooks@3.11.4`, `el-form-react-components@4.5.x`,
+`el-form-react@4.1.x`.
+
+### 🐞 Bug Fix — `FormProvider` context reactivity
+
+- **`FormProvider` context getter no longer lags one render behind.** A component reading `useFormContext().form.formState` directly during render previously observed form state one render late, because the context getter returned a ref refreshed only in a post-commit effect. The ref is now updated during render, so direct reads are current within the same render pass. No public API change. (A `React.memo`-wrapped child with unchanged props still won't re-render on a bare direct read — subscribe via `useField` / `useFormSelector` when a component must react to state changes.)
+
+## Maintenance — Zod 3 AutoForm fix
+
+Released: `el-form-core@2.3.3`, `el-form-react-components@4.7.3`,
+`el-form-react-hooks@3.15.1`, `el-form-react@4.1.15`.
+
+### 🐞 Bug Fix — AutoForm field generation under Zod 3.x
+
+- **AutoForm rendered zero fields when used with Zod 3.x** (only the Submit/Reset buttons appeared). It read a `ZodObject`'s shape from `getDef(schema).shape`, which in Zod 3 is a getter **function** (in Zod 4 the shape is already an object), so iterating it produced no keys. A new `getObjectShape` helper in `el-form-core` invokes the getter when needed and falls back to the public `.shape`, so AutoForm now generates fields across Zod 3 and Zod 4.
+
 ## [3.11.0] - 2026-06-05
 
 Released: `el-form-react-hooks@3.11.0`, `el-form-react-components@4.5.0`,

--- a/docs/docs/concepts/form-state.md
+++ b/docs/docs/concepts/form-state.md
@@ -26,6 +26,9 @@ interface FormState<T> {
   isSubmitting: boolean;                       // submit handler in flight
   isValid: boolean;                            // no current errors
   isDirty: boolean;                            // any value changed from default
+  isSubmitted: boolean;                        // true after the first submit attempt
+  isSubmitSuccessful: boolean;                 // true when the last submit passed validation and the handler ran without throwing
+  submitCount: number;                         // number of submit attempts
 }
 ```
 
@@ -36,6 +39,11 @@ A few things worth knowing:
 - **`touched`** flips to `true` when a field is blurred, so you can defer
   showing errors until the user leaves a field.
 - **`isDirty`** compares against `defaultValues`; resetting clears it.
+- **`isSubmitted`** flips to `true` after the first submit attempt and is reset by
+  `reset()`.
+- **`isSubmitSuccessful`** is `true` when the last submit passed validation and the
+  submit handler ran without throwing; it is reset by `reset()`.
+- **`submitCount`** counts submit attempts and is reset by `reset()`.
 
 ```tsx
 const { register, handleSubmit, formState } = useForm({

--- a/docs/docs/concepts/validation.md
+++ b/docs/docs/concepts/validation.md
@@ -28,6 +28,15 @@ type ValidatorFunction = (values: any) => {
 
 This simple interface means El Form can work with any validation library or custom logic.
 
+:::tip Standard Schema support
+El Form automatically detects any validator that implements the
+[**Standard Schema**](https://standardschema.dev) spec — i.e. it exposes a
+`~standard` property — and validates through that protocol. So **Valibot**,
+**ArkType**, and any other Standard Schema-compliant library work out of the box, with
+no resolver or adapter to install. (Zod and Yup are detected via their own shapes as
+well.)
+:::
+
 ## Validation Libraries
 
 ### Zod (Recommended)
@@ -264,7 +273,6 @@ const { formState } = useForm({
 
 // Check validation status
 console.log(formState.isValid); // true/false
-console.log(formState.isValidating); // true during async validation
 console.log(formState.errors); // Current error state
 console.log(formState.touched); // Which fields have been touched
 ```

--- a/docs/docs/guides/error-handling.md
+++ b/docs/docs/guides/error-handling.md
@@ -380,9 +380,6 @@ function EmailValidationForm() {
     <form>
       <div>
         <input {...register("email")} placeholder="Email" />
-        {formState.isValidating && (
-          <span className="text-blue-500">Checking email...</span>
-        )}
         {formState.errors.email && (
           <span className="text-red-500">{formState.errors.email}</span>
         )}

--- a/docs/docs/guides/use-form.md
+++ b/docs/docs/guides/use-form.md
@@ -258,7 +258,6 @@ return (
   <div>
     {/* Validation state */}
     <p>Valid: {formState.isValid}</p>
-    <p>Validating: {formState.isValidating}</p>
 
     {/* Change tracking */}
     <p>Dirty: {formState.isDirty}</p>
@@ -266,6 +265,8 @@ return (
 
     {/* Submission state */}
     <p>Submitting: {formState.isSubmitting}</p>
+    <p>Submitted: {formState.isSubmitted}</p>
+    <p>Submit successful: {formState.isSubmitSuccessful}</p>
     <p>Submit count: {formState.submitCount}</p>
 
     {/* Errors */}
@@ -350,8 +351,9 @@ const email = watch("email");
 // Watch multiple fields
 const [email, password] = watch(["email", "password"]);
 
-// Watch with selector function
-const isFormValid = watch((formState) => formState.isValid);
+// watch() is for value paths; read form-level status from formState directly
+// (or use useFormSelector for an isolated subscription).
+const isFormValid = formState.isValid;
 
 // Use in effects
 useEffect(() => {
@@ -389,26 +391,24 @@ Complete FormState interface reference:
 ```tsx
 interface FormState<T = any> {
   // Values and validation
-  values: T; // Current form values
-  errors: Record<string, string>; // Validation errors
-  touched: Record<string, boolean>; // Fields user has interacted with
+  values: Partial<T>; // Current form values
+  errors: Partial<Record<keyof T, string>>; // Validation errors (string per field)
+  touched: Partial<Record<keyof T, boolean>>; // Fields user has interacted with
   isValid: boolean; // Overall form validity
-  isValidating: boolean; // Async validation in progress
 
   // Submission state
   isSubmitting: boolean; // Form submission in progress
-  isSubmitted: boolean; // Form has been submitted
-  submitCount: number; // Number of submission attempts
+  isSubmitted: boolean; // True after the first submit attempt; reset by reset()
+  isSubmitSuccessful: boolean; // True when the last submit passed validation and the handler ran without throwing; reset by reset()
+  submitCount: number; // Number of submit attempts; reset by reset()
 
   // Change tracking
-  isDirty: boolean; // Form has been modified
-  dirtyFields: Record<string, boolean>; // Which fields have been modified
-
-  // Advanced state
-  defaultValues: T; // Original default values
-  isLoading: boolean; // Initial form loading state
+  isDirty: boolean; // Form has been modified from defaults
 }
 ```
+
+> Per-field dirty/touched maps are exposed as the `getDirtyFields()` /
+> `getTouchedFields()` methods — they are not fields on `formState`.
 
 ## Best Practices
 

--- a/docs/src/sandboxes/registry.ts
+++ b/docs/src/sandboxes/registry.ts
@@ -18,9 +18,7 @@ export interface PlaygroundExample {
   note?: string;
 }
 
-// The four learning-path examples. useForm / validation / field-array run live;
-// AutoForm is shown as static source until a known field-generation bug with
-// zod 3.x is fixed in el-form-react-components (AutoForm renders no fields).
+// The four learning-path examples — all run live in the Sandpack sandbox.
 export const PLAYGROUND_EXAMPLES: PlaygroundExample[] = [
   {
     id: "useform",
@@ -44,8 +42,7 @@ export const PLAYGROUND_EXAMPLES: PlaygroundExample[] = [
     id: "autoform",
     label: "AutoForm",
     blurb: "Generate a whole form from a Zod schema.",
-    staticCode: autoFormBasicFiles["/App.tsx"] as string,
-    note: "Static preview for now — the live AutoForm demo is paused while we fix a field-generation issue with recent Zod 3.x versions.",
+    files: autoFormBasicFiles,
   },
 ];
 

--- a/docs/static/llms-full.txt
+++ b/docs/static/llms-full.txt
@@ -43,7 +43,7 @@ Peer requirement: React 18+ (the hooks API works with React 16.8+).
 | Package                    | Exports                                  | Use when |
 | -------------------------- | ---------------------------------------- | -------- |
 | `el-form-react`            | re-exports hooks + components + styles    | most apps |
-| `el-form-react-hooks`      | `useForm`, `FormProvider`, `useFormContext`, `useField` | custom forms |
+| `el-form-react-hooks`      | `useForm`, `FormProvider`, `useFormContext`, `useFormSelector`, `useField`, `useWatch`, `useFieldArray`, `shallowEqual` | custom forms |
 | `el-form-react-components` | `AutoForm`, field components, `styles.css` | schema-driven forms |
 | `el-form-core`             | validation engine + utilities             | other frameworks / advanced |
 
@@ -150,8 +150,13 @@ export function LoginForm() {
 ```
 
 `useForm` returns (most-used): `register`, `handleSubmit`, `formState`
-(`errors`, `touched`, `isDirty`, `isSubmitting`, `isValid`), `watch`,
-`setError`, `clearErrors`, `reset`, `setValue`, `getValues`.
+(`values`, `errors`, `touched`, `isDirty`, `isSubmitting`, `isValid`,
+`isSubmitted`, `isSubmitSuccessful`, `submitCount`), `watch`,
+`setError`, `clearErrors`, `reset`, `setValue`. Each `errors[field]` is a
+plain string (no `.message`). `isSubmitted`/`isSubmitSuccessful`/`submitCount`
+track submit attempts and are reset by `reset()`. There is no `isValidating`,
+`defaultValues`, `dirtyFields`, or `isLoading` on `formState` — per-field
+dirty/touched maps are the `getDirtyFields()` / `getTouchedFields()` methods.
 
 Validation triggers are configured per event:
 
@@ -247,6 +252,53 @@ function App() {
 Three reusability patterns are supported: **context** (`FormProvider` +
 `useFormContext`), **prop-passing** (`<Field form={form} />`), and **hybrid**
 (`form || useFormContext()`).
+
+--------------------------------------------------------------------------------
+## Reactive hooks (inside `<FormProvider>`)
+
+`useWatch` — reactively subscribe to value(s) by path; a reactive mirror of
+`form.watch()` built on the selector store, so each watcher re-renders in
+isolation. Returns **values only** (use `useField` for `value + error +
+touched`, or `useFormSelector` for an arbitrary derived slice). Must be used
+within a `<FormProvider>`.
+
+```tsx
+import { useWatch } from "el-form-react-hooks";
+const all = useWatch<MyForm>();                          // Partial<MyForm>
+const email = useWatch<MyForm, "email">("email");         // string
+const pair = useWatch<MyForm, "a" | "b">(["a", "b"]);     // { a, b }
+```
+
+`useFieldArray` — dynamic array fields. Returns a `fields` array where each row
+has a stable `id` (use as the React `key`) plus `append`, `prepend`, `insert`,
+`remove`, `move`, `swap`, `update`, and `replace`. `name` is restricted to
+array-valued paths; item types are inferred. Works in `FormProvider` (re-renders
+only when its array changes) or with a `form` prop.
+
+```tsx
+import { useFieldArray } from "el-form-react-hooks";
+const { fields, append, remove } = useFieldArray<MyForm, "items">({ name: "items" });
+```
+
+--------------------------------------------------------------------------------
+## Reactive external values (props / server data)
+
+`useForm({ values })` re-syncs the form whenever the `values` object's content
+changes (deep-compared, so a new-object/same-content render is a no-op — no
+memoization needed). It takes precedence over `defaultValues` for the initial
+state. Pair with `keepDirtyValues: true` to keep fields the user is mid-editing
+while untouched fields sync. This is the el-form equivalent of React Hook Form's
+`values` prop (+ `resetOptions: { keepDirtyValues: true }`) and Formik's
+`enableReinitialize`.
+
+```tsx
+useForm({ values: serverData, keepDirtyValues: true });
+```
+
+Notes: `values` replaces the **whole** value object (full shape, not a partial
+patch); `isDirty` is measured against `defaultValues`, not the latest `values`;
+don't put `File`/`Blob` in reactive `values` (deep-compare can't tell two files
+apart).
 
 --------------------------------------------------------------------------------
 ## Links

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -6,14 +6,16 @@ Install everything with `npm install el-form-react`. The library is modular, so 
 
 Key facts:
 - AutoForm: `import { AutoForm } from "el-form-react-components"` — pass a `schema`, get a working form. Import `"el-form-react-components/styles.css"` for zero-config styling.
-- useForm: `import { useForm } from "el-form-react-hooks"` — `register`, `handleSubmit`, `formState`, `watch`, `setError`, `clearErrors` (familiar React Hook Form API).
+- useForm: `import { useForm } from "el-form-react-hooks"` — `register`, `handleSubmit`, `formState`, `watch`, `setError`, `clearErrors` (familiar React Hook Form API). `formState` fields: `values`, `errors` (string per field), `touched`, `isValid`, `isDirty`, `isSubmitting`, `isSubmitted`, `isSubmitSuccessful`, `submitCount`.
+- Reactive hooks (inside `<FormProvider>`): `useWatch` (subscribe to value(s) by path, values only), `useField` (`value + error + touched`), `useFormSelector` (derived slice), `useFieldArray` (dynamic array fields with stable row ids).
+- Reactive external values: `useForm({ values, keepDirtyValues })` re-syncs to props/server data (RHF `values` / Formik `enableReinitialize` equivalent).
 - Validation-agnostic: Zod (v3 + v4), Yup, Valibot, custom validators, or no validation. Validation libraries are optional peer installs.
 - TypeScript-first with strong inference. Works with Next.js, Vite, Remix, CRA. React 18+.
 - MIT licensed. Repo: https://github.com/colorpulse6/el-form
 
 ## Packages
 - `el-form-react`: everything (hooks + components + styles) — recommended default.
-- `el-form-react-hooks`: `useForm`, `FormProvider`, `useField` — for custom forms.
+- `el-form-react-hooks`: `useForm`, `FormProvider`, `useFormContext`, `useFormSelector`, `useField`, `useWatch`, `useFieldArray`, `shallowEqual` — for custom forms.
 - `el-form-react-components`: `AutoForm` + prebuilt field components.
 - `el-form-core`: framework-agnostic validation engine (build your own bindings).
 


### PR DESCRIPTION
Docs audit follow-up — bring the docs current with recently-shipped changes.

- **Playground:** AutoForm example flipped to **live** (the zod-3 field-gen fix is published in `el-form-react-components@4.7.3`).
- **`formState` shape corrected in 5 places** — added the submit-meta trio (`isSubmitted`/`isSubmitSuccessful`/`submitCount`) and removed **fabricated** fields (`isValidating`/`defaultValues`/`dirtyFields`/`isLoading`), including stray inline example usages that would give readers `undefined`.
- **Documented `useWatch`** (3 overloads) and the reactive **`values` / `keepDirtyValues`** `useForm` options in the API reference.
- **`changelog.md`** caught up (3.11.4 → 3.15.x + the AutoForm zod-3 fix).
- **`llms.txt` / `llms-full.txt`** hook + formState inventory refreshed.
- API overview lists all hooks; validation concept now names **Standard Schema**.
- Fixed an incorrect `watch((formState) => …)` example (`watch` takes value paths, not a selector).

Docs build clean. No package/source changes; no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)