### PR TITLE
fix(hooks): async validators now actually run

### DIFF
--- a/.changeset/async-validation-dispatch.md
+++ b/.changeset/async-validation-dispatch.md
@@ -1,0 +1,12 @@
+---
+"el-form-react-hooks": patch
+---
+
+Fix: async validators now actually run. Previously `onChangeAsync` / `onBlurAsync` /
+`onSubmitAsync` (field- and form-level), `asyncDebounceMs` / `*AsyncDebounceMs`, and
+`asyncAlways` were silent no-ops — the hooks layer never dispatched an async validation
+event. They now run: sync validation first (instant), then the async validator (only if
+sync passes, unless `asyncAlways`), debounced, with stale-result protection on change/blur;
+`submit()` / `handleSubmit` / `trigger()` await async validation and a failing async rule
+blocks submission. **Behavior change:** forms that configured async validators will now
+surface async errors and can gate submit where they previously passed silently.

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -14,6 +14,27 @@ All notable changes to the el-form project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — Fixed
+
+### 🐞 Bug Fix — async validators now actually run (`el-form-react-hooks`)
+
+- **`onChangeAsync` / `onBlurAsync` / `onSubmitAsync` (field- and form-level) were
+  silent no-ops.** The hooks layer never dispatched an async validation event, so
+  every async validator — including `asyncDebounceMs` / `*AsyncDebounceMs`
+  debounce config and the `asyncAlways` flag — had zero effect. They now run:
+  - Sync validators fire first (instant feedback); async validators run only if
+    sync passes, unless `asyncAlways: true` is set on that config.
+  - Change/blur async is **non-blocking** — the async result updates the UI when
+    it settles, with stale-result protection so superseded in-flight results are
+    discarded.
+  - `submit()` / `handleSubmit` / `trigger()` **await** async validation; a
+    failing async rule blocks submission.
+  - Form-level `validators.onSubmitAsync` runs on submit and can return
+    `{ fields: { <name>: msg } }` to attach per-field errors.
+- **Behavior change:** forms that configured async validators will now surface
+  async errors and can gate submission where they previously passed silently.
+- See the updated [Async Validation Guide](./guides/async-validation.md).
+
 ## [3.15.0] - 2026-06-09
 
 Released: `el-form-react-hooks@3.15.0`, `el-form-react-components@4.7.2`,

--- a/docs/docs/concepts/validation.md
+++ b/docs/docs/concepts/validation.md
@@ -203,64 +203,90 @@ const form = useForm({
   validators: { onChange: baseSchema },
   fieldValidators: {
     email: {
-      // Custom async validation for email uniqueness
-      onChangeAsync: async (value) => {
-        if (!value) return { isValid: true };
+      // Async check for email uniqueness — runs after sync validators pass
+      onChangeAsync: async ({ value }) => {
+        if (!value) return undefined;
 
         const response = await fetch(`/api/check-email?email=${value}`);
         const data = await response.json();
 
-        return {
-          isValid: !data.exists,
-          errors: data.exists ? { email: "Email already taken" } : undefined,
-        };
+        // Return an error string, or undefined when valid
+        return data.exists ? "Email already taken" : undefined;
       },
+      onChangeAsyncDebounceMs: 500,
     },
     username: {
-      // Custom sync validation
-      onChange: (value) => ({
-        isValid: /^[a-zA-Z0-9_]+$/.test(value),
-        errors: /^[a-zA-Z0-9_]+$/.test(value)
+      // Sync field-level validation — return error string or undefined
+      onChange: ({ value }) =>
+        /^[a-zA-Z0-9_]+$/.test(value)
           ? undefined
-          : { username: "Only letters, numbers, and underscores allowed" },
-      }),
+          : "Only letters, numbers, and underscores allowed",
     },
   },
 });
 ```
 
+:::note Field validator return shape
+Field-level validators (both sync and async) return a **string** (the error
+message) or **`undefined`** (valid). They do **not** return `{ isValid, errors }`
+— that shape is only used internally by schema libraries. Form-level validators
+in `validators` that target specific fields return `{ fields: { <name>: msg } }`
+from async variants; see the [Async Validation Guide](../guides/async-validation.md).
+:::
+
 ## Async Validation
 
-El Form handles async validation with automatic debouncing:
+El Form runs async validators on change/blur and awaits them on submit, with
+stale-result protection so an in-flight result that arrives after the field value
+has changed is discarded.
+
+Use `onChangeAsync` / `onBlurAsync` / `onSubmitAsync` in `fieldValidators` for
+field-level checks. These return a **string** (error) or **`undefined`** (valid):
 
 ```typescript
-const asyncValidator = async (values: any) => {
-  // Simulate API call
-  await new Promise((resolve) => setTimeout(resolve, 500));
-
-  const errors: Record<string, string> = {};
-
-  if (values.username) {
-    const response = await fetch(
-      `/api/validate-username?username=${values.username}`
-    );
-    const data = await response.json();
-
-    if (data.taken) {
-      errors.username = "Username is already taken";
-    }
-  }
-
-  return {
-    errors: Object.keys(errors).length > 0 ? errors : undefined,
-    isValid: Object.keys(errors).length === 0,
-  };
-};
-
 const form = useForm({
-  validators: { onChangeAsync: asyncValidator },
+  defaultValues: { username: "" },
+  fieldValidators: {
+    username: {
+      onChangeAsync: async ({ value }) => {
+        if (!value) return undefined;
+        const res = await fetch(`/api/validate-username?username=${value}`);
+        const { taken } = await res.json();
+        return taken ? "Username is already taken" : undefined;
+      },
+      onChangeAsyncDebounceMs: 500, // debounce while the user types
+    },
+  },
 });
 ```
+
+For a form-level async submit check, use `validators.onSubmitAsync`. Return
+`{ fields: { <name>: msg } }` to attach per-field errors:
+
+```typescript
+const form = useForm({
+  defaultValues: { email: "" },
+  validators: {
+    onSubmitAsync: async ({ value }) => {
+      const res = await fetch("/api/check-availability", {
+        method: "POST",
+        body: JSON.stringify(value),
+      });
+      const { emailTaken } = await res.json();
+      if (emailTaken) {
+        return { fields: { email: "That email is already registered" } };
+      }
+    },
+  },
+});
+```
+
+**Submission is blocked** while async validators run — `submit()`,
+`handleSubmit`, and `trigger()` all `await` the result and a failing async rule
+prevents the submit handler from being called.
+
+For a deep dive, including `asyncAlways` and per-event debounce options, see the
+[Async Validation Guide](../guides/async-validation.md).
 
 ## Validation State
 

--- a/docs/docs/guides/async-validation.md
+++ b/docs/docs/guides/async-validation.md
@@ -109,6 +109,69 @@ fieldValidators: {
 }
 ```
 
+## Execution order and `asyncAlways`
+
+By default, async validators only run when all **sync** validators for that
+field pass. This avoids a network round-trip while a format error is still on
+screen:
+
+```
+sync validator → passes → async validator runs
+sync validator → fails  → async validator skipped (sync error shown)
+```
+
+Set `asyncAlways: true` on a field validator config to always run async,
+regardless of sync errors:
+
+```typescript
+fieldValidators: {
+  email: {
+    onChange: ({ value }) =>
+      value.includes("@") ? undefined : "Invalid email format",
+    onChangeAsync: async ({ value }) => {
+      const res = await fetch(`/api/check-email?email=${value}`);
+      const { exists } = await res.json();
+      return exists ? "Email already taken" : undefined;
+    },
+    asyncAlways: true, // run async even if sync fails
+    asyncDebounceMs: 500,
+  },
+}
+```
+
+## Async validation and form submission
+
+`submit()`, `handleSubmit`, and `trigger()` **await all async validators** before
+proceeding. A failing async rule blocks the submit handler — the data is never
+passed to `onSubmit` until every async check passes. Change/blur async validation
+is **non-blocking** — the sync error (if any) appears instantly and the async
+result updates the UI when it settles.
+
+## Form-level async submit validation
+
+Use `validators.onSubmitAsync` for async checks that span multiple fields.
+Return `{ fields: { <fieldName>: errorMessage } }` to attach per-field errors,
+or `undefined` to pass:
+
+```typescript
+const form = useForm({
+  defaultValues: { email: "", username: "" },
+  validators: {
+    onSubmitAsync: async ({ value }) => {
+      const res = await fetch("/api/check-availability", {
+        method: "POST",
+        body: JSON.stringify(value),
+      });
+      const { emailTaken, usernameTaken } = await res.json();
+      const fields: Record<string, string> = {};
+      if (emailTaken) fields.email = "Email already registered";
+      if (usernameTaken) fields.username = "Username already taken";
+      if (Object.keys(fields).length) return { fields };
+    },
+  },
+});
+```
+
 ## Combining with schema validation
 
 Async validators run alongside your schema. Use the schema for shape/format and

--- a/docs/superpowers/plans/2026-06-10-async-validation-dispatch.md
+++ b/docs/superpowers/plans/2026-06-10-async-validation-dispatch.md
@@ -1,0 +1,524 @@
+# Fix Async Validation Dispatch — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make el-form's async validators (`onChangeAsync`/`onBlurAsync`/`onSubmitAsync`, field + form level, with `*AsyncDebounceMs`/`asyncDebounceMs`/`asyncAlways`) actually run — they are currently silent no-ops because the hooks layer never dispatches `isAsync: true`.
+
+**Architecture:** Hooks-only. The `el-form-core` engine already runs + debounces async validators when given `isAsync:true`. Add async dispatch in `el-form-react-hooks`: new `validateFieldAsync` / `validateFormAsync` / gate helpers on the validation manager; the `register` onChange/onBlur handlers run a **non-blocking** async pass (sync-first, stale-guarded), and `submit`/`trigger` run a **blocking** async pass.
+
+**Tech Stack:** TypeScript, React 18, Vitest + @testing-library/react. Tests render a `useForm` component and assert via `data-testid` + `fireEvent`/`waitFor` (see `src/__tests__/validation-modes.test.tsx`). One manager unit test constructs `createValidationManager` directly with a real `ValidationEngine`.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-async-validation-dispatch-design.md`
+**Branch:** `fix/async-validation-dispatch` (already created).
+**Run hooks tests:** `pnpm --filter el-form-react-hooks test <pattern>`. (If `Cannot find package 'vitest'` appears, delete a stray untracked `./vitest.config.ts` at the repo root.)
+
+**Async validator shape** (`el-form-core` `ValidatorConfig`): `onChangeAsync?: (ctx: { value, values, fieldName }) => Promise<string | undefined>` (string = error, undefined = ok). Async debounce keys: `onChangeAsyncDebounceMs`, `asyncDebounceMs`. Gate flag: `asyncAlways?: boolean`.
+
+> **Test-coverage trap:** the existing `src/__tests__/asyncValidation.test.tsx` does NOT catch this bug — its key assertion is guarded by `if (lastCall)`, so it passes even when the async validator never runs. New tests must assert the async validator was called **> 0 times unconditionally**.
+
+---
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `packages/el-form-react-hooks/src/utils/validation.ts` | add `validateFieldAsync`, `validateFormAsync`, `hasAsyncValidator`, `shouldRunAsync` to the manager (+ interface) |
+| `packages/el-form-react-hooks/src/useForm.ts` | onChange/onBlur: run the non-blocking async pass (gated, stale-guarded) |
+| `packages/el-form-react-hooks/src/utils/submitOperations.ts` | await async form validation before submit succeeds |
+| `packages/el-form-react-hooks/src/utils/errorManagement.ts` | `trigger` awaits sync + async |
+| docs: `concepts/validation.md`, `guides/async-validation.md`, `changelog.md` | document that async now runs |
+
+---
+
+## Task 1: Validation-manager async methods + gate (unit-tested)
+
+**Files:**
+- Modify: `packages/el-form-react-hooks/src/utils/validation.ts`
+- Test: `packages/el-form-react-hooks/src/__tests__/validateFieldAsync.test.ts` (new)
+
+- [ ] **Step 1: Write the failing unit test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { ValidationEngine } from "el-form-core";
+import { createValidationManager } from "../utils/validation";
+
+function makeManager(opts: Partial<Parameters<typeof createValidationManager>[0]> = {}) {
+  return createValidationManager<{ email: string }>({
+    validationEngine: { current: new ValidationEngine() } as any,
+    validators: {},
+    fieldValidators: {},
+    mode: "onChange",
+    ...(opts as any),
+  });
+}
+
+describe("validateFieldAsync + gate", () => {
+  it("invokes the field's onChangeAsync validator and returns its error", async () => {
+    let calls = 0;
+    const mgr = makeManager({
+      fieldValidators: { email: { onChangeAsync: async () => { calls++; return "taken"; } } },
+    });
+    const r = await mgr.validateFieldAsync("email", "a@b.com", { email: "a@b.com" }, "onChange");
+    expect(calls).toBe(1);
+    expect(r.isValid).toBe(false);
+    expect(r.errors.email).toBe("taken");
+  });
+
+  it("hasAsyncValidator detects field- and form-level async keys", () => {
+    expect(makeManager().hasAsyncValidator("email", "onChange")).toBe(false);
+    expect(
+      makeManager({ fieldValidators: { email: { onChangeAsync: async () => undefined } } })
+        .hasAsyncValidator("email", "onChange")
+    ).toBe(true);
+    expect(
+      makeManager({ validators: { onSubmitAsync: async () => undefined } as any })
+        .hasAsyncValidator("email", "onSubmit")
+    ).toBe(true);
+  });
+
+  it("shouldRunAsync gates on sync-pass unless asyncAlways", () => {
+    const base = { email: { onChangeAsync: async () => undefined } };
+    const mgr = makeManager({ fieldValidators: base });
+    expect(mgr.shouldRunAsync("email", "onChange", true)).toBe(true);   // sync passed
+    expect(mgr.shouldRunAsync("email", "onChange", false)).toBe(false); // sync failed, no asyncAlways
+    const always = makeManager({ fieldValidators: { email: { ...base.email, asyncAlways: true } } });
+    expect(always.shouldRunAsync("email", "onChange", false)).toBe(true); // asyncAlways
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter el-form-react-hooks test validateFieldAsync`
+Expected: FAIL — `validateFieldAsync`/`hasAsyncValidator`/`shouldRunAsync` are not functions.
+
+- [ ] **Step 3: Implement the methods**
+
+In `validation.ts`, before the `return { ... }` of `createValidationManager`, add local helpers; then add the four members to the returned object and to the `ValidationManager` interface.
+
+```ts
+// local helpers (define alongside the others, before `return`)
+const hasAsyncValidator = (
+  fieldName: keyof T,
+  eventType: "onChange" | "onBlur" | "onSubmit"
+): boolean => {
+  const key = `${eventType}Async`;
+  const fc = (fieldValidators as any)[fieldName as any];
+  return !!(fc && fc[key]) || !!(validators && (validators as any)[key]);
+};
+const asyncAlwaysFor = (fieldName: keyof T): boolean => {
+  const fc = (fieldValidators as any)[fieldName as any];
+  return !!(fc && fc.asyncAlways) || !!(validators && (validators as any).asyncAlways);
+};
+```
+
+Returned-object additions (mirror the existing sync `validateField`/`validateForm`, but build `isAsync: true` events so the engine resolves the `${type}Async` key):
+
+```ts
+    hasAsyncValidator,
+    shouldRunAsync: (fieldName, eventType, syncPassed) =>
+      hasAsyncValidator(fieldName, eventType) && (syncPassed || asyncAlwaysFor(fieldName)),
+
+    validateFieldAsync: async (fieldName, fieldValue, formValues, eventType) => {
+      const fieldKey = String(fieldName);
+      const fieldConfig = (fieldValidators as any)[fieldKey];
+      const event: ValidatorEvent = { type: eventType, isAsync: true, fieldName: fieldKey };
+      let result: { isValid: boolean; errors: Record<string, string> } = { isValid: true, errors: {} };
+      if (fieldConfig) {
+        result = await validationEngine.current.validateField(fieldKey, fieldValue, formValues, fieldConfig, event);
+      }
+      if (result.isValid && validators) {
+        const formResult = await validationEngine.current.validateForm(formValues, validators, event);
+        if (!formResult.isValid && formResult.errors[fieldKey]) {
+          result = { isValid: false, errors: { [fieldKey]: formResult.errors[fieldKey] } };
+        }
+      }
+      return result;
+    },
+
+    validateFormAsync: async (values, eventType = "onSubmit") => {
+      const ASYNC_KEYS = ["onChangeAsync", "onBlurAsync", "onSubmitAsync"] as const;
+      const allErrors: Record<string, string> = {};
+      let isValid = true;
+      const runKeys = (cfg: ValidatorConfig | undefined) =>
+        eventType === "onSubmit"
+          ? (ASYNC_KEYS.filter((k) => cfg && typeof (cfg as any)[k] !== "undefined") as string[])
+              .map((k) => k.replace(/Async$/, ""))
+          : [eventType];
+      for (const [fieldName, fieldConfig] of Object.entries(fieldValidators)) {
+        for (const type of runKeys(fieldConfig as ValidatorConfig)) {
+          if (!(fieldConfig as any)[`${type}Async`]) continue;
+          const event: ValidatorEvent = { type: type as any, isAsync: true };
+          const r = await validationEngine.current.validateField(
+            fieldName, values[fieldName as keyof T], values, fieldConfig as ValidatorConfig, event
+          );
+          if (!r.isValid) { isValid = false; Object.assign(allErrors, r.errors); }
+        }
+      }
+      if (validators) {
+        for (const type of runKeys(validators)) {
+          if (!(validators as any)[`${type}Async`]) continue;
+          const event: ValidatorEvent = { type: type as any, isAsync: true };
+          const r = await validationEngine.current.validateForm(values, validators, event);
+          if (!r.isValid) { isValid = false; Object.assign(allErrors, r.errors); }
+        }
+      }
+      return { isValid, errors: allErrors as Record<keyof T, string> };
+    },
+```
+
+Add the matching signatures to the `ValidationManager<T>` interface.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm --filter el-form-react-hooks test validateFieldAsync`
+Expected: PASS (3/3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/el-form-react-hooks/src/utils/validation.ts packages/el-form-react-hooks/src/__tests__/validateFieldAsync.test.ts
+git commit -m "feat(hooks): validateFieldAsync + async gate on the validation manager"
+```
+
+---
+
+## Task 2: onChange/onBlur run the async pass (the headline fix)
+
+**Files:**
+- Modify: `packages/el-form-react-hooks/src/useForm.ts`
+- Test: `packages/el-form-react-hooks/src/__tests__/asyncDispatch.test.tsx` (new)
+
+- [ ] **Step 1: Write the failing repro test**
+
+```tsx
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+let calls = 0;
+function Demo() {
+  const { register, formState } = useForm<{ email: string }>({
+    defaultValues: { email: "" },
+    validateOn: "onChange",
+    fieldValidators: {
+      email: { onChangeAsync: async () => { calls++; return "Already taken"; } },
+    },
+  });
+  return (
+    <div>
+      <input aria-label="email" {...register("email")} />
+      <span data-testid="err">{formState.errors.email ?? ""}</span>
+    </div>
+  );
+}
+
+function BlurDemo() {
+  const { register, formState } = useForm<{ email: string }>({
+    defaultValues: { email: "" },
+    validateOn: "onBlur",
+    fieldValidators: { email: { onBlurAsync: async () => { calls++; return "Already taken"; } } },
+  });
+  return (<div><input aria-label="email" {...register("email")} /><span data-testid="err">{formState.errors.email ?? ""}</span></div>);
+}
+
+describe("async dispatch", () => {
+  it("runs onChangeAsync and surfaces its error", async () => {
+    calls = 0;
+    render(<Demo />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "a@b.com" } });
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Already taken"));
+    expect(calls).toBeGreaterThan(0); // UNGUARDED — the bug made this 0
+  });
+
+  it("runs onBlurAsync on blur (mirrored wiring)", async () => {
+    calls = 0;
+    render(<BlurDemo />);
+    const input = screen.getByLabelText("email");
+    fireEvent.change(input, { target: { value: "a@b.com" } });
+    fireEvent.blur(input);
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Already taken"));
+    expect(calls).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter el-form-react-hooks test asyncDispatch`
+Expected: FAIL — error never appears and `calls` stays 0 (async never dispatched).
+
+- [ ] **Step 3: Wire the non-blocking async pass into the onChange handler**
+
+In `useForm.ts`, the onChange handler has `if (shouldValidateResult) { const result = await validationManager.validateField(...); setFormState(...merge sync errors...); }`. Insert the async pass **inside that block, immediately after the sync `setFormState`** — so `result` is in scope (no hoist needed) and async timing follows the same `mode`/`validateOn` as sync:
+
+```ts
+// inside `if (shouldValidateResult)`, right after the sync setFormState:
+// Non-blocking async validation pass (sync-first; engine handles debounce).
+if (validationManager.shouldRunAsync(fieldName, "onChange", result.isValid)) {
+  const syncPassed = result.isValid; // capture: was there a sync error for this field?
+  const latestValues = name.includes(".")
+    ? setNestedValue(formStateRef.current?.values ?? {}, name, value)
+    : { ...(formStateRef.current?.values ?? {}), [name]: value };
+  void validationManager
+    .validateFieldAsync(fieldName, value, latestValues, "onChange")
+    .then((asyncResult) => {
+      // stale guard: drop the result if the field changed since
+      if (getNestedValue(formStateRef.current?.values ?? {}, name) !== value) return;
+      setFormState((prev) => {
+        // Clear the keys this async pass OWNS (only when sync passed — otherwise a
+        // legitimate sync error must survive, e.g. under asyncAlways), then re-apply
+        // the async result — so an async error CLEARS when the field becomes async-valid.
+        const newErrors: any = { ...prev.errors };
+        if (syncPassed) { delete newErrors[fieldName]; delete newErrors.form; }
+        Object.assign(newErrors, asyncResult.errors);
+        const isValid = Object.values(newErrors).every((e) => !e);
+        return { ...prev, errors: newErrors, isValid };
+      });
+    });
+}
+```
+(`shouldRunAsync` already includes the `hasAsyncValidator` check, so no separate guard is needed. The clear is gated on `syncPassed` so that under `asyncAlways` — which can run async even when sync failed — a legitimate sync error is preserved; the stale guard ensures the value is unchanged.)
+
+Apply the **same pattern** inside the onBlur handler's `if (validationManager.shouldValidate("onBlur"))` block (use `"onBlur"`, the onBlur `result.isValid`, and `currentState.values[fieldName]` as the value where the onBlur handler reads it).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm --filter el-form-react-hooks test asyncDispatch`
+Expected: PASS.
+
+- [ ] **Step 5: Full suite + commit**
+
+Run: `pnpm --filter el-form-react-hooks test` → all pass.
+```bash
+git add packages/el-form-react-hooks/src/useForm.ts packages/el-form-react-hooks/src/__tests__/asyncDispatch.test.tsx
+git commit -m "feat(hooks): run async validators on change/blur (non-blocking, sync-first)"
+```
+
+---
+
+## Task 3: Sync-first gating, asyncAlways, and the stale guard
+
+**Files:**
+- Modify: (none beyond Task 2 — these behaviors are already wired; this task adds the tests and any fixes)
+- Test: append to `asyncDispatch.test.tsx`
+
+- [ ] **Step 1: Write the tests**
+
+```tsx
+import { z } from "zod";
+// 1) sync-first gating: invalid format -> sync error, async NOT called
+function GateDemo({ asyncAlways = false }: { asyncAlways?: boolean }) {
+  const { register, formState } = useForm<{ email: string }>({
+    defaultValues: { email: "" },
+    validateOn: "onChange",
+    fieldValidators: {
+      email: {
+        onChange: (v: string) => (v.includes("@") ? undefined : "Invalid"),
+        onChangeAsync: async () => { calls++; return "Taken"; },
+        asyncAlways,
+      },
+    },
+  });
+  return (<div><input aria-label="email" {...register("email")} /><span data-testid="err">{formState.errors.email ?? ""}</span></div>);
+}
+
+it("does not run async when sync fails (no asyncAlways)", async () => {
+  calls = 0;
+  render(<GateDemo />);
+  fireEvent.change(screen.getByLabelText("email"), { target: { value: "bad" } });
+  await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid"));
+  await new Promise((r) => setTimeout(r, 50));
+  expect(calls).toBe(0);
+});
+
+it("runs async despite sync failure when asyncAlways", async () => {
+  calls = 0;
+  render(<GateDemo asyncAlways />);
+  fireEvent.change(screen.getByLabelText("email"), { target: { value: "bad" } });
+  await waitFor(() => expect(calls).toBeGreaterThan(0));
+});
+
+it("discards a stale async result when the value changed", async () => {
+  // async validator echoes which value it saw, after a tick
+  function StaleDemo() {
+    const { register, formState } = useForm<{ email: string }>({
+      defaultValues: { email: "" },
+      validateOn: "onChange",
+      fieldValidators: {
+        email: { onChangeAsync: async ({ value }: any) => { await new Promise((r) => setTimeout(r, 30)); return `err:${value}`; } },
+      },
+    });
+    return (<div><input aria-label="email" {...register("email")} /><span data-testid="err">{formState.errors.email ?? ""}</span></div>);
+  }
+  render(<StaleDemo />);
+  const input = screen.getByLabelText("email");
+  fireEvent.change(input, { target: { value: "A" } });
+  fireEvent.change(input, { target: { value: "B" } });
+  await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("err:B"));
+  // the stale "err:A" must never have been applied
+  expect(screen.getByTestId("err").textContent).not.toBe("err:A");
+});
+
+it("clears the async error when the field becomes async-valid", async () => {
+  function ClearDemo() {
+    const { register, formState } = useForm<{ email: string }>({
+      defaultValues: { email: "" },
+      validateOn: "onChange",
+      fieldValidators: {
+        email: { onChangeAsync: async ({ value }: any) => (value === "taken@x.com" ? "Taken" : undefined) },
+      },
+    });
+    return (<div><input aria-label="email" {...register("email")} /><span data-testid="err">{formState.errors.email ?? ""}</span></div>);
+  }
+  render(<ClearDemo />);
+  const input = screen.getByLabelText("email");
+  fireEvent.change(input, { target: { value: "taken@x.com" } });
+  await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Taken"));
+  fireEvent.change(input, { target: { value: "free@x.com" } });
+  await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("")); // async-valid -> error cleared
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `pnpm --filter el-form-react-hooks test asyncDispatch`
+Expected: the gating + asyncAlways tests pass from Task 2's wiring; the stale-guard test passes because of the value re-check. If the stale test fails, the guard in Task 2 Step 3 needs the `getNestedValue(...) !== value` check (verify it's applied on both onChange and onBlur).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/el-form-react-hooks/src/__tests__/asyncDispatch.test.tsx packages/el-form-react-hooks/src/useForm.ts
+git commit -m "test(hooks): async sync-first gating, asyncAlways, stale-result guard"
+```
+
+---
+
+## Task 4: Blocking async on submit and trigger
+
+**Files:**
+- Modify: `packages/el-form-react-hooks/src/utils/submitOperations.ts`, `packages/el-form-react-hooks/src/utils/errorManagement.ts`
+- Test: `packages/el-form-react-hooks/src/__tests__/asyncSubmit.test.tsx` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+it("onSubmitAsync blocks submission when it fails", async () => {
+  let submitted = false;
+  function Demo() {
+    const { register, handleSubmit, formState } = useForm<{ email: string }>({
+      defaultValues: { email: "a@b.com" },
+      // Form-level async error shape: the engine maps `result.fields` to field errors
+      // (FormLevelValidator). A bare string lands under errors.form instead.
+      validators: { onSubmitAsync: async () => ({ fields: { email: "Taken" } }) } as any,
+      onSubmit: () => { submitted = true; },
+    });
+    return (
+      <form onSubmit={handleSubmit(() => { submitted = true; })}>
+        <input aria-label="email" {...register("email")} />
+        <button type="submit">Submit</button>
+        <span data-testid="err">{(formState.errors as any).email ?? ""}</span>
+      </form>
+    );
+  }
+  render(<Demo />);
+  fireEvent.click(screen.getByText("Submit"));
+  await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Taken"));
+  expect(submitted).toBe(false);
+});
+```
+
+> RESOLVED shape: form-level async validators are `FormLevelValidator` — return `{ fields: { <field>: "<error>" } }` to set per-field errors (the engine's `executeFormAsyncValidation` only maps `result.fields`). A bare string return lands under `errors.form`. Use `{ fields: { email: "Taken" } }` as above.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter el-form-react-hooks test asyncSubmit`
+Expected: FAIL — `submitted` is `true` (async ignored, submit succeeds) and no error shows.
+
+- [ ] **Step 3: Await async in submit + trigger**
+
+In `submitOperations.ts`, each of `handleSubmit` / `submit` / `submitAsync` does `const { isValid, errors } = await validationManager.validateForm(formState.values)`. After it, if still valid, run the blocking async pass and merge:
+```ts
+let finalValid = isValid;
+let finalErrors = errors;
+if (finalValid) {
+  const asyncResult = await validationManager.validateFormAsync(formState.values, "onSubmit");
+  if (!asyncResult.isValid) { finalValid = false; finalErrors = { ...finalErrors, ...asyncResult.errors }; }
+}
+// use finalValid / finalErrors for the setFormState + the isValid branch that calls onSubmit
+```
+**Important:** restructure so the existing error-writing `setFormState` (including its `touched` derivation that marks errored fields touched) runs **after** the async pass using `finalErrors`/`finalValid` — don't leave the sync `setFormState` in place and write async errors in a second, separate update (that would lose the `touched` marking for async-only errors).
+In `errorManagement.ts` `trigger` (it has three branches — no-arg, array, single-field), after the existing sync validation in each, await the matching async pass and merge into the written errors before resolving: **no-arg** → `validateFormAsync(values, "onSubmit")`; **array `trigger(['a','b'])`** → `validateFieldAsync` per field (mirror the per-field sync loop); **single-field** → `validateFieldAsync` for that field.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm --filter el-form-react-hooks test asyncSubmit`
+Expected: PASS.
+
+- [ ] **Step 5: Full suite + commit**
+
+Run: `pnpm --filter el-form-react-hooks test` → all pass.
+```bash
+git add packages/el-form-react-hooks/src/utils/submitOperations.ts packages/el-form-react-hooks/src/utils/errorManagement.ts packages/el-form-react-hooks/src/__tests__/asyncSubmit.test.tsx
+git commit -m "feat(hooks): block submit/trigger on async validation"
+```
+
+---
+
+## Task 5: Docs + changeset + verification
+
+**Files:**
+- Modify: `docs/docs/concepts/validation.md`, `docs/docs/guides/async-validation.md`, `docs/docs/changelog.md`
+- Create: `.changeset/async-validation-dispatch.md`
+
+- [ ] **Step 1: Docs**
+
+Update `guides/async-validation.md` + `concepts/validation.md` so the async examples reflect reality (async validators now run on change/blur and block submit; `asyncAlways`; `*AsyncDebounceMs`). Fix any example that implied async already worked.
+
+- [ ] **Step 2: Changeset (patch, prominent note)**
+
+Create `.changeset/async-validation-dispatch.md`:
+```md
+---
+"el-form-react-hooks": patch
+---
+
+Fix: async validators now actually run. Previously `onChangeAsync` / `onBlurAsync` /
+`onSubmitAsync` (field- and form-level), `asyncDebounceMs` / `*AsyncDebounceMs`, and
+`asyncAlways` were silent no-ops — the hooks layer never dispatched an async validation
+event. They now run: sync validation first (instant), then the async validator (only if
+sync passes, unless `asyncAlways`), debounced, with stale-result protection on change/blur;
+`submit()` / `handleSubmit` / `trigger()` await async validation and a failing async rule
+blocks submission. **Behavior change:** forms that configured async validators will now
+surface async errors and can gate submit where they previously passed silently.
+```
+
+- [ ] **Step 3: Build docs + commit**
+
+Run: `pnpm --filter el-form-docs build` → SUCCESS.
+```bash
+git add docs .changeset/async-validation-dispatch.md
+git commit -m "docs: async validators now run (changelog + guides)"
+```
+
+---
+
+## Task 6: Full verification
+
+- [ ] `pnpm --filter el-form-react-hooks test` — all pass (incl. the new async tests).
+- [ ] `pnpm --filter el-form-react-hooks lint` — clean.
+- [ ] `pnpm build:packages` — builds.
+- [ ] `pnpm --filter el-form-docs build` — clean.
+
+## Out of scope (per spec)
+
+`isValidating` (the next slice — resumes the full P2b + P9); no `el-form-core` changes; no new public option names.

--- a/docs/superpowers/specs/2026-06-10-async-validation-dispatch-design.md
+++ b/docs/superpowers/specs/2026-06-10-async-validation-dispatch-design.md
@@ -1,0 +1,123 @@
+# Fix async validation dispatch — design (2026-06-10)
+
+Make el-form's async validators actually run. They are currently dead at the hooks layer.
+
+## The bug (root cause, verified)
+
+`el-form-react-hooks` never dispatches an async validation event, so `onChangeAsync` /
+`onBlurAsync` / `onSubmitAsync` (field- and form-level) and `*AsyncDebounceMs` / `asyncDebounceMs`
+are silent no-ops. In `packages/el-form-react-hooks/src/utils/validation.ts`, `validateField`
+(line ~95) and the two form-level paths (~192, ~217) build the engine event with
+**`isAsync: false`** — there is no `isAsync: true` anywhere in `el-form-react-hooks/src`. The core
+engine resolves the validator key as `event.isAsync ? "${type}Async" : "${type}"`
+(`el-form-core/src/validators/engine.ts` ~53/~83), so with `isAsync:false` it looks up the **sync**
+key, finds no sync validator, and returns `{ isValid: true }` — the user's `*Async` function is
+never called. Direct probe: `fieldValidators.email.onChangeAsync` + `validateOn: "onChange"` →
+`onChangeAsync calls: 0`. (Discovered during the P2b/P9 plan review — see
+[[async-validation-broken-bug]].)
+
+**The engine is whole.** It already implements `validateAsync` with async debounce
+(`${type}AsyncDebounceMs` / `asyncDebounceMs`), and the superseded-promise hang is already fixed.
+The fix is hooks-only — `el-form-core` is untouched.
+
+## Decisions (locked with the user)
+
+- **Sync first, async only if sync passes** — by default. `ValidatorConfig` already has an
+  `asyncAlways?: boolean` flag (currently dead like the rest of async); honor it: when
+  `asyncAlways: true` on the relevant config, run the async pass even if the sync pass failed. This
+  makes the existing public option actually work and is the opt-out for "always run both".
+- **onChange/onBlur async is non-blocking**, **submit/trigger async is blocking** (see below).
+- **Patch** bump for `el-form-react-hooks`, with a prominent changelog note (a previously-silent
+  feature now runs; forms with `*Async` validators will start surfacing async errors and gating
+  submit).
+
+## Architecture (hooks-only)
+
+### Unit A — `validation.ts`: async dispatch surface
+- Keep `validateField(field, value, values, eventType)` as the **sync** pass (unchanged — builds the
+  `isAsync:false` event, runs field-sync then form-sync).
+- Add `validateFieldAsync(field, value, values, eventType)` — builds the `isAsync:true` event and
+  runs `engine.validateField` (field async) then, if that passes, `engine.validateForm` (form
+  async); returns the merged async result. Debounce is handled by the engine.
+- Add `hasAsyncValidator(field, eventType): boolean` — true if `fieldValidators[field]` or the
+  form-level `validators` has a `${eventType}Async` key. Used to gate whether an async pass is worth
+  starting.
+
+### Unit B — `useForm.ts`: onChange / onBlur orchestration (non-blocking)
+In the `register` onChange and onBlur handlers, after the existing sync `validateField` +
+`setFormState`:
+```text
+// gate: sync passed (or asyncAlways) AND an async validator exists for this event
+if ((syncResult.isValid || hasAsyncAlways(field)) && validationManager.hasAsyncValidator(field, eventType)) {
+  validationManager.validateFieldAsync(field, value, latestValues, eventType).then((asyncResult) => {
+    // stale guard: only apply if the field value hasn't changed since
+    if (getNestedValue(formStateRef.current.values, name) !== value) return;
+    if (!asyncResult.isValid) setFormState((prev) => ({ ...prev, errors: { ...prev.errors, ...asyncResult.errors }, isValid: false }));
+  });
+}
+```
+The async pass does **not** block the synchronous handler — the sync error (or clear) is applied
+immediately; the async error layers in when it settles.
+
+### Unit C — submit / trigger (blocking)
+- `submitOperations.ts` (`handleSubmit` / `submit` / `submitAsync`): after sync `validateForm`
+  passes, **await** an async form-validation pass (`onSubmitAsync`); if it fails, treat the form as
+  invalid (don't call `onSubmit` / don't report success). Submit must not succeed while an async
+  rule fails.
+- `errorManagement.ts` `trigger`: `trigger()` is "validate now" — it should **await** both sync and
+  async validation and write the combined errors. Blocking; no staleness (the user asked for the
+  result).
+
+### Stale-result guard
+Only the non-blocking onChange/onBlur path needs it: when the async result resolves, re-read the
+field's current value from `formStateRef.current.values`; if it no longer equals the validated
+value, discard the result. (The engine's debounce collapses rapid keystrokes; this guards the
+post-debounce server-latency window.) Submit/trigger await inline, so no staleness there.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `el-form-react-hooks/src/utils/validation.ts` | add `validateFieldAsync` + `hasAsyncValidator`; keep `validateField` sync |
+| `el-form-react-hooks/src/useForm.ts` | onChange/onBlur: run async pass (gated, non-blocking, stale-guarded) |
+| `el-form-react-hooks/src/utils/submitOperations.ts` | await async form validation before submit succeeds |
+| `el-form-react-hooks/src/utils/errorManagement.ts` | `trigger` awaits sync + async |
+| docs: `concepts/validation.md`, `guides/async-validation.md`, `changelog.md` | document that async validators run; fix any stale async-validation examples |
+
+## Testing (TDD, in `el-form-react-hooks`)
+
+> **Note for the plan:** the existing `src/__tests__/asyncValidation.test.tsx` gives FALSE
+> confidence — its key assertion is guarded by `if (lastCall)`, so it passes even when the async
+> validator never runs. The repro test below must assert the validator was called **>0 times
+> unconditionally** (do not guard it). Add the new tests here (or a new file) accordingly.
+
+- **The repro:** a field with `onChangeAsync` returning an error → typing surfaces it (the exact
+  probe that returned `0 calls` now invokes the validator — assert call count > 0 unconditionally —
+  and shows the error after a tick).
+- **asyncAlways:** a field with a failing sync `onChange` + an `onChangeAsync` and `asyncAlways: true`
+  → the async validator still runs despite the sync failure; without `asyncAlways` it does not.
+- **Sync-first gating:** field with `onChange` (format) + `onChangeAsync` (uniqueness): an invalid
+  format shows the sync error and the async validator is **not** called; a valid format → async is
+  called and its error shows.
+- **Stale guard:** type "a@b.com" (async pending), then change to "c@d.com" before it resolves →
+  the first async result is discarded (no error for the stale value).
+- **Debounce:** with `onChangeAsyncDebounceMs`, rapid typing fires the async validator once.
+- **Submit blocking:** `validators: { onSubmitAsync }` that fails → `submit()`/`handleSubmit`
+  does not call `onSubmit` and reports invalid; passes → submits.
+- **trigger:** `trigger()` resolves after async runs and reflects async errors.
+- **No regression:** existing sync-only validation behaves exactly as before.
+
+## Non-goals / deferred
+
+- **`isValidating`** — the next slice (resumes the full P2b + P9). This fix builds the async flow
+  `isValidating` will hook into, but does not add the flag.
+- No `el-form-core` engine changes (it already works).
+- No new public option names (uses the existing `*Async` / `*AsyncDebounceMs` config).
+
+## Risks
+
+- **Behavior change** — forms that configured async validators (and silently passed) will now
+  validate async and can block submit. This is the intended fix; called out loudly in the changelog.
+- **Stale async results** — mitigated by the value re-check guard on the non-blocking path.
+- **submit/trigger now await async** — slightly slower submit when async rules exist; correct and
+  expected.

--- a/docs/superpowers/specs/2026-06-10-async-validation-dispatch-design.md
+++ b/docs/superpowers/specs/2026-06-10-async-validation-dispatch-design.md
@@ -52,7 +52,14 @@ if ((syncResult.isValid || hasAsyncAlways(field)) && validationManager.hasAsyncV
   validationManager.validateFieldAsync(field, value, latestValues, eventType).then((asyncResult) => {
     // stale guard: only apply if the field value hasn't changed since
     if (getNestedValue(formStateRef.current.values, name) !== value) return;
-    if (!asyncResult.isValid) setFormState((prev) => ({ ...prev, errors: { ...prev.errors, ...asyncResult.errors }, isValid: false }));
+    // clear this async pass's owned errors (field + form), re-apply the result,
+    // recompute validity — so an async error CLEARS when the field becomes async-valid:
+    setFormState((prev) => {
+      const errors: any = { ...prev.errors };
+      if (syncResult.isValid) { delete errors[field]; delete errors.form; } // only clear what async owns (preserve sync error under asyncAlways)
+      Object.assign(errors, asyncResult.errors);
+      return { ...prev, errors, isValid: Object.values(errors).every((e) => !e) };
+    });
   });
 }
 ```

--- a/packages/el-form-react-hooks/src/__tests__/asyncDispatch.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/asyncDispatch.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+let calls = 0;
+function Demo() {
+  const { register, formState } = useForm<{ email: string }>({
+    defaultValues: { email: "" },
+    validateOn: "onChange",
+    fieldValidators: {
+      email: { onChangeAsync: async () => { calls++; return "Already taken"; } },
+    },
+  });
+  return (
+    <div>
+      <input aria-label="email" {...register("email")} />
+      <span data-testid="err">{formState.errors.email ?? ""}</span>
+    </div>
+  );
+}
+
+function BlurDemo() {
+  const { register, formState } = useForm<{ email: string }>({
+    defaultValues: { email: "" },
+    validateOn: "onBlur",
+    fieldValidators: { email: { onBlurAsync: async () => { calls++; return "Already taken"; } } },
+  });
+  return (<div><input aria-label="email" {...register("email")} /><span data-testid="err">{formState.errors.email ?? ""}</span></div>);
+}
+
+describe("async dispatch", () => {
+  it("runs onChangeAsync and surfaces its error", async () => {
+    calls = 0;
+    render(<Demo />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "a@b.com" } });
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Already taken"));
+    expect(calls).toBeGreaterThan(0); // UNGUARDED — the bug made this 0
+  });
+
+  it("runs onBlurAsync on blur (mirrored wiring)", async () => {
+    calls = 0;
+    render(<BlurDemo />);
+    const input = screen.getByLabelText("email");
+    fireEvent.change(input, { target: { value: "a@b.com" } });
+    fireEvent.blur(input);
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Already taken"));
+    expect(calls).toBeGreaterThan(0);
+  });
+});

--- a/packages/el-form-react-hooks/src/__tests__/asyncDispatch.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/asyncDispatch.test.tsx
@@ -30,6 +30,21 @@ function BlurDemo() {
   return (<div><input aria-label="email" {...register("email")} /><span data-testid="err">{formState.errors.email ?? ""}</span></div>);
 }
 
+function GateDemo({ asyncAlways = false }: { asyncAlways?: boolean }) {
+  const { register, formState } = useForm<{ email: string }>({
+    defaultValues: { email: "" },
+    validateOn: "onChange",
+    fieldValidators: {
+      email: {
+        onChange: ({ value: v }: { value: string; values: any; fieldName: string }) => (v.includes("@") ? undefined : "Invalid"),
+        onChangeAsync: async () => { calls++; return "Taken"; },
+        asyncAlways,
+      },
+    },
+  });
+  return (<div><input aria-label="email" {...register("email")} /><span data-testid="err">{formState.errors.email ?? ""}</span></div>);
+}
+
 describe("async dispatch", () => {
   it("runs onChangeAsync and surfaces its error", async () => {
     calls = 0;
@@ -47,5 +62,61 @@ describe("async dispatch", () => {
     fireEvent.blur(input);
     await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Already taken"));
     expect(calls).toBeGreaterThan(0);
+  });
+
+  it("does not run async when sync fails (no asyncAlways)", async () => {
+    calls = 0;
+    render(<GateDemo />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "bad" } });
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid"));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(calls).toBe(0);
+  });
+
+  it("runs async despite sync failure when asyncAlways", async () => {
+    calls = 0;
+    render(<GateDemo asyncAlways />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "bad" } });
+    await waitFor(() => expect(calls).toBeGreaterThan(0));
+  });
+
+  it("discards a stale async result when the value changed", async () => {
+    // async validator echoes which value it saw, after a tick
+    function StaleDemo() {
+      const { register, formState } = useForm<{ email: string }>({
+        defaultValues: { email: "" },
+        validateOn: "onChange",
+        fieldValidators: {
+          email: { onChangeAsync: async ({ value }: any) => { await new Promise((r) => setTimeout(r, 30)); return `err:${value}`; } },
+        },
+      });
+      return (<div><input aria-label="email" {...register("email")} /><span data-testid="err">{formState.errors.email ?? ""}</span></div>);
+    }
+    render(<StaleDemo />);
+    const input = screen.getByLabelText("email");
+    fireEvent.change(input, { target: { value: "A" } });
+    fireEvent.change(input, { target: { value: "B" } });
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("err:B"));
+    // the stale "err:A" must never have been applied
+    expect(screen.getByTestId("err").textContent).not.toBe("err:A");
+  });
+
+  it("clears the async error when the field becomes async-valid", async () => {
+    function ClearDemo() {
+      const { register, formState } = useForm<{ email: string }>({
+        defaultValues: { email: "" },
+        validateOn: "onChange",
+        fieldValidators: {
+          email: { onChangeAsync: async ({ value }: any) => (value === "taken@x.com" ? "Taken" : undefined) },
+        },
+      });
+      return (<div><input aria-label="email" {...register("email")} /><span data-testid="err">{formState.errors.email ?? ""}</span></div>);
+    }
+    render(<ClearDemo />);
+    const input = screen.getByLabelText("email");
+    fireEvent.change(input, { target: { value: "taken@x.com" } });
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Taken"));
+    fireEvent.change(input, { target: { value: "free@x.com" } });
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("")); // async-valid -> error cleared
   });
 });

--- a/packages/el-form-react-hooks/src/__tests__/asyncSubmit.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/asyncSubmit.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+it("onSubmitAsync blocks submission when it fails", async () => {
+  let submitted = false;
+  function Demo() {
+    const { register, handleSubmit, formState } = useForm<{ email: string }>({
+      defaultValues: { email: "a@b.com" },
+      // Form-level async error shape: the engine maps `result.fields` to field errors
+      // (FormLevelValidator). A bare string lands under errors.form instead.
+      validators: { onSubmitAsync: async () => ({ fields: { email: "Taken" } }) } as any,
+      onSubmit: () => { submitted = true; },
+    });
+    return (
+      <form onSubmit={handleSubmit(() => { submitted = true; })}>
+        <input aria-label="email" {...register("email")} />
+        <button type="submit">Submit</button>
+        <span data-testid="err">{(formState.errors as any).email ?? ""}</span>
+      </form>
+    );
+  }
+  render(<Demo />);
+  fireEvent.click(screen.getByText("Submit"));
+  await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Taken"));
+  expect(submitted).toBe(false);
+});

--- a/packages/el-form-react-hooks/src/__tests__/asyncSubmit.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/asyncSubmit.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { it, expect, beforeEach } from "vitest";
 import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
 import { useForm } from "..";
 

--- a/packages/el-form-react-hooks/src/__tests__/asyncSubmit.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/asyncSubmit.test.tsx
@@ -27,3 +27,53 @@ it("onSubmitAsync blocks submission when it fails", async () => {
   await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Taken"));
   expect(submitted).toBe(false);
 });
+
+it("trigger('email') runs the field's onChangeAsync and surfaces its error", async () => {
+  function Demo() {
+    const form = useForm<{ email: string }>({
+      defaultValues: { email: "test@example.com" },
+      fieldValidators: {
+        email: { onChangeAsync: async () => "Taken" },
+      } as any,
+    });
+    return (
+      <div>
+        <input aria-label="email" {...form.register("email")} />
+        <button
+          type="button"
+          onClick={async () => { await form.trigger("email"); }}
+        >
+          Trigger
+        </button>
+        <span data-testid="err">{(form.formState.errors as any).email ?? ""}</span>
+      </div>
+    );
+  }
+  render(<Demo />);
+  fireEvent.click(screen.getByText("Trigger"));
+  await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Taken"));
+});
+
+it("async passes — submit succeeds when onSubmitAsync returns no errors", async () => {
+  let submitted = false;
+  function Demo() {
+    const { register, handleSubmit, formState } = useForm<{ email: string }>({
+      defaultValues: { email: "ok@example.com" },
+      // Returning undefined/null means "no error" — the engine treats { fields: {} } as invalid
+      // (empty-object is truthy), so we explicitly return undefined for a clean pass.
+      validators: { onSubmitAsync: async () => undefined } as any,
+      onSubmit: () => { submitted = true; },
+    });
+    return (
+      <form onSubmit={handleSubmit(() => { submitted = true; })}>
+        <input aria-label="email" {...register("email")} />
+        <button type="submit">Submit</button>
+        <span data-testid="err">{(formState.errors as any).email ?? ""}</span>
+      </form>
+    );
+  }
+  render(<Demo />);
+  fireEvent.click(screen.getByText("Submit"));
+  await waitFor(() => expect(submitted).toBe(true));
+  expect(screen.getByTestId("err").textContent).toBe("");
+});

--- a/packages/el-form-react-hooks/src/__tests__/validateFieldAsync.test.ts
+++ b/packages/el-form-react-hooks/src/__tests__/validateFieldAsync.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { ValidationEngine } from "el-form-core";
+import { createValidationManager } from "../utils/validation";
+
+function makeManager(opts: Partial<Parameters<typeof createValidationManager>[0]> = {}) {
+  return createValidationManager<{ email: string }>({
+    validationEngine: { current: new ValidationEngine() } as any,
+    validators: {},
+    fieldValidators: {},
+    mode: "onChange",
+    ...(opts as any),
+  });
+}
+
+describe("validateFieldAsync + gate", () => {
+  it("invokes the field's onChangeAsync validator and returns its error", async () => {
+    let calls = 0;
+    const mgr = makeManager({
+      fieldValidators: { email: { onChangeAsync: async () => { calls++; return "taken"; } } },
+    });
+    const r = await mgr.validateFieldAsync("email", "a@b.com", { email: "a@b.com" }, "onChange");
+    expect(calls).toBe(1);
+    expect(r.isValid).toBe(false);
+    expect(r.errors.email).toBe("taken");
+  });
+
+  it("hasAsyncValidator detects field- and form-level async keys", () => {
+    expect(makeManager().hasAsyncValidator("email", "onChange")).toBe(false);
+    expect(
+      makeManager({ fieldValidators: { email: { onChangeAsync: async () => undefined } } })
+        .hasAsyncValidator("email", "onChange")
+    ).toBe(true);
+    expect(
+      makeManager({ validators: { onSubmitAsync: async () => undefined } as any })
+        .hasAsyncValidator("email", "onSubmit")
+    ).toBe(true);
+  });
+
+  it("shouldRunAsync gates on sync-pass unless asyncAlways", () => {
+    const base = { email: { onChangeAsync: async () => undefined } };
+    const mgr = makeManager({ fieldValidators: base });
+    expect(mgr.shouldRunAsync("email", "onChange", true)).toBe(true);   // sync passed
+    expect(mgr.shouldRunAsync("email", "onChange", false)).toBe(false); // sync failed, no asyncAlways
+    const always = makeManager({ fieldValidators: { email: { ...base.email, asyncAlways: true } } });
+    expect(always.shouldRunAsync("email", "onChange", false)).toBe(true); // asyncAlways
+  });
+});

--- a/packages/el-form-react-hooks/src/useForm.ts
+++ b/packages/el-form-react-hooks/src/useForm.ts
@@ -371,6 +371,27 @@ export function useForm<T extends Record<string, any>>(
                 isValid: isFormValid,
               };
             });
+
+            // Non-blocking async validation pass (sync-first; engine handles debounce).
+            if (validationManager.shouldRunAsync(fieldName, "onChange", result.isValid)) {
+              const syncPassed = result.isValid;
+              const latestValues = name.includes(".")
+                ? setNestedValue(formStateRef.current?.values ?? {}, name, value)
+                : { ...(formStateRef.current?.values ?? {}), [name]: value };
+              void validationManager
+                .validateFieldAsync(fieldName, value, latestValues, "onChange")
+                .then((asyncResult) => {
+                  // stale guard: drop the result if the field changed since
+                  if (getNestedValue(formStateRef.current?.values ?? {}, name) !== value) return;
+                  setFormState((prev) => {
+                    const newErrors: any = { ...prev.errors };
+                    if (syncPassed) { delete newErrors[fieldName]; delete newErrors.form; }
+                    Object.assign(newErrors, asyncResult.errors);
+                    const isValid = Object.values(newErrors).every((e) => !e);
+                    return { ...prev, errors: newErrors, isValid };
+                  });
+                });
+            }
           }
         },
         onBlur: async (_e: React.FocusEvent<any>) => {
@@ -383,9 +404,10 @@ export function useForm<T extends Record<string, any>>(
 
           if (validationManager.shouldValidate("onBlur")) {
             const currentState = formStateRef.current!;
+            const blurValue = currentState.values[fieldName];
             const result = await validationManager.validateField(
               fieldName,
-              currentState.values[fieldName],
+              blurValue,
               currentState.values,
               "onBlur"
             );
@@ -395,6 +417,27 @@ export function useForm<T extends Record<string, any>>(
                 errors: { ...prev.errors, ...result.errors },
                 isValid: false,
               }));
+            }
+
+            // Non-blocking async validation pass on blur.
+            if (validationManager.shouldRunAsync(fieldName, "onBlur", result.isValid)) {
+              const syncPassed = result.isValid;
+              const latestValues = name.includes(".")
+                ? setNestedValue(formStateRef.current?.values ?? {}, name, blurValue)
+                : { ...(formStateRef.current?.values ?? {}), [name]: blurValue };
+              void validationManager
+                .validateFieldAsync(fieldName, blurValue, latestValues, "onBlur")
+                .then((asyncResult) => {
+                  // stale guard: drop the result if the field changed since
+                  if (getNestedValue(formStateRef.current?.values ?? {}, name) !== blurValue) return;
+                  setFormState((prev) => {
+                    const newErrors: any = { ...prev.errors };
+                    if (syncPassed) { delete newErrors[fieldName]; delete newErrors.form; }
+                    Object.assign(newErrors, asyncResult.errors);
+                    const isValid = Object.values(newErrors).every((e) => !e);
+                    return { ...prev, errors: newErrors, isValid };
+                  });
+                });
             }
           }
         },

--- a/packages/el-form-react-hooks/src/useForm.ts
+++ b/packages/el-form-react-hooks/src/useForm.ts
@@ -385,7 +385,7 @@ export function useForm<T extends Record<string, any>>(
                   if (getNestedValue(formStateRef.current?.values ?? {}, name) !== value) return;
                   setFormState((prev) => {
                     const newErrors: any = { ...prev.errors };
-                    if (syncPassed) { delete newErrors[fieldName]; delete newErrors.form; }
+                    if (syncPassed) { delete newErrors[fieldName]; }
                     Object.assign(newErrors, asyncResult.errors);
                     const isValid = Object.values(newErrors).every((e) => !e);
                     return { ...prev, errors: newErrors, isValid };
@@ -432,7 +432,7 @@ export function useForm<T extends Record<string, any>>(
                   if (getNestedValue(formStateRef.current?.values ?? {}, name) !== blurValue) return;
                   setFormState((prev) => {
                     const newErrors: any = { ...prev.errors };
-                    if (syncPassed) { delete newErrors[fieldName]; delete newErrors.form; }
+                    if (syncPassed) { delete newErrors[fieldName]; }
                     Object.assign(newErrors, asyncResult.errors);
                     const isValid = Object.values(newErrors).every((e) => !e);
                     return { ...prev, errors: newErrors, isValid };

--- a/packages/el-form-react-hooks/src/utils/__tests__/errorManagement.test.ts
+++ b/packages/el-form-react-hooks/src/utils/__tests__/errorManagement.test.ts
@@ -31,6 +31,8 @@ const createValidationManager = (
   ({
     validateField: vi.fn(async () => ({ isValid: true, errors: {} })),
     validateForm: vi.fn(async () => ({ isValid: true, errors: {} })),
+    validateFieldAsync: vi.fn(async () => ({ isValid: true, errors: {} })),
+    validateFormAsync: vi.fn(async () => ({ isValid: true, errors: {} })),
     shouldValidate: vi.fn(() => true),
     ...overrides,
   }) as ValidationManager<TestValues>;

--- a/packages/el-form-react-hooks/src/utils/errorManagement.ts
+++ b/packages/el-form-react-hooks/src/utils/errorManagement.ts
@@ -91,20 +91,28 @@ export function createErrorManagementManager<T extends Record<string, any>>(
               formState.values,
               "onSubmit"
             );
-            // Blocking async pass per field: only when sync validation passed.
+            // Blocking async pass per field: run all three async event keys.
             if (r.isValid) {
-              const asyncR = await validationManager.validateFieldAsync(
-                name,
-                formState.values[name],
-                formState.values,
-                "onSubmit"
-              );
-              if (!asyncR.isValid) {
+              let asyncValid = true;
+              const asyncErrors = { ...r.errors };
+              for (const ev of ["onChange", "onBlur", "onSubmit"] as const) {
+                const asyncR = await validationManager.validateFieldAsync(
+                  name,
+                  formState.values[name],
+                  formState.values,
+                  ev
+                );
+                if (!asyncR.isValid) {
+                  asyncValid = false;
+                  Object.assign(asyncErrors, asyncR.errors);
+                }
+              }
+              if (!asyncValid) {
                 return {
                   name,
                   r: {
                     isValid: false,
-                    errors: { ...r.errors, ...asyncR.errors },
+                    errors: asyncErrors,
                   },
                 };
               }
@@ -135,19 +143,21 @@ export function createErrorManagementManager<T extends Record<string, any>>(
         "onSubmit"
       );
 
-      // Blocking async pass: only runs when sync validation passed.
+      // Blocking async pass: run all three async event keys.
       let finalValid = result.isValid;
       let finalErrors = result.errors;
       if (finalValid) {
-        const asyncResult = await validationManager.validateFieldAsync(
-          nameOrNames,
-          formState.values[nameOrNames],
-          formState.values,
-          "onSubmit"
-        );
-        if (!asyncResult.isValid) {
-          finalValid = false;
-          finalErrors = { ...finalErrors, ...asyncResult.errors };
+        for (const ev of ["onChange", "onBlur", "onSubmit"] as const) {
+          const asyncResult = await validationManager.validateFieldAsync(
+            nameOrNames,
+            formState.values[nameOrNames],
+            formState.values,
+            ev
+          );
+          if (!asyncResult.isValid) {
+            finalValid = false;
+            finalErrors = { ...finalErrors, ...asyncResult.errors };
+          }
         }
       }
 

--- a/packages/el-form-react-hooks/src/utils/errorManagement.ts
+++ b/packages/el-form-react-hooks/src/utils/errorManagement.ts
@@ -58,23 +58,59 @@ export function createErrorManagementManager<T extends Record<string, any>>(
         const { isValid, errors } = await validationManager.validateForm(
           formState.values
         );
-        setFormState((prev) => ({ ...prev, errors, isValid }));
-        return isValid;
+
+        // Blocking async pass: only runs when sync validation passed.
+        let finalValid = isValid;
+        let finalErrors = errors;
+        if (finalValid) {
+          const asyncResult = await validationManager.validateFormAsync(
+            formState.values,
+            "onSubmit"
+          );
+          if (!asyncResult.isValid) {
+            finalValid = false;
+            finalErrors = { ...finalErrors, ...asyncResult.errors };
+          }
+        }
+
+        setFormState((prev) => ({
+          ...prev,
+          errors: finalErrors,
+          isValid: finalValid,
+        }));
+        return finalValid;
       }
 
       // Validate multiple fields: merge each field's errors, clearing ones now valid
       if (Array.isArray(nameOrNames)) {
         const results = await Promise.all(
-          nameOrNames.map((name) =>
-            validationManager
-              .validateField(
+          nameOrNames.map(async (name) => {
+            const r = await validationManager.validateField(
+              name,
+              formState.values[name],
+              formState.values,
+              "onSubmit"
+            );
+            // Blocking async pass per field: only when sync validation passed.
+            if (r.isValid) {
+              const asyncR = await validationManager.validateFieldAsync(
                 name,
                 formState.values[name],
                 formState.values,
                 "onSubmit"
-              )
-              .then((r) => ({ name, r }))
-          )
+              );
+              if (!asyncR.isValid) {
+                return {
+                  name,
+                  r: {
+                    isValid: false,
+                    errors: { ...r.errors, ...asyncR.errors },
+                  },
+                };
+              }
+            }
+            return { name, r };
+          })
         );
         setFormState((prev) => {
           const errors: Record<string, string | undefined> = { ...prev.errors };
@@ -98,9 +134,26 @@ export function createErrorManagementManager<T extends Record<string, any>>(
         formState.values,
         "onSubmit"
       );
+
+      // Blocking async pass: only runs when sync validation passed.
+      let finalValid = result.isValid;
+      let finalErrors = result.errors;
+      if (finalValid) {
+        const asyncResult = await validationManager.validateFieldAsync(
+          nameOrNames,
+          formState.values[nameOrNames],
+          formState.values,
+          "onSubmit"
+        );
+        if (!asyncResult.isValid) {
+          finalValid = false;
+          finalErrors = { ...finalErrors, ...asyncResult.errors };
+        }
+      }
+
       setFormState((prev) => {
         const errors: Record<string, string | undefined> = { ...prev.errors };
-        if (!result.isValid) Object.assign(errors, result.errors);
+        if (!finalValid) Object.assign(errors, finalErrors);
         else delete errors[String(nameOrNames)];
         return {
           ...prev,
@@ -108,7 +161,7 @@ export function createErrorManagementManager<T extends Record<string, any>>(
           isValid: Object.keys(errors).length === 0,
         };
       });
-      return result.isValid;
+      return finalValid;
     }) as UseFormReturn<T>["trigger"],
   };
 }

--- a/packages/el-form-react-hooks/src/utils/submitOperations.ts
+++ b/packages/el-form-react-hooks/src/utils/submitOperations.ts
@@ -62,16 +62,32 @@ export function createSubmitOperationsManager<T extends Record<string, any>>(
           formState.values
         );
 
+        // Blocking async validation pass: only runs when sync validation passed
+        // (keeps it consistent with the onChange/onBlur gate). A failing async
+        // rule blocks submission and merges its errors into the written state.
+        let finalValid = isValid;
+        let finalErrors = errors;
+        if (finalValid) {
+          const asyncResult = await validationManager.validateFormAsync(
+            formState.values,
+            "onSubmit"
+          );
+          if (!asyncResult.isValid) {
+            finalValid = false;
+            finalErrors = { ...finalErrors, ...asyncResult.errors };
+          }
+        }
+
         setFormState((prev) => ({
           ...prev,
-          errors,
-          isValid,
+          errors: finalErrors,
+          isValid: finalValid,
           isSubmitting: false,
           // Mark all fields with errors as touched so they display
-          touched: !isValid
+          touched: !finalValid
             ? {
                 ...prev.touched,
-                ...Object.keys(errors).reduce(
+                ...Object.keys(finalErrors).reduce(
                   (acc, field) => ({ ...acc, [field]: true }),
                   {}
                 ),
@@ -79,19 +95,19 @@ export function createSubmitOperationsManager<T extends Record<string, any>>(
             : prev.touched,
         }));
 
-        if (isValid) {
+        if (finalValid) {
           await onValid(formState.values as T);
           setFormState((prev) => ({ ...prev, isSubmitSuccessful: true }));
         } else {
           if (shouldFocusError !== false) {
             const el = findFirstErrorElement(
-              errors as Record<string, any>,
+              finalErrors as Record<string, any>,
               (name) => fieldRefs.current.get(name as keyof T)
             );
             el?.focus();
           }
           if (onError) {
-            onError(errors);
+            onError(finalErrors);
           }
         }
       };
@@ -118,13 +134,27 @@ export function createSubmitOperationsManager<T extends Record<string, any>>(
           formState.values
         );
 
+        // Blocking async validation pass: only runs when sync validation passed.
+        let finalValid = isValid;
+        let finalErrors = errors;
+        if (finalValid) {
+          const asyncResult = await validationManager.validateFormAsync(
+            formState.values,
+            "onSubmit"
+          );
+          if (!asyncResult.isValid) {
+            finalValid = false;
+            finalErrors = { ...finalErrors, ...asyncResult.errors };
+          }
+        }
+
         setFormState((prev) => ({
           ...prev,
-          errors,
-          isValid,
+          errors: finalErrors,
+          isValid: finalValid,
         }));
 
-        if (isValid) {
+        if (finalValid) {
           await onSubmit(formState.values as T);
           setFormState((prev) => ({ ...prev, isSubmitSuccessful: true }));
         }
@@ -151,13 +181,27 @@ export function createSubmitOperationsManager<T extends Record<string, any>>(
           formState.values
         );
 
+        // Blocking async validation pass: only runs when sync validation passed.
+        let finalValid = isValid;
+        let finalErrors = errors;
+        if (finalValid) {
+          const asyncResult = await validationManager.validateFormAsync(
+            formState.values,
+            "onSubmit"
+          );
+          if (!asyncResult.isValid) {
+            finalValid = false;
+            finalErrors = { ...finalErrors, ...asyncResult.errors };
+          }
+        }
+
         setFormState((prev) => ({
           ...prev,
-          errors,
-          isValid,
+          errors: finalErrors,
+          isValid: finalValid,
         }));
 
-        if (isValid) {
+        if (finalValid) {
           // If onSubmit is provided, call it
           if (onSubmit) {
             await onSubmit(formState.values as T);
@@ -165,7 +209,7 @@ export function createSubmitOperationsManager<T extends Record<string, any>>(
           setFormState((prev) => ({ ...prev, isSubmitSuccessful: true }));
           return { success: true, data: formState.values as T };
         } else {
-          return { success: false, errors };
+          return { success: false, errors: finalErrors };
         }
       } finally {
         setFormState((prev) => ({ ...prev, isSubmitting: false }));

--- a/packages/el-form-react-hooks/src/utils/validation.ts
+++ b/packages/el-form-react-hooks/src/utils/validation.ts
@@ -26,6 +26,29 @@ export interface ValidationManager<T extends Record<string, any>> {
   ) => Promise<{ isValid: boolean; errors: Record<keyof T, string> }>;
 
   shouldValidate: (eventType: "onChange" | "onBlur" | "onSubmit") => boolean;
+
+  hasAsyncValidator: (
+    fieldName: keyof T,
+    eventType: "onChange" | "onBlur" | "onSubmit"
+  ) => boolean;
+
+  shouldRunAsync: (
+    fieldName: keyof T,
+    eventType: "onChange" | "onBlur" | "onSubmit",
+    syncPassed: boolean
+  ) => boolean;
+
+  validateFieldAsync: (
+    fieldName: keyof T,
+    fieldValue: any,
+    formValues: Partial<T>,
+    eventType: "onChange" | "onBlur" | "onSubmit"
+  ) => Promise<{ isValid: boolean; errors: Record<string, string> }>;
+
+  validateFormAsync: (
+    values: Partial<T>,
+    eventType?: "onChange" | "onBlur" | "onSubmit"
+  ) => Promise<{ isValid: boolean; errors: Record<keyof T, string> }>;
 }
 
 export interface ValidationManagerOptions<T extends Record<string, any>> {
@@ -51,6 +74,25 @@ export function createValidationManager<T extends Record<string, any>>(
     validateOn,
     schema,
   } = options;
+
+  // ---------------------------------------------------------------------------
+  // Async gate helpers (defined before the returned object so they can close
+  // over fieldValidators / validators without capturing a stale reference).
+  // ---------------------------------------------------------------------------
+
+  const hasAsyncValidator = (
+    fieldName: keyof T,
+    eventType: "onChange" | "onBlur" | "onSubmit"
+  ): boolean => {
+    const key = `${eventType}Async`;
+    const fc = (fieldValidators as any)[fieldName as any];
+    return !!(fc && fc[key]) || !!(validators && (validators as any)[key]);
+  };
+
+  const asyncAlwaysFor = (fieldName: keyof T): boolean => {
+    const fc = (fieldValidators as any)[fieldName as any];
+    return !!(fc && fc.asyncAlways) || !!(validators && (validators as any).asyncAlways);
+  };
 
   return {
     // Determine if validation should run based on mode and validateOn option
@@ -244,6 +286,104 @@ export function createValidationManager<T extends Record<string, any>>(
           }
         } catch (error: unknown) {
           console.warn("Schema validation error:", error);
+        }
+      }
+
+      return { isValid, errors: allErrors as Record<keyof T, string> };
+    },
+
+    // -------------------------------------------------------------------------
+    // Async counterparts
+    // -------------------------------------------------------------------------
+
+    hasAsyncValidator,
+
+    shouldRunAsync: (
+      fieldName: keyof T,
+      eventType: "onChange" | "onBlur" | "onSubmit",
+      syncPassed: boolean
+    ) => hasAsyncValidator(fieldName, eventType) && (syncPassed || asyncAlwaysFor(fieldName)),
+
+    validateFieldAsync: async (
+      fieldName: keyof T,
+      fieldValue: any,
+      formValues: Partial<T>,
+      eventType: "onChange" | "onBlur" | "onSubmit"
+    ): Promise<{ isValid: boolean; errors: Record<string, string> }> => {
+      const fieldKey = String(fieldName);
+      const fieldConfig = (fieldValidators as any)[fieldKey];
+      const event: ValidatorEvent = { type: eventType, isAsync: true, fieldName: fieldKey };
+      let result: { isValid: boolean; errors: Record<string, string> } = { isValid: true, errors: {} };
+
+      if (fieldConfig) {
+        result = await validationEngine.current.validateField(
+          fieldKey,
+          fieldValue,
+          formValues,
+          fieldConfig,
+          event
+        );
+      }
+
+      if (result.isValid && validators) {
+        const formResult = await validationEngine.current.validateForm(
+          formValues,
+          validators,
+          event
+        );
+        if (!formResult.isValid && formResult.errors[fieldKey]) {
+          result = { isValid: false, errors: { [fieldKey]: formResult.errors[fieldKey] } };
+        }
+      }
+
+      return result;
+    },
+
+    validateFormAsync: async (
+      values: Partial<T>,
+      eventType: "onChange" | "onBlur" | "onSubmit" = "onSubmit"
+    ): Promise<{ isValid: boolean; errors: Record<keyof T, string> }> => {
+      const ASYNC_KEYS = ["onChangeAsync", "onBlurAsync", "onSubmitAsync"] as const;
+      const allErrors: Record<string, string> = {};
+      let isValid = true;
+
+      // Which sync event types map to configured async keys on a given config.
+      const asyncEventTypes = (cfg: ValidatorConfig | undefined): string[] =>
+        eventType === "onSubmit"
+          ? (ASYNC_KEYS.filter((k) => cfg && typeof (cfg as any)[k] !== "undefined") as string[]).map(
+              (k) => k.replace(/Async$/, "")
+            )
+          : [eventType];
+
+      // Validate all fields with field-level async validators
+      for (const [fieldName, fieldConfig] of Object.entries(fieldValidators)) {
+        for (const type of asyncEventTypes(fieldConfig as ValidatorConfig)) {
+          if (!(fieldConfig as any)[`${type}Async`]) continue;
+          const event: ValidatorEvent = { type: type as "onChange" | "onBlur" | "onSubmit", isAsync: true };
+          const r = await validationEngine.current.validateField(
+            fieldName,
+            values[fieldName as keyof T],
+            values,
+            fieldConfig as ValidatorConfig,
+            event
+          );
+          if (!r.isValid) {
+            isValid = false;
+            Object.assign(allErrors, r.errors);
+          }
+        }
+      }
+
+      // Run form-level async validators
+      if (validators) {
+        for (const type of asyncEventTypes(validators)) {
+          if (!(validators as any)[`${type}Async`]) continue;
+          const event: ValidatorEvent = { type: type as "onChange" | "onBlur" | "onSubmit", isAsync: true };
+          const r = await validationEngine.current.validateForm(values, validators, event);
+          if (!r.isValid) {
+            isValid = false;
+            Object.assign(allErrors, r.errors);
+          }
         }
       }
 


### PR DESCRIPTION
## The bug
el-form's async validators (`onChangeAsync`/`onBlurAsync`/`onSubmitAsync`, field- and form-level, `*AsyncDebounceMs`/`asyncDebounceMs`/`asyncAlways`) were **silent no-ops** — the hooks layer always built the engine validation event with `isAsync: false`, so the engine resolved the sync key and never invoked the async validator. The `el-form-core` engine already handles async correctly; this is a hooks-only fix.

## The fix
- **`utils/validation.ts`** — `validateFieldAsync` / `validateFormAsync` / `hasAsyncValidator` / `shouldRunAsync` (dispatch `isAsync: true`).
- **`useForm.ts`** — onChange/onBlur run a **non-blocking** async pass: sync-first (gated; honors `asyncAlways`), stale-guarded, clear-on-success.
- **`submitOperations.ts` / `errorManagement.ts`** — `submit()`/`handleSubmit`/`trigger()` **await** async (blocking); a failing async rule blocks submission; `trigger('field')` runs all the field's configured async keys.
- Docs + changeset; corrected stale `{isValid,errors}` async examples.

## Verification
- `el-form-react-hooks` suite **142 pass**; lint clean; `pnpm build:packages` + DTS; docs build clean.
- TDD throughout; final comprehensive review confirmed the core wiring correct (its two merge-gate findings fixed + tests added).

## ⚠️ Behavior change (patch, documented in changeset)
Forms that configured async validators (and silently passed) will now actually validate async and can **gate submit**. Intended fix for a previously-dead documented feature.

## Known follow-ups (non-blocking)
Form-level *bare-string* change/blur async is swallowed (use `{ fields: {...} }`); `asyncAlways` applies only pre-submit; a core quirk where form async returning `{ fields: {} }` reads as invalid; submit-path duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)