### PR TITLE
feat(hooks): formState completeness + validation modes (isValidating, dirtyFields, onTouched, reValidateMode)

### DIFF
--- a/.changeset/formstate-validation-modes.md
+++ b/.changeset/formstate-validation-modes.md
@@ -1,0 +1,9 @@
+---
+"el-form-react-hooks": minor
+---
+
+Add `formState.isValidating` (true during async validation) and reactive
+`formState.dirtyFields` (flat path-keyed, the reactive twin of `getDirtyFields()`),
+plus two validation-timing options: `mode: "onTouched"` (validate on first blur,
+then on change once touched) and opt-in `reValidateMode` ("onChange" | "onBlur" |
+"onSubmit") controlling re-validation timing after the form is submitted. All additive.

--- a/docs/docs/api/use-form.md
+++ b/docs/docs/api/use-form.md
@@ -182,6 +182,9 @@ Opt-in. Once the form has been submitted at least once, `reValidateMode` pins al
 post-submit re-validation to the single chosen event (React Hook Form's
 `reValidateMode`). Leaving it `undefined` keeps the existing behavior.
 
+> **Precedence:** `validateOn` takes priority. If you set both `validateOn` and
+> `reValidateMode`, `validateOn` wins and `reValidateMode` is ignored.
+
 ```typescript
 const form = useForm({
   validators: { onChange: schema },

--- a/docs/docs/api/use-form.md
+++ b/docs/docs/api/use-form.md
@@ -32,7 +32,8 @@ interface UseFormOptions<T extends Record<string, any>> {
   onSubmit?: (values: T) => void | Promise<void>;
   fieldValidators?: Partial<Record<keyof T, ValidatorConfig>>;
   fileValidators?: Partial<Record<keyof T, FileValidationOptions>>;
-  mode?: "onChange" | "onBlur" | "onSubmit" | "all";
+  mode?: "onChange" | "onBlur" | "onTouched" | "onSubmit" | "all";
+  reValidateMode?: "onChange" | "onBlur" | "onSubmit";
   validateOn?: "onChange" | "onBlur" | "onSubmit" | "manual";
   shouldFocusError?: boolean; // default true
   values?: Partial<T>; // reactive external values (props/server data)
@@ -157,11 +158,43 @@ const form = useForm({
 
 #### mode
 
-**Type:** `"onChange" | "onBlur" | "onSubmit" | "all"`  
+**Type:** `"onChange" | "onBlur" | "onTouched" | "onSubmit" | "all"`  
 **Optional:** Yes  
 **Default:** `"onSubmit"`
 
-Legacy validation mode setting. Use `validateOn` for more precise control.
+When validation first runs for a field, matching React Hook Form's `mode`:
+
+- `"onChange"` — validate on every change.
+- `"onBlur"` — validate when a field loses focus.
+- `"onTouched"` — validate on a field's **first blur**, then on **every change**
+  once it has been touched.
+- `"onSubmit"` — validate only on submit (the default).
+- `"all"` — validate on both change and blur.
+
+Use `validateOn` for more granular control over the trigger event.
+
+#### reValidateMode
+
+**Type:** `"onChange" | "onBlur" | "onSubmit"`  
+**Optional:** Yes — **default `undefined`** (behavior unchanged)
+
+Opt-in. Once the form has been submitted at least once, `reValidateMode` pins all
+post-submit re-validation to the single chosen event (React Hook Form's
+`reValidateMode`). Leaving it `undefined` keeps the existing behavior.
+
+```typescript
+const form = useForm({
+  validators: { onChange: schema },
+  reValidateMode: "onBlur", // after the first submit, re-validate only on blur
+});
+```
+
+**Transient-clear nuance:** el-form's `register` `onChange` handler eagerly clears a
+field's error _before_ the `reValidateMode` gate is applied. So with
+`reValidateMode: "onBlur"`, a post-submit **keystroke visibly clears** the field's
+error immediately, and a later **blur re-adds** it if the value is still invalid.
+This is expected — the error reappears on the next gated event rather than on the
+keystroke itself.
 
 #### validateOn
 
@@ -417,9 +450,11 @@ interface FormState<T> {
   isSubmitting: boolean; // Form submission in progress
   isValid: boolean; // Overall form validity
   isDirty: boolean; // Form has been modified
+  isValidating: boolean; // Validation in flight (esp. async); reset by reset()
   isSubmitted: boolean; // True after the first submit attempt; reset by reset()
   isSubmitSuccessful: boolean; // True when the last submit passed validation and the handler ran without throwing; reset by reset()
   submitCount: number; // Number of submit attempts; reset by reset()
+  dirtyFields: Partial<Record<string, boolean>>; // Reactive, path-keyed map of dirty fields; reset by reset()
 }
 ```
 
@@ -435,9 +470,11 @@ console.log(formState.touched); // Which fields have been touched
 console.log(formState.isValid); // Is the entire form valid?
 console.log(formState.isDirty); // Has the form been modified?
 console.log(formState.isSubmitting); // Is submission in progress?
+console.log(formState.isValidating); // Is async validation in flight?
 console.log(formState.isSubmitted); // Has a submit been attempted?
 console.log(formState.isSubmitSuccessful); // Did the last submit succeed?
 console.log(formState.submitCount); // How many submit attempts?
+console.log(formState.dirtyFields); // { "profile.name": true, ... } reactive, path-keyed
 
 // Conditional rendering based on state
 {

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -14,6 +14,31 @@ All notable changes to the el-form project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — Added
+
+### ✨ New `formState` fields + validation-timing options — `el-form-react-hooks`
+
+- **`formState.isValidating: boolean`** — `true` while any **async** validation is in
+  flight (an `onChange`/`onBlur`/submit/`trigger()` async validator), and `false`
+  otherwise. Reset by `reset()`. (Previously there was no `isValidating` on
+  `formState`.)
+- **`formState.dirtyFields: Partial<Record<string, boolean>>`** — a reactive, flat,
+  **path-keyed** map of dirty fields (e.g. `{ "profile.name": true }`); the reactive
+  twin of the existing `getDirtyFields()` method. Keys are path strings (matching
+  `getDirtyFields()`), **not** `keyof T`. Reset by `reset()`.
+- **`mode: "onTouched"`** — a new value for the existing `useForm({ mode })` option.
+  Validates a field on its **first blur**, then on **every change** once it has been
+  touched (matches React Hook Form's `onTouched`).
+- **`reValidateMode?: "onChange" | "onBlur" | "onSubmit"`** — a new opt-in `useForm`
+  option (default `undefined` = behavior unchanged). Once the form has been submitted,
+  it pins post-submit re-validation to the single chosen event (RHF-style). Note:
+  `register`'s `onChange` eagerly clears a field's error _before_ the gate, so with
+  `reValidateMode: "onBlur"` a post-submit keystroke visibly clears the error
+  immediately and a later blur re-adds it if still invalid.
+- All four additions are additive and backward-compatible — existing forms are
+  unaffected. See the [Form State concept](./concepts/form-state.md) and the
+  [useForm API](./api/use-form.md).
+
 ## [Unreleased] — Fixed
 
 ### 🐞 Bug Fix — async validators now actually run (`el-form-react-hooks`)

--- a/docs/docs/concepts/form-state.md
+++ b/docs/docs/concepts/form-state.md
@@ -26,9 +26,11 @@ interface FormState<T> {
   isSubmitting: boolean;                       // submit handler in flight
   isValid: boolean;                            // no current errors
   isDirty: boolean;                            // any value changed from default
+  isValidating: boolean;                       // any async validation in flight
   isSubmitted: boolean;                        // true after the first submit attempt
   isSubmitSuccessful: boolean;                 // true when the last submit passed validation and the handler ran without throwing
   submitCount: number;                         // number of submit attempts
+  dirtyFields: Partial<Record<string, boolean>>; // reactive, path-keyed map of dirty fields
 }
 ```
 
@@ -39,6 +41,15 @@ A few things worth knowing:
 - **`touched`** flips to `true` when a field is blurred, so you can defer
   showing errors until the user leaves a field.
 - **`isDirty`** compares against `defaultValues`; resetting clears it.
+- **`isValidating`** is `true` while validation is in flight — most importantly while
+  an `onChange`/`onBlur` **async** validator runs, and also for the brief duration of
+  `submit`/`handleSubmit`/`trigger()` validation (which is bracketed as a whole). It is
+  `false` otherwise. Use it to show a spinner or disable submit during in-flight checks.
+  Reset by `reset()`.
+- **`dirtyFields`** is a reactive, flat, **path-keyed** map of the fields that differ
+  from their defaults (e.g. `{ "profile.name": true }`) — the reactive twin of the
+  [`getDirtyFields()`](#field-level-state-queries) method. Its keys are path strings
+  (matching `getDirtyFields()`), **not** `keyof T`. Reset by `reset()`.
 - **`isSubmitted`** flips to `true` after the first submit attempt and is reset by
   `reset()`.
 - **`isSubmitSuccessful`** is `true` when the last submit passed validation and the

--- a/docs/static/llms-full.txt
+++ b/docs/static/llms-full.txt
@@ -151,12 +151,18 @@ export function LoginForm() {
 
 `useForm` returns (most-used): `register`, `handleSubmit`, `formState`
 (`values`, `errors`, `touched`, `isDirty`, `isSubmitting`, `isValid`,
-`isSubmitted`, `isSubmitSuccessful`, `submitCount`), `watch`,
-`setError`, `clearErrors`, `reset`, `setValue`. Each `errors[field]` is a
-plain string (no `.message`). `isSubmitted`/`isSubmitSuccessful`/`submitCount`
-track submit attempts and are reset by `reset()`. There is no `isValidating`,
-`defaultValues`, `dirtyFields`, or `isLoading` on `formState` — per-field
-dirty/touched maps are the `getDirtyFields()` / `getTouchedFields()` methods.
+`isValidating`, `isSubmitted`, `isSubmitSuccessful`, `submitCount`,
+`dirtyFields`), `watch`, `setError`, `clearErrors`, `reset`, `setValue`. Each
+`errors[field]` is a plain string (no `.message`).
+`isSubmitted`/`isSubmitSuccessful`/`submitCount` track submit attempts and are
+reset by `reset()`. `isValidating` is `true` while any async validation
+(onChange/onBlur/submit/`trigger()` async validator) is in flight, else `false`;
+reset by `reset()`. `dirtyFields` is a reactive, flat, path-keyed map of dirty
+fields (e.g. `{ "profile.name": true }`) — the reactive twin of
+`getDirtyFields()` (keys are path strings, not `keyof T`); reset by `reset()`.
+There is no `defaultValues` or `isLoading` on `formState` — per-field
+dirty/touched maps are also available as the `getDirtyFields()` /
+`getTouchedFields()` methods.
 
 Validation triggers are configured per event:
 
@@ -164,6 +170,24 @@ Validation triggers are configured per event:
 useForm({ validators: { onChange: schema } }); // validate on change
 useForm({ validators: { onBlur: schema } });   // validate on blur
 useForm({ validators: { onSubmit: schema } }); // validate on submit
+```
+
+Validation timing options (RHF parity):
+
+```tsx
+// mode: when a field is first validated
+useForm({ mode: "onChange" });  // validate every change
+useForm({ mode: "onBlur" });    // validate on blur
+useForm({ mode: "onTouched" }); // validate on first blur, then every change once touched
+useForm({ mode: "onSubmit" });  // validate only on submit (default)
+useForm({ mode: "all" });       // validate on change and blur
+
+// reValidateMode (opt-in; default undefined = unchanged): after the form has been
+// submitted once, pin post-submit re-validation to a single event.
+useForm({ validators: { onChange: schema }, reValidateMode: "onBlur" });
+// Nuance: register's onChange eagerly CLEARS a field's error before the
+// reValidateMode gate, so with reValidateMode: "onBlur" a post-submit keystroke
+// visibly clears the error immediately and a later blur re-adds it if still invalid.
 ```
 
 --------------------------------------------------------------------------------

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -6,7 +6,8 @@ Install everything with `npm install el-form-react`. The library is modular, so 
 
 Key facts:
 - AutoForm: `import { AutoForm } from "el-form-react-components"` — pass a `schema`, get a working form. Import `"el-form-react-components/styles.css"` for zero-config styling.
-- useForm: `import { useForm } from "el-form-react-hooks"` — `register`, `handleSubmit`, `formState`, `watch`, `setError`, `clearErrors` (familiar React Hook Form API). `formState` fields: `values`, `errors` (string per field), `touched`, `isValid`, `isDirty`, `isSubmitting`, `isSubmitted`, `isSubmitSuccessful`, `submitCount`.
+- useForm: `import { useForm } from "el-form-react-hooks"` — `register`, `handleSubmit`, `formState`, `watch`, `setError`, `clearErrors` (familiar React Hook Form API). `formState` fields: `values`, `errors` (string per field), `touched`, `isValid`, `isDirty`, `isSubmitting`, `isValidating` (async validation in flight), `isSubmitted`, `isSubmitSuccessful`, `submitCount`, `dirtyFields` (reactive, path-keyed map; reactive twin of `getDirtyFields()`).
+- Validation timing (RHF parity): `mode: "onChange" | "onBlur" | "onTouched" | "onSubmit" | "all"` (`onTouched` = validate on first blur, then every change once touched); opt-in `reValidateMode: "onChange" | "onBlur" | "onSubmit"` pins post-submit re-validation to one event (default `undefined` = unchanged).
 - Reactive hooks (inside `<FormProvider>`): `useWatch` (subscribe to value(s) by path, values only), `useField` (`value + error + touched`), `useFormSelector` (derived slice), `useFieldArray` (dynamic array fields with stable row ids).
 - Reactive external values: `useForm({ values, keepDirtyValues })` re-syncs to props/server data (RHF `values` / Formik `enableReinitialize` equivalent).
 - Validation-agnostic: Zod (v3 + v4), Yup, Valibot, custom validators, or no validation. Validation libraries are optional peer installs.

--- a/docs/superpowers/plans/2026-06-10-formstate-validation-modes.md
+++ b/docs/superpowers/plans/2026-06-10-formstate-validation-modes.md
@@ -1,0 +1,591 @@
+# formState completeness + validation modes (P2b + P9) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `formState.isValidating` + a reactive `formState.dirtyFields`, and the `mode: "onTouched"` + opt-in `reValidateMode` validation-timing options to `el-form-react-hooks` — all additive/backward-compatible.
+
+**Architecture:** Four additive `FormState`/`UseFormOptions` fields. `isValidating` is driven by a counter wrapper around the async validation sites. `dirtyFields` is the reactive twin of `getDirtyFields()`, kept in lockstep with `isDirty` by replacing the ~7 ad-hoc `isDirty: size>0` writes with one paired patch. `onTouched`/`reValidateMode` make `shouldValidate` aware of per-field touched state and `isSubmitted`.
+
+**Tech Stack:** TypeScript, React 18, Vitest + @testing-library/react (jsdom). Tests render a component using `useForm` and assert via `data-testid` spans + `fireEvent` (see `src/__tests__/validation-modes.test.tsx`, `state-tracking.test.tsx`).
+
+**Spec:** `docs/superpowers/specs/2026-06-10-formstate-validation-modes-design.md`
+**Branch:** `feat/formstate-validation-modes` (already created).
+**Run all hooks tests with:** `pnpm --filter el-form-react-hooks test` (a stray root `vitest.config.ts` will break config resolution — if `Cannot find package 'vitest'` appears, check for and delete an untracked `./vitest.config.ts` at the repo root).
+
+---
+
+## File Structure
+
+| File | Responsibility / change |
+|------|--------------------------|
+| `packages/el-form-react-hooks/src/types.ts` | `FormState` += `isValidating: boolean`, `dirtyFields: Partial<Record<string, boolean>>`; `UseFormOptions.mode` union += `"onTouched"`; `UseFormOptions` += `reValidateMode?` |
+| `packages/el-form-react-hooks/src/utils/dirtyState.ts` | add `toRecord()` + `statePatch()` (the paired `{ isDirty, dirtyFields }` write) |
+| `packages/el-form-react-hooks/src/utils/validation.ts` | `shouldValidate(eventType, ctx?)` new precedence; accept `reValidateMode` |
+| `packages/el-form-react-hooks/src/utils/arrayOperations.ts` | route its dirty write through `statePatch()` |
+| `packages/el-form-react-hooks/src/utils/formState.ts`, `formHistory.ts` | `statePatch()` at their `isDirty` writes; `dirtyFields: {}` on reset/restore |
+| `packages/el-form-react-hooks/src/useForm.ts` | init/reset new fields; `pendingValidationsRef` + `runValidating`; pass `ctx` (touched, isSubmitted) + `reValidateMode`; use `statePatch()` |
+| docs: `concepts/form-state.md`, `api/use-form.md`, `static/llms*.txt`, `changelog.md` | document the additions |
+
+---
+
+## Task 1: Additive fields + defaults + reset
+
+**Files:**
+- Modify: `packages/el-form-react-hooks/src/types.ts`
+- Modify: `packages/el-form-react-hooks/src/useForm.ts` (initial `useState`, `reset()`)
+- Modify: `packages/el-form-react-hooks/src/utils/formState.ts` (resetValues), `utils/formHistory.ts` (restore)
+- Test: `packages/el-form-react-hooks/src/__tests__/formstate-completeness.test.tsx` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/el-form-react-hooks/src/__tests__/formstate-completeness.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+function Demo() {
+  const form = useForm<{ name: string }>({ defaultValues: { name: "" } });
+  const { register, formState, reset } = form;
+  return (
+    <div>
+      <input aria-label="name" {...register("name")} />
+      <span data-testid="isValidating">{String(formState.isValidating)}</span>
+      <span data-testid="dirtyFields">{JSON.stringify(formState.dirtyFields)}</span>
+      <button onClick={() => reset()}>reset</button>
+    </div>
+  );
+}
+
+describe("formState completeness — defaults & reset", () => {
+  it("starts with isValidating=false and dirtyFields={}", () => {
+    render(<Demo />);
+    expect(screen.getByTestId("isValidating").textContent).toBe("false");
+    expect(screen.getByTestId("dirtyFields").textContent).toBe("{}");
+  });
+
+  it("reset() restores isValidating=false and dirtyFields={}", () => {
+    render(<Demo />);
+    fireEvent.change(screen.getByLabelText("name"), { target: { value: "x" } });
+    fireEvent.click(screen.getByText("reset"));
+    expect(screen.getByTestId("isValidating").textContent).toBe("false");
+    expect(screen.getByTestId("dirtyFields").textContent).toBe("{}");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter el-form-react-hooks test formstate-completeness`
+Expected: FAIL — `formState.isValidating` / `formState.dirtyFields` are `undefined` (renders `"undefined"`, not `"false"`/`"{}"`).
+
+- [ ] **Step 3: Add the fields to `FormState`**
+
+In `types.ts`, inside `interface FormState<T>` after `submitCount: number;`:
+
+```ts
+  /** True while any async validation is in flight. Reset by `reset()`. */
+  isValidating: boolean;
+  /** Per-field dirty map (flat, path-keyed) — the reactive twin of
+   *  `getDirtyFields()`. Reset by `reset()`. */
+  dirtyFields: Partial<Record<string, boolean>>;
+```
+
+- [ ] **Step 4: Seed the defaults everywhere `FormState` is constructed**
+
+In `useForm.ts`, the initial `useState<FormState<T>>({...})` object: add `isValidating: false,` and `dirtyFields: {},`. In `reset()`'s `setFormState({...})`: add `isValidating: false,` and `dirtyFields: {},`. In `utils/formState.ts` `resetValues` and `utils/formHistory.ts` restore (wherever a full `FormState` is built / `isDirty`/submit-meta defaults are set), add the same two defaults. (Grep `isSubmitted: false` to find every full-state construction site — add the two new defaults beside them.)
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `pnpm --filter el-form-react-hooks test formstate-completeness`
+Expected: PASS (2/2).
+
+- [ ] **Step 6: Run the full hooks suite (no regressions from the type change)**
+
+Run: `pnpm --filter el-form-react-hooks test`
+Expected: all pass. (The runtime gate uses esbuild type-stripping, so a fixture missing the new required `FormState` fields won't fail vitest — but keep the typed fixtures honest: in `utils/__tests__/formState.test.ts` extend its `Omit<FormState<TestValues>, "isSubmitted" | ...>` to also exclude `"isValidating" | "dirtyFields"` and add `isValidating: false, dirtyFields: {}` to the defaulted spread; in `utils/__tests__/formHistory.test.ts` add the two fields to the `makeState` base. This mirrors the fix used when the submit-meta trio was added.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/el-form-react-hooks/src/types.ts packages/el-form-react-hooks/src/useForm.ts packages/el-form-react-hooks/src/utils/formState.ts packages/el-form-react-hooks/src/utils/formHistory.ts packages/el-form-react-hooks/src/__tests__/formstate-completeness.test.tsx
+git commit -m "feat(hooks): add isValidating + dirtyFields to formState (defaults + reset)"
+```
+
+---
+
+## Task 2: Reactive `dirtyFields` population
+
+**Files:**
+- Modify: `packages/el-form-react-hooks/src/utils/dirtyState.ts` (add `toRecord` + `statePatch`)
+- Modify: `packages/el-form-react-hooks/src/useForm.ts`, `utils/formState.ts`, `utils/fieldOperations.ts`, `utils/formHistory.ts`, `utils/arrayOperations.ts` (route the 7 `isDirty: size>0` writes + arrayOps through `statePatch`)
+- Test: append to `formstate-completeness.test.tsx`
+
+- [ ] **Step 1: Write the failing test** (append to the describe block)
+
+```tsx
+import { z } from "zod";
+
+function DirtyDemo() {
+  const form = useForm<{ name: string; tags: string[] }>({
+    defaultValues: { name: "", tags: [] },
+  });
+  const { register, formState, addArrayItem, getDirtyFields } = form;
+  return (
+    <div>
+      <input aria-label="name" {...register("name")} />
+      <span data-testid="dirtyFields">{JSON.stringify(formState.dirtyFields)}</span>
+      <span data-testid="getDirty">{JSON.stringify(getDirtyFields())}</span>
+      <span data-testid="isDirty">{String(formState.isDirty)}</span>
+      <button onClick={() => addArrayItem("tags", "a")}>addTag</button>
+    </div>
+  );
+}
+
+describe("reactive dirtyFields", () => {
+  it("populates on edit and matches getDirtyFields()", () => {
+    render(<DirtyDemo />);
+    expect(screen.getByTestId("dirtyFields").textContent).toBe("{}");
+    fireEvent.change(screen.getByLabelText("name"), { target: { value: "x" } });
+    expect(JSON.parse(screen.getByTestId("dirtyFields").textContent!)).toEqual({ name: true });
+    expect(screen.getByTestId("dirtyFields").textContent).toBe(screen.getByTestId("getDirty").textContent);
+    expect(screen.getByTestId("isDirty").textContent).toBe("true");
+  });
+
+  it("marks the array path dirty on an array op", () => {
+    render(<DirtyDemo />);
+    fireEvent.click(screen.getByText("addTag"));
+    expect(JSON.parse(screen.getByTestId("dirtyFields").textContent!).tags).toBe(true);
+    expect(screen.getByTestId("isDirty").textContent).toBe("true");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter el-form-react-hooks test formstate-completeness`
+Expected: FAIL — `dirtyFields` stays `{}` after edits (not yet populated).
+
+- [ ] **Step 3: Add `toRecord` + `statePatch` to the dirty manager**
+
+In `dirtyState.ts`, extend the `DirtyStateManager` interface and the returned object:
+
+```ts
+// interface additions:
+  toRecord: () => Record<string, boolean>;
+  statePatch: () => { isDirty: boolean; dirtyFields: Record<string, boolean> };
+```
+```ts
+// implementation additions (inside createDirtyStateManager's returned object):
+    toRecord: (): Record<string, boolean> => {
+      const out: Record<string, boolean> = {};
+      dirtyFieldsRef.current.forEach((path) => {
+        out[path] = true;
+      });
+      return out;
+    },
+    statePatch: () => ({
+      isDirty: dirtyFieldsRef.current.size > 0,
+      dirtyFields: (() => {
+        const out: Record<string, boolean> = {};
+        dirtyFieldsRef.current.forEach((p) => (out[p] = true));
+        return out;
+      })(),
+    }),
+```
+(Keep `statePatch` self-contained rather than calling `toRecord` to avoid `this` binding issues on the object literal.)
+
+- [ ] **Step 4: Route the dirty writes through `statePatch()`**
+
+Replace each `isDirty: dirtyFieldsRef.current.size > 0` (and arrayOps' `isDirty: true`) with `...dirtyManager.statePatch()` inside the `setFormState` updater. The 7 derived sites (per the spec): `useForm.ts` regular onChange (~328) and file-input onChange (~260); `utils/formState.ts` (~41, ~57, ~71); `utils/fieldOperations.ts` (~148); `utils/formHistory.ts` (~132). Plus `utils/arrayOperations.ts` `addArrayItem`/`removeArrayItem` (replace their `isDirty: true` — `addDirtyField(path)` is already called there, so `statePatch()` will include the path). Example transform:
+
+```ts
+// before:
+return { ...prev, values: newValues, errors: newErrors, isDirty: dirtyFieldsRef.current.size > 0 };
+// after:
+return { ...prev, values: newValues, errors: newErrors, ...dirtyManager.statePatch() };
+```
+
+Ensure each of these sites has `dirtyManager` in scope (it is — managers receive it). For `formState.ts`/`fieldOperations.ts`/`formHistory.ts`/`arrayOperations.ts`, confirm the manager is the same `dirtyManager` instance passed into them.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `pnpm --filter el-form-react-hooks test formstate-completeness`
+Expected: PASS (4/4 in this file now).
+
+- [ ] **Step 6: Full suite + commit**
+
+Run: `pnpm --filter el-form-react-hooks test` → all pass.
+```bash
+git add packages/el-form-react-hooks/src/utils/dirtyState.ts packages/el-form-react-hooks/src/useForm.ts packages/el-form-react-hooks/src/utils/formState.ts packages/el-form-react-hooks/src/utils/fieldOperations.ts packages/el-form-react-hooks/src/utils/formHistory.ts packages/el-form-react-hooks/src/utils/arrayOperations.ts packages/el-form-react-hooks/src/__tests__/formstate-completeness.test.tsx
+git commit -m "feat(hooks): reactive formState.dirtyFields via paired dirty write"
+```
+
+---
+
+## Task 3: `isValidating` via a counter wrapper
+
+**Files:**
+- Modify: `packages/el-form-react-hooks/src/useForm.ts` (counter + `runValidating`, wrap async sites)
+- Test: `packages/el-form-react-hooks/src/__tests__/isValidating.test.tsx` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+// el-form async field-validator shape (verified against asyncValidation.test.tsx /
+// el-form-core validators/types.ts): onChangeAsync is (ctx: { value, values, fieldName })
+// => Promise<string | undefined>. NOTE: fieldValidators async does NOT trigger on change
+// via "smart validation" (that only inspects form-level `validators`), so the demo sets
+// `validateOn: "onChange"` to force validation on change — exactly like asyncValidation.test.tsx.
+function Demo({ reject = false }: { reject?: boolean }) {
+  const form = useForm<{ email: string }>({
+    defaultValues: { email: "" },
+    validateOn: "onChange",
+    fieldValidators: {
+      email: {
+        onChangeAsync: reject
+          ? async () => {
+              throw new Error("boom");
+            }
+          : async () => {
+              await new Promise((r) => setTimeout(r, 30));
+              return "bad";
+            },
+      },
+    },
+  });
+  const { register, formState } = form;
+  return (
+    <div>
+      <input aria-label="email" {...register("email")} />
+      <span data-testid="isValidating">{String(formState.isValidating)}</span>
+    </div>
+  );
+}
+
+describe("isValidating", () => {
+  it("is true while async validation runs, then false", async () => {
+    render(<Demo />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "x" } });
+    await waitFor(() => expect(screen.getByTestId("isValidating").textContent).toBe("true"));
+    await waitFor(() => expect(screen.getByTestId("isValidating").textContent).toBe("false"));
+  });
+
+  it("returns to false even if the async validator throws", async () => {
+    render(<Demo reject />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "x" } });
+    await waitFor(() => expect(screen.getByTestId("isValidating").textContent).toBe("false"));
+  });
+});
+```
+
+> NOTE: the async shape + `validateOn: "onChange"` trigger above are verified against
+> `asyncValidation.test.tsx`. If the real codebase differs, mirror that test exactly — the
+> behavior under test is what matters (`isValidating` flips true→false, and false on throw).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter el-form-react-hooks test isValidating`
+Expected: FAIL — `isValidating` never becomes `"true"`.
+
+- [ ] **Step 3: Add the counter + wrapper in `useForm.ts`**
+
+```ts
+const pendingValidationsRef = useRef(0);
+const runValidating = useCallback(async <R,>(fn: () => Promise<R>): Promise<R> => {
+  if (++pendingValidationsRef.current === 1) {
+    setFormState((prev) => (prev.isValidating ? prev : { ...prev, isValidating: true }));
+  }
+  try {
+    return await fn();
+  } finally {
+    if (--pendingValidationsRef.current === 0) {
+      setFormState((prev) => (prev.isValidating ? { ...prev, isValidating: false } : prev));
+    }
+  }
+}, []);
+```
+
+- [ ] **Step 4: Wrap the async validation entry points**
+
+Wrap each async validation so it runs inside `runValidating`:
+- `register`'s onChange async `validationManager.validateField(...)` (the `await` that runs when `shouldValidate("onChange")`) and the onBlur equivalent.
+- `trigger` — wrap the **whole** `trigger()` body once (one increment per call), not each inner `validateField`/`validateForm` (it has all-fields / multi-field `Promise.all` / single-field paths). `trigger` lives in `utils/errorManagement.ts`; if wrapping there is awkward, wrap at the `useForm` boundary where `trigger` is exposed, or pass `runValidating` into the error-management manager.
+- The form-level `validateForm` in `utils/submitOperations.ts` — wrap so `isValidating` is true during submit validation (pass `runValidating` into the submit-operations manager, or wrap the exposed `submit`/`handleSubmit`).
+
+Keep it minimal: every `await validationManager.validate*` that can be async runs inside exactly one `runValidating` frame. **TypeScript:** `trigger` and `handleSubmit` are exposed via `as UseFormReturn<T>["..."]` overload casts (`useForm.ts` ~536/~556/~563-564) — when wrapping them, re-cast the wrapped function to preserve the overload surface so the public types don't change.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `pnpm --filter el-form-react-hooks test isValidating`
+Expected: PASS (2/2).
+
+- [ ] **Step 6: Full suite + commit**
+
+Run: `pnpm --filter el-form-react-hooks test` → all pass.
+```bash
+git add packages/el-form-react-hooks/src/useForm.ts packages/el-form-react-hooks/src/utils/errorManagement.ts packages/el-form-react-hooks/src/utils/submitOperations.ts packages/el-form-react-hooks/src/__tests__/isValidating.test.tsx
+git commit -m "feat(hooks): formState.isValidating during async validation"
+```
+
+---
+
+## Task 4: `mode: "onTouched"`
+
+**Files:**
+- Modify: `packages/el-form-react-hooks/src/types.ts` (mode union)
+- Modify: `packages/el-form-react-hooks/src/utils/validation.ts` (`shouldValidate(eventType, ctx?)`)
+- Modify: `packages/el-form-react-hooks/src/useForm.ts` (pass `fieldTouched` in ctx at the onChange/onBlur callsites)
+- Test: `packages/el-form-react-hooks/src/__tests__/onTouched.test.tsx` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { z } from "zod";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+const schema = z.object({ email: z.string().email("Invalid email") });
+
+function Demo() {
+  const { register, formState } = useForm<{ email: string }>({
+    mode: "onTouched",
+    validators: { onChange: schema, onBlur: schema },
+    defaultValues: { email: "" },
+  });
+  return (
+    <form>
+      <input aria-label="email" {...register("email")} />
+      <span data-testid="err">{formState.errors.email ?? ""}</span>
+    </form>
+  );
+}
+
+describe("mode: onTouched", () => {
+  it("does not validate on change before the field is touched", () => {
+    render(<Demo />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "bad" } });
+    expect(screen.getByTestId("err").textContent).toBe("");
+  });
+  it("validates on blur, then on subsequent change", async () => {
+    render(<Demo />);
+    const input = screen.getByLabelText("email");
+    fireEvent.change(input, { target: { value: "bad" } });
+    fireEvent.blur(input);
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid email"));
+    fireEvent.change(input, { target: { value: "still-bad" } });
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid email"));
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter el-form-react-hooks test onTouched`
+Expected: FAIL — without `onTouched` handling, the first change validates (err shows "Invalid email" when it should be empty), or `"onTouched"` is a type error.
+
+- [ ] **Step 3: Add `"onTouched"` to the mode union**
+
+`types.ts`: `mode?: "onChange" | "onBlur" | "onSubmit" | "all" | "onTouched";`
+
+- [ ] **Step 4: Make `shouldValidate` touched-aware**
+
+In `utils/validation.ts`, change the signature to `shouldValidate(eventType, ctx?: { fieldTouched?: boolean; isSubmitted?: boolean })` and implement the precedence from the spec (this step adds steps 2,4(onTouched gate),5(onTouched); `reValidateMode` arrives in Task 5):
+
+```ts
+shouldValidate: (
+  eventType: "onChange" | "onBlur" | "onSubmit",
+  ctx: { fieldTouched?: boolean; isSubmitted?: boolean } = {}
+): boolean => {
+  if (validateOn) {
+    if (validateOn === "manual") return false;
+    if (validateOn === eventType) return true;
+    if (eventType === "onSubmit") return true;
+    return false;
+  }
+  if (eventType === "onSubmit") return true;
+  // (Task 5 inserts the reValidateMode branch here)
+  const hasValidatorForEvent = validators && (validators as any)[eventType];
+  if (hasValidatorForEvent) {
+    if (mode === "onTouched" && eventType === "onChange" && !ctx.fieldTouched) return false;
+    return true;
+  }
+  if (mode === "all") return eventType === "onChange" || eventType === "onBlur";
+  if (mode === "onTouched") {
+    if (eventType === "onBlur") return true;
+    return !!ctx.fieldTouched;
+  }
+  if (mode === eventType) return true;
+  return false;
+},
+```
+
+- [ ] **Step 5: Pass `fieldTouched` from the callsites**
+
+In `useForm.ts`, the onChange/onBlur handlers call `validationManager.shouldValidate("onChange"|"onBlur")`. Pass ctx: `shouldValidate("onChange", { fieldTouched: !!getNestedValue(formStateRef.current?.touched, name) })`. (Touched is set on blur; on the onChange path read the latest touched from `formStateRef.current`.)
+
+- [ ] **Step 6: Run to verify it passes**
+
+Run: `pnpm --filter el-form-react-hooks test onTouched`
+Expected: PASS (2/2). Then `pnpm --filter el-form-react-hooks test validation-modes` → still PASS (existing modes unaffected).
+
+- [ ] **Step 7: Full suite + commit**
+
+Run: `pnpm --filter el-form-react-hooks test` → all pass.
+```bash
+git add packages/el-form-react-hooks/src/types.ts packages/el-form-react-hooks/src/utils/validation.ts packages/el-form-react-hooks/src/useForm.ts packages/el-form-react-hooks/src/__tests__/onTouched.test.tsx
+git commit -m "feat(hooks): mode 'onTouched'"
+```
+
+---
+
+## Task 5: `reValidateMode`
+
+**Files:**
+- Modify: `packages/el-form-react-hooks/src/types.ts` (`reValidateMode?`)
+- Modify: `packages/el-form-react-hooks/src/utils/validation.ts` (reValidateMode branch + manager option)
+- Modify: `packages/el-form-react-hooks/src/useForm.ts` (pass `reValidateMode`; pass `isSubmitted` in ctx)
+- Test: `packages/el-form-react-hooks/src/__tests__/reValidateMode.test.tsx` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { z } from "zod";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+const schema = z.object({ email: z.string().email("Invalid email") });
+
+function Demo() {
+  const { register, handleSubmit, formState } = useForm<{ email: string }>({
+    validators: { onChange: schema, onBlur: schema, onSubmit: schema },
+    reValidateMode: "onBlur",
+    defaultValues: { email: "" },
+  });
+  return (
+    <form onSubmit={handleSubmit(() => {})}>
+      <input aria-label="email" {...register("email")} />
+      <button type="submit">Submit</button>
+      <span data-testid="err">{formState.errors.email ?? ""}</span>
+    </form>
+  );
+}
+
+// IMPORTANT: el-form's register onChange handler clears the field error
+// UNCONDITIONALLY (outside the shouldValidate gate), then re-validation (gated by
+// shouldValidate) re-adds it if still invalid. So the observable effect of
+// reValidateMode "onBlur" is: after submit, an onChange to a still-invalid value
+// clears the error and does NOT re-add it (re-validation suppressed); a blur re-adds it.
+describe("reValidateMode", () => {
+  it("after submit, an onChange does not re-validate (reValidateMode onBlur); a blur does", async () => {
+    render(<Demo />);
+    const input = screen.getByLabelText("email");
+    fireEvent.change(input, { target: { value: "bad" } });   // pre-submit onChange validates -> error
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid email"));
+    fireEvent.click(screen.getByText("Submit"));              // submit -> isSubmitted true; error stays
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid email"));
+    // post-submit: type ANOTHER invalid value. onChange eager-clears the error and
+    // reValidateMode:'onBlur' suppresses onChange re-validation -> stays cleared.
+    fireEvent.change(input, { target: { value: "alsobad" } });
+    expect(screen.getByTestId("err").textContent).toBe("");
+    // a blur re-validates (reValidateMode onBlur) -> error returns
+    fireEvent.blur(input);
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid email"));
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter el-form-react-hooks test reValidateMode`
+Expected: FAIL — without reValidateMode handling, the post-submit onChange of `"alsobad"` re-validates (smart-validation), so the error re-appears and the `toBe("")` assertion fails; or `reValidateMode` is a type error.
+
+- [ ] **Step 3: Add the option + manager wiring**
+
+`types.ts`: `reValidateMode?: "onChange" | "onBlur" | "onSubmit";`. In `useForm.ts`, destructure `reValidateMode` from options and pass it into `createValidationManager({ ..., reValidateMode })`. In `utils/validation.ts`, accept `reValidateMode` in the manager options and insert the branch in `shouldValidate` right after the `if (eventType === "onSubmit") return true;` line:
+
+```ts
+  if (reValidateMode && ctx.isSubmitted) {
+    return eventType === reValidateMode;
+  }
+```
+
+- [ ] **Step 4: Pass `isSubmitted` from the callsites**
+
+In `useForm.ts` onChange/onBlur handlers, add `isSubmitted: !!formStateRef.current?.isSubmitted` to the ctx passed to `shouldValidate`.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `pnpm --filter el-form-react-hooks test reValidateMode`
+Expected: PASS. Then full validation suite (`test validation-modes onTouched`) still PASS.
+
+- [ ] **Step 6: Full suite + commit**
+
+Run: `pnpm --filter el-form-react-hooks test` → all pass.
+```bash
+git add packages/el-form-react-hooks/src/types.ts packages/el-form-react-hooks/src/utils/validation.ts packages/el-form-react-hooks/src/useForm.ts packages/el-form-react-hooks/src/__tests__/reValidateMode.test.tsx
+git commit -m "feat(hooks): opt-in reValidateMode (post-submit re-validation timing)"
+```
+
+---
+
+## Task 6: Docs + changeset
+
+**Files:**
+- Modify: `docs/docs/concepts/form-state.md`, `docs/docs/api/use-form.md`, `docs/static/llms.txt`, `docs/static/llms-full.txt`, `docs/docs/changelog.md`
+- Create: `.changeset/formstate-validation-modes.md`
+
+- [ ] **Step 1: Document the fields/options**
+
+- `concepts/form-state.md` + `api/use-form.md`: add `isValidating` and `dirtyFields` to the `FormState` shape; add `mode: "onTouched"` to the mode list and a `reValidateMode` entry to `UseFormOptions` (opt-in; governs post-submit re-validation timing).
+- `static/llms-full.txt`: change the `isValidating` note (it currently says "There is no `isValidating`…") to reflect that it now exists; add `dirtyFields`, `onTouched`, `reValidateMode`. Mirror the key bits into `static/llms.txt`.
+
+- [ ] **Step 2: Changelog + changeset**
+
+Add a `changelog.md` entry. Create `.changeset/formstate-validation-modes.md`:
+
+```md
+---
+"el-form-react-hooks": minor
+---
+
+Add `formState.isValidating` (true during async validation) and reactive
+`formState.dirtyFields` (flat path-keyed, the reactive twin of `getDirtyFields()`),
+plus two validation-timing options: `mode: "onTouched"` (validate on first blur,
+then on change once touched) and opt-in `reValidateMode` ("onChange" | "onBlur" |
+"onSubmit") controlling re-validation timing after the form is submitted. All additive.
+```
+
+- [ ] **Step 3: Build docs + commit**
+
+Run: `pnpm --filter el-form-docs build` → SUCCESS, no broken links.
+```bash
+git add docs .changeset/formstate-validation-modes.md
+git commit -m "docs: document isValidating, dirtyFields, onTouched, reValidateMode"
+```
+
+---
+
+## Task 7: Full verification
+
+- [ ] `pnpm --filter el-form-react-hooks test` — all pass (incl. the 4 new test files).
+- [ ] `pnpm --filter el-form-react-hooks lint` — clean.
+- [ ] `pnpm build:packages` — builds (DTS picks up the new `FormState`/`UseFormOptions` fields).
+- [ ] `pnpm --filter el-form-docs build` — clean.
+
+## Out of scope (per spec)
+
+Per-field `validatingFields`; nested RHF-style `dirtyFields`; `isValidating` gating `canSubmit`. These are explicit non-goals for this slice.

--- a/docs/superpowers/plans/2026-06-10-formstate-validation-modes.md
+++ b/docs/superpowers/plans/2026-06-10-formstate-validation-modes.md
@@ -14,6 +14,32 @@
 
 ---
 
+## Reconciliation note (verified against current code, post-async-fix #90)
+
+This branch was cut **before** the async-validation-dispatch fix (PR #90) landed on `main`, then
+rebased onto it. The fix added `validateFieldAsync` / `validateFormAsync` / `hasAsyncValidator` /
+`shouldRunAsync` to `utils/validation.ts` and a non-blocking async pass to `useForm.ts`
+onChange/onBlur, plus blocking async in `trigger`/submit. **Verified line references** (use these;
+they supersede the `~NNN` hints in the tasks below):
+
+- **Task 1 — full `FormState` construction sites** (add `isValidating: false, dirtyFields: {}`):
+  `useForm.ts:55` (initial `useState`), `useForm.ts:558` (`reset()`), `utils/formState.ts:82`
+  (`resetValues`), `utils/formHistory.ts:126` (`restoreSnapshot`).
+- **Task 2 — derived `isDirty: …size > 0` writes** (route through `statePatch()`):
+  `useForm.ts:260` (file onChange), `useForm.ts:328` (regular onChange), `utils/formState.ts:41`
+  (`setValue`), `:57` (`updateValue`), `:71` (`setValues`), `utils/fieldOperations.ts:148`,
+  `utils/formHistory.ts:132` (`restoreSnapshot`). Plus `utils/arrayOperations.ts:24` & `:31`
+  (`isDirty: true`; `addDirtyField(path)` already called above each).
+- **Task 4 — `shouldValidate` callsites** (pass `ctx`): `useForm.ts:243` (file onChange — pass ctx
+  for consistency), `:333-334` (regular onChange), `:405` (onBlur). Also update the
+  `shouldValidate` **interface signature** at `utils/validation.ts:28` and the
+  `ValidationManagerOptions.mode` union at `:58` (add `"onTouched"`), and destructure
+  `reValidateMode` in `createValidationManager`.
+- **Task 3 — `isValidating`**: the async-fix changed what to wrap. See Task 3 Step 4 below (fully
+  rewritten for the new `validateFieldAsync`/`validateFormAsync` structure).
+
+---
+
 ## File Structure
 
 | File | Responsibility / change |
@@ -229,7 +255,9 @@ git commit -m "feat(hooks): reactive formState.dirtyFields via paired dirty writ
 ## Task 3: `isValidating` via a counter wrapper
 
 **Files:**
-- Modify: `packages/el-form-react-hooks/src/useForm.ts` (counter + `runValidating`, wrap async sites)
+- Modify: `packages/el-form-react-hooks/src/useForm.ts` (counter + `runValidating`, wrap onChange/onBlur async; thread `runValidating` into managers)
+- Modify: `packages/el-form-react-hooks/src/utils/errorManagement.ts` (accept `runValidating`, wrap `trigger` body)
+- Modify: `packages/el-form-react-hooks/src/utils/submitOperations.ts` (accept `runValidating`, wrap submit validation region)
 - Test: `packages/el-form-react-hooks/src/__tests__/isValidating.test.tsx` (new)
 
 - [ ] **Step 1: Write the failing test**
@@ -315,14 +343,73 @@ const runValidating = useCallback(async <R,>(fn: () => Promise<R>): Promise<R> =
 }, []);
 ```
 
-- [ ] **Step 4: Wrap the async validation entry points**
+- [ ] **Step 4: Wrap the async validation entry points** *(rewritten for post-async-fix code)*
 
-Wrap each async validation so it runs inside `runValidating`:
-- `register`'s onChange async `validationManager.validateField(...)` (the `await` that runs when `shouldValidate("onChange")`) and the onBlur equivalent.
-- `trigger` — wrap the **whole** `trigger()` body once (one increment per call), not each inner `validateField`/`validateForm` (it has all-fields / multi-field `Promise.all` / single-field paths). `trigger` lives in `utils/errorManagement.ts`; if wrapping there is awkward, wrap at the `useForm` boundary where `trigger` is exposed, or pass `runValidating` into the error-management manager.
-- The form-level `validateForm` in `utils/submitOperations.ts` — wrap so `isValidating` is true during submit validation (pass `runValidating` into the submit-operations manager, or wrap the exposed `submit`/`handleSubmit`).
+> **Critical scoping.** After PR #90 the genuinely-async calls are `validateFieldAsync` (field) and
+> `validateFormAsync` (form). `isValidating` wraps **those async passes** — NOT the synchronous
+> `validateField`/`validateForm`. Wrapping the sync path would flip `isValidating` true→false on
+> every keystroke even with no async validator configured. The spec's "wrap the onChange/onBlur
+> async path, trigger, and submit's validateForm" maps onto the new async methods as follows.
 
-Keep it minimal: every `await validationManager.validate*` that can be async runs inside exactly one `runValidating` frame. **TypeScript:** `trigger` and `handleSubmit` are exposed via `as UseFormReturn<T>["..."]` overload casts (`useForm.ts` ~536/~556/~563-564) — when wrapping them, re-cast the wrapped function to preserve the overload surface so the public types don't change.
+Wrap exactly these four sites:
+
+1. **`register` onChange async pass** (`useForm.ts` ~376–394) — currently
+   `void validationManager.validateFieldAsync(fieldName, value, latestValues, "onChange").then((asyncResult) => { … })`.
+   Wrap the call and add a `.catch`:
+   ```ts
+   void runValidating(() =>
+     validationManager.validateFieldAsync(fieldName, value, latestValues, "onChange")
+   )
+     .then((asyncResult) => { /* keep the existing stale-guard + clear-on-success body verbatim */ })
+     .catch(() => {}); // rejecting async validator: runValidating's finally still resets the flag
+   ```
+2. **`register` onBlur async pass** (`useForm.ts` ~423–441) — same wrap + `.catch(() => {})`.
+3. **`trigger`** (`utils/errorManagement.ts`) — wrap the **whole** body once (one increment per
+   call; it has all-fields / multi-field `Promise.all` / single-field branches, each awaiting sync
+   **and** async passes). Pass `runValidating` into `createErrorManagementManager`. `trigger` has no
+   user callback, so wrapping the whole body is correct:
+   ```ts
+   trigger: ((nameOrNames?: keyof T | (keyof T)[]) =>
+     runValidating(async () => { /* existing trigger body, returns the boolean */ })
+   ) as UseFormReturn<T>["trigger"],
+   ```
+4. **submit** (`utils/submitOperations.ts`, all three of `handleSubmit`/`submit`/`submitAsync`) —
+   wrap **only the validation region** (sync `validateForm` + conditional `validateFormAsync`), NOT
+   the user's `onSubmit` callback, so `isValidating` is false while `onSubmit` runs. Pass
+   `runValidating` into `createSubmitOperationsManager`. Transform each:
+   ```ts
+   // before:
+   const { isValid, errors } = await validationManager.validateForm(formState.values);
+   let finalValid = isValid; let finalErrors = errors;
+   if (finalValid) {
+     const asyncResult = await validationManager.validateFormAsync(formState.values, "onSubmit");
+     if (!asyncResult.isValid) { finalValid = false; finalErrors = { ...finalErrors, ...asyncResult.errors }; }
+   }
+   // after:
+   const { finalValid, finalErrors } = await runValidating(async () => {
+     const { isValid, errors } = await validationManager.validateForm(formState.values);
+     let v = isValid; let e = errors;
+     if (v) {
+       const a = await validationManager.validateFormAsync(formState.values, "onSubmit");
+       if (!a.isValid) { v = false; e = { ...e, ...a.errors }; }
+     }
+     return { finalValid: v, finalErrors: e };
+   });
+   ```
+
+**Wiring `runValidating` into the managers:** add an optional
+`runValidating?: <R>(fn: () => Promise<R>) => Promise<R>` to `SubmitOperationsOptions` and
+`ErrorManagementOptions`; pass it from `useForm.ts` (where it is defined). Inside each manager,
+default to a pass-through when absent so directly-constructed test managers are unaffected:
+`const run = options.runValidating ?? (<R,>(fn: () => Promise<R>) => fn());`
+
+**Define `runValidating` early** in `useForm.ts` (right after the `useState`/refs, before any
+manager is created at ~113–165) so it is in scope for `registerImpl`, submit, and error managers.
+Add it to `registerImpl`'s `useCallback` dep array (it is stable, so no extra re-creation).
+
+**TypeScript:** `trigger`, `handleSubmit`, `submit` are exposed via `as UseFormReturn<T>["…"]`
+overload casts — keep the re-cast on the wrapped functions so the public overload surface is
+unchanged.
 
 - [ ] **Step 5: Run to verify it passes**
 

--- a/docs/superpowers/specs/2026-06-10-formstate-validation-modes-design.md
+++ b/docs/superpowers/specs/2026-06-10-formstate-validation-modes-design.md
@@ -1,0 +1,142 @@
+# formState completeness + validation modes (P2b + P9) — design (2026-06-10)
+
+Bundle the two smallest RHF-parity items into one slice: finish `formState`
+(`isValidating` + reactive `dirtyFields`) and add two validation-timing options
+(`mode: "onTouched"` + `reValidateMode`).
+
+## Goal
+
+RHF-parity polish, purely additive. After this slice:
+- `formState.isValidating` is `true` while any async validation is in flight.
+- `formState.dirtyFields` is a reactive twin of `getDirtyFields()`.
+- `useForm({ mode: "onTouched" })` validates on first blur, then on change once touched.
+- `useForm({ reValidateMode })` controls re-validation timing after the form is submitted.
+
+## Decisions (locked with the user)
+
+- **el-form-consistent MVP**, not full RHF clone:
+  - `dirtyFields` is a **flat path-keyed** record (`{ "profile.name": true }`) — same shape as
+    today's `getDirtyFields()`. (No nested RHF-style mirror.)
+  - `isValidating` is a single **form-level boolean**. (No per-field `validatingFields`.)
+- **`reValidateMode` is opt-in** — default `undefined` = current behavior unchanged; only when
+  set does it change post-submit timing. (RHF defaults to `"onChange"`; we default to off to
+  honor el-form's "backward-compatible by default" principle.)
+
+## Current state (verified)
+
+- `FormState` (`packages/el-form-react-hooks/src/types.ts`): `values, errors, touched,
+  isSubmitting, isValid, isDirty, isSubmitted, isSubmitSuccessful, submitCount`. No
+  `isValidating`, no `dirtyFields`.
+- `UseFormOptions`: `mode?: "onChange" | "onBlur" | "onSubmit" | "all"`, plus `validateOn`. No
+  `reValidateMode`.
+- `shouldValidate(eventType)` (`utils/validation.ts`): precedence is
+  `validateOn` → smart-validation (a validator exists for the event) → `mode`. It is **not**
+  aware of touched or submitted state.
+- Dirty is a mutation-driven `Set` (`dirtyFieldsRef`); `getDirtyFields()`
+  (`utils/fieldOperations.ts`) returns a flat `Record<path, boolean>` from it. `isDirty` is
+  written ad-hoc as `isDirty: dirtyFieldsRef.current.size > 0` in several places.
+- `arrayOperations` **already** calls `addDirtyField(path)` (in `addArrayItem`/`removeArrayItem`)
+  alongside `isDirty: true`, so the dirty Set *is* updated for array edits today — it just won't
+  populate the new reactive `dirtyFields` unless its write is routed through the paired helper.
+  (An earlier audit framed this as a missing-`addDirtyField` gap; that was stale/incorrect.)
+
+## Architecture (4 additive units + 1 fix)
+
+### Unit A — `isValidating`
+- `FormState += isValidating: boolean` (default `false`).
+- A `pendingValidationsRef` counter lives in `useForm`. A small helper
+  `runValidating(setFormState, counterRef, fn)` wraps an async validation: `++count`
+  (set `isValidating: true` on 0→1), `await fn()` in `try/finally`, `--count` (set
+  `isValidating: false` on 1→0). Only writes formState when the flag flips.
+- Wrap the async validation entry points: the `register` onChange/onBlur async `validateField`
+  path, `trigger`, and the form-level `validateForm` in submit. **Granularity:** wrap the whole
+  `trigger()` body in one `runValidating` (one increment per call) — `trigger` has multiple
+  internal validate calls (all-fields, multi-field `Promise.all`, single-field), so wrapping each
+  inner call would over-count. The earlier superseded-promise fix guarantees superseded async
+  validations resolve, so the counter cannot get stuck.
+- `reset()` sets `isValidating: false`.
+
+### Unit B — reactive `dirtyFields`
+- `FormState += dirtyFields: Partial<Record<string, boolean>>` (default `{}`), same shape and
+  path-string keys as `getDirtyFields()`.
+- Introduce `dirtyManager.toRecord(): Record<string, boolean>` (the Set → flat record), and a
+  `syncDirtyState(prev)` shape that produces `{ isDirty: size > 0, dirtyFields: toRecord() }`.
+  Replace the scattered `isDirty: dirtyFieldsRef.current.size > 0` writes with this paired write so
+  `isDirty` and `dirtyFields` can never drift. The 7 derived `isDirty: size > 0` writes to
+  convert: `useForm.ts` regular onChange (~328) and file-input onChange (~260) paths;
+  `utils/formState.ts` (~41, ~57, ~71); `utils/fieldOperations.ts` (~148); `utils/formHistory.ts`
+  (~132). (Separately, the `reset()` ternary at `useForm.ts` ~521 is a reset-style write — it sets
+  `dirtyFields: {}`, not from the Set.)
+- `arrayOperations` already adds the path via `addDirtyField`; the only change is routing its
+  dirty write through the paired helper so `dirtyFields` is populated alongside `isDirty`.
+- `getDirtyFields()` stays (reads the same Set) — `dirtyFields` is its reactive twin.
+- `reset()` / snapshot restore set `dirtyFields: {}` (cleared with the dirty Set).
+
+### Unit C — `mode: "onTouched"`
+- Add `"onTouched"` to the `mode` union in `UseFormOptions`.
+- `shouldValidate` gains an optional context arg `{ fieldTouched?: boolean }`. For
+  `mode === "onTouched"`: `onBlur` → validate; `onChange` → validate **only if** `fieldTouched`.
+  (Matches RHF: validate on first blur, re-validate on change once touched.)
+- The `register` onChange/onBlur callsites pass the field's touched flag (from
+  `formStateRef.current.touched`).
+
+### Unit D — `reValidateMode`
+- `UseFormOptions += reValidateMode?: "onChange" | "onBlur" | "onSubmit"`.
+- `shouldValidate` context gains `isSubmitted?: boolean`. When `reValidateMode` is set **and**
+  `isSubmitted` is true, post-submit `onChange`/`onBlur` validation follows `reValidateMode`
+  (i.e. validate when `eventType === reValidateMode`); `onSubmit` always validates. When unset
+  or pre-submit, behavior is unchanged.
+- Threaded through `createValidationManager` options; callsites pass
+  `isSubmitted` from `formStateRef.current`.
+
+### `shouldValidate` precedence (final)
+1. `validateOn` (explicit per-event override) — unchanged, highest. It wins over `reValidateMode`
+   (step 3): both are explicit timing knobs, and the per-event `validateOn` is the more specific one.
+2. `eventType === "onSubmit"` → always `true`.
+3. If `reValidateMode` set **and** `isSubmitted` → `eventType === reValidateMode`.
+4. Smart-validation (a validator exists for the event) → `true`, **except** under
+   `mode: "onTouched"` an `onChange` on an untouched field stays `false`.
+5. `mode`: `"all"` → change/blur true; `"onTouched"` → blur true, change iff touched;
+   `mode === eventType` → true; else `false`.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `el-form-react-hooks/src/types.ts` | `FormState` += `isValidating`, `dirtyFields`; `UseFormOptions` += `reValidateMode`, mode union += `"onTouched"` |
+| `el-form-react-hooks/src/utils/validation.ts` | `shouldValidate(eventType, ctx?)` new logic; accept `reValidateMode` |
+| `el-form-react-hooks/src/utils/dirtyState.ts` | `toRecord()`; paired dirty-write helper |
+| `el-form-react-hooks/src/utils/arrayOperations.ts` | route its existing dirty write through the paired helper (path already added via `addDirtyField`) |
+| `el-form-react-hooks/src/useForm.ts` | `pendingValidationsRef` + `runValidating`; init/reset new fields; pass ctx + `reValidateMode`; use paired dirty-write |
+| `el-form-react-hooks/src/utils/submitOperations.ts` | `isValidating` around `validateForm` |
+| `el-form-react-hooks/src/utils/formState.ts`, `formHistory.ts` | reset/restore defaults for new fields |
+| docs: `concepts/form-state.md`, `api/use-form.md`, `llms*.txt`, `changelog.md` | document `isValidating`, `dirtyFields`, `onTouched`, `reValidateMode` (and flip the "no `isValidating`" note) |
+
+## Testing (TDD, in `el-form-react-hooks`)
+
+- **isValidating:** an async field validator that resolves after a tick → `isValidating` true
+  during, false after; two concurrent validations → stays true until both settle; a **rejecting**
+  async validator still flips it back to `false` (the counter never gets stuck); `reset()`
+  clears it.
+- **dirtyFields:** edit nested + top-level fields → `dirtyFields` matches `getDirtyFields()` and
+  reacts; an array append/remove marks the array path dirty; `reset()` and snapshot restore
+  clear it; `isDirty` and `dirtyFields` never disagree.
+- **onTouched:** change before blur → no validation/error; blur → validates; change after
+  touched → validates.
+- **reValidateMode:** unset → behavior unchanged; set to `"onBlur"` → after submit, an onChange
+  does not re-validate but an onBlur does; pre-submit follows `mode`.
+
+## Non-goals / deferred
+
+- Per-field `validatingFields` (RHF) — form-level boolean only this slice.
+- Nested RHF-style `dirtyFields` object — flat path-keyed to match `getDirtyFields()`.
+- `isValidating` does not gate `canSubmit` (out of scope; revisit if asked).
+
+## Risks
+
+- **dirtyFields drift** — mitigated by the single paired-write helper replacing the ~7 ad-hoc
+  `isDirty` writes (enumerated in Unit B), so `isDirty` and `dirtyFields` are always written
+  together. The TDD "never disagree" test guards it.
+- **Validation-timing regressions** — `shouldValidate` is load-bearing; the new branches are
+  additive (opt-in `reValidateMode`, new `onTouched` mode) and existing `mode`/`validateOn`
+  paths are preserved. Existing validation tests must stay green.

--- a/docs/superpowers/specs/2026-06-10-formstate-validation-modes-design.md
+++ b/docs/superpowers/specs/2026-06-10-formstate-validation-modes-design.md
@@ -65,7 +65,7 @@ RHF-parity polish, purely additive. After this slice:
   `isDirty` and `dirtyFields` can never drift. The 7 derived `isDirty: size > 0` writes to
   convert: `useForm.ts` regular onChange (~328) and file-input onChange (~260) paths;
   `utils/formState.ts` (~41, ~57, ~71); `utils/fieldOperations.ts` (~148); `utils/formHistory.ts`
-  (~132). (Separately, the `reset()` ternary at `useForm.ts` ~521 is a reset-style write — it sets
+  (~132). (Separately, the `reset()` ternary at `useForm.ts` ~564 is a reset-style write — it sets
   `dirtyFields: {}`, not from the Set.)
 - `arrayOperations` already adds the path via `addDirtyField`; the only change is routing its
   dirty write through the paired helper so `dirtyFields` is populated alongside `isDirty`.

--- a/packages/el-form-react-hooks/src/__tests__/formstate-completeness.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/formstate-completeness.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+function Demo() {
+  const form = useForm<{ name: string }>({ defaultValues: { name: "" } });
+  const { register, formState, reset } = form;
+  return (
+    <div>
+      <input aria-label="name" {...register("name")} />
+      <span data-testid="isValidating">{String(formState.isValidating)}</span>
+      <span data-testid="dirtyFields">{JSON.stringify(formState.dirtyFields)}</span>
+      <button onClick={() => reset()}>reset</button>
+    </div>
+  );
+}
+
+describe("formState completeness — defaults & reset", () => {
+  it("starts with isValidating=false and dirtyFields={}", () => {
+    render(<Demo />);
+    expect(screen.getByTestId("isValidating").textContent).toBe("false");
+    expect(screen.getByTestId("dirtyFields").textContent).toBe("{}");
+  });
+
+  it("reset() restores isValidating=false and dirtyFields={}", () => {
+    render(<Demo />);
+    fireEvent.change(screen.getByLabelText("name"), { target: { value: "x" } });
+    fireEvent.click(screen.getByText("reset"));
+    expect(screen.getByTestId("isValidating").textContent).toBe("false");
+    expect(screen.getByTestId("dirtyFields").textContent).toBe("{}");
+  });
+});

--- a/packages/el-form-react-hooks/src/__tests__/formstate-completeness.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/formstate-completeness.test.tsx
@@ -32,3 +32,47 @@ describe("formState completeness — defaults & reset", () => {
     expect(screen.getByTestId("dirtyFields").textContent).toBe("{}");
   });
 });
+
+function DirtyDemo() {
+  const form = useForm<{ name: string; tags: string[] }>({
+    defaultValues: { name: "", tags: [] },
+  });
+  const { register, formState, addArrayItem, getDirtyFields } = form;
+  return (
+    <div>
+      <input aria-label="name" {...register("name")} />
+      <span data-testid="dirtyFields">{JSON.stringify(formState.dirtyFields)}</span>
+      <span data-testid="getDirty">{JSON.stringify(getDirtyFields())}</span>
+      <span data-testid="isDirty">{String(formState.isDirty)}</span>
+      <button onClick={() => addArrayItem("tags", "a")}>addTag</button>
+      <button onClick={() => form.reset()}>resetDirty</button>
+    </div>
+  );
+}
+
+describe("reactive dirtyFields", () => {
+  it("populates on edit and matches getDirtyFields()", () => {
+    render(<DirtyDemo />);
+    expect(screen.getByTestId("dirtyFields").textContent).toBe("{}");
+    fireEvent.change(screen.getByLabelText("name"), { target: { value: "x" } });
+    expect(JSON.parse(screen.getByTestId("dirtyFields").textContent!)).toEqual({ name: true });
+    expect(screen.getByTestId("dirtyFields").textContent).toBe(screen.getByTestId("getDirty").textContent);
+    expect(screen.getByTestId("isDirty").textContent).toBe("true");
+  });
+
+  it("marks the array path dirty on an array op", () => {
+    render(<DirtyDemo />);
+    fireEvent.click(screen.getByText("addTag"));
+    expect(JSON.parse(screen.getByTestId("dirtyFields").textContent!).tags).toBe(true);
+    expect(screen.getByTestId("isDirty").textContent).toBe("true");
+  });
+
+  it("reset() clears a populated dirtyFields back to {}", () => {
+    render(<DirtyDemo />);
+    fireEvent.change(screen.getByLabelText("name"), { target: { value: "x" } });
+    expect(JSON.parse(screen.getByTestId("dirtyFields").textContent!)).toEqual({ name: true });
+    fireEvent.click(screen.getByText("resetDirty"));
+    expect(screen.getByTestId("dirtyFields").textContent).toBe("{}");
+    expect(screen.getByTestId("isDirty").textContent).toBe("false");
+  });
+});

--- a/packages/el-form-react-hooks/src/__tests__/formstate-completeness.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/formstate-completeness.test.tsx
@@ -46,6 +46,7 @@ function DirtyDemo() {
       <span data-testid="isDirty">{String(formState.isDirty)}</span>
       <button onClick={() => addArrayItem("tags", "a")}>addTag</button>
       <button onClick={() => form.reset()}>resetDirty</button>
+      <button onClick={() => form.reset({ keepDirty: true })}>resetKeepDirty</button>
     </div>
   );
 }
@@ -74,5 +75,14 @@ describe("reactive dirtyFields", () => {
     fireEvent.click(screen.getByText("resetDirty"));
     expect(screen.getByTestId("dirtyFields").textContent).toBe("{}");
     expect(screen.getByTestId("isDirty").textContent).toBe("false");
+  });
+
+  it("reset({ keepDirty: true }) keeps dirtyFields populated and consistent with isDirty", () => {
+    render(<DirtyDemo />);
+    fireEvent.change(screen.getByLabelText("name"), { target: { value: "x" } });
+    expect(JSON.parse(screen.getByTestId("dirtyFields").textContent!)).toEqual({ name: true });
+    fireEvent.click(screen.getByText("resetKeepDirty"));
+    expect(JSON.parse(screen.getByTestId("dirtyFields").textContent!)).toEqual({ name: true });
+    expect(screen.getByTestId("isDirty").textContent).toBe("true");
   });
 });

--- a/packages/el-form-react-hooks/src/__tests__/isValidating.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/isValidating.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+
+// fieldValidators async does NOT trigger on change via "smart validation" (which only
+// inspects form-level `validators`), so the demo sets validateOn:"onChange" to force it —
+// exactly like the existing asyncValidation.test.tsx.
+function Demo({ reject = false }: { reject?: boolean }) {
+  const form = useForm<{ email: string }>({
+    defaultValues: { email: "" },
+    validateOn: "onChange",
+    fieldValidators: {
+      email: {
+        onChangeAsync: reject
+          ? async () => { throw new Error("boom"); }
+          : async () => { await new Promise((r) => setTimeout(r, 30)); return "bad"; },
+      },
+    } as any,
+  });
+  const { register, formState } = form;
+  return (
+    <div>
+      <input aria-label="email" {...register("email")} />
+      <span data-testid="isValidating">{String(formState.isValidating)}</span>
+    </div>
+  );
+}
+
+describe("isValidating", () => {
+  it("is true while async validation runs, then false", async () => {
+    render(<Demo />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "x" } });
+    await waitFor(() => expect(screen.getByTestId("isValidating").textContent).toBe("true"));
+    await waitFor(() => expect(screen.getByTestId("isValidating").textContent).toBe("false"));
+  });
+
+  it("returns to false even if the async validator throws", async () => {
+    render(<Demo reject />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "x" } });
+    await waitFor(() => expect(screen.getByTestId("isValidating").textContent).toBe("false"));
+  });
+});

--- a/packages/el-form-react-hooks/src/__tests__/onTouched.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/onTouched.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { z } from "zod";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+const schema = z.object({ email: z.string().email("Invalid email") });
+
+function Demo() {
+  const { register, formState } = useForm<{ email: string }>({
+    mode: "onTouched",
+    validators: { onChange: schema, onBlur: schema },
+    defaultValues: { email: "" },
+  });
+  return (
+    <form>
+      <input aria-label="email" {...register("email")} />
+      <span data-testid="err">{formState.errors.email ?? ""}</span>
+    </form>
+  );
+}
+
+describe("mode: onTouched", () => {
+  it("does not validate on change before the field is touched", async () => {
+    render(<Demo />);
+    fireEvent.change(screen.getByLabelText("email"), { target: { value: "bad" } });
+    // If onTouched were NOT suppressing this pre-touch change, the change would
+    // trigger (async) validation that surfaces an error within this window. The
+    // 50ms wait gives that incorrect validation time to land, so asserting "" here
+    // proves no validation ran — not that we merely checked too early. (Verified:
+    // without the onTouched impl, this assertion fails with "Invalid email".)
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.getByTestId("err").textContent).toBe("");
+  });
+  it("validates on blur, then on subsequent change", async () => {
+    render(<Demo />);
+    const input = screen.getByLabelText("email");
+    fireEvent.change(input, { target: { value: "bad" } });
+    fireEvent.blur(input);
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid email"));
+    fireEvent.change(input, { target: { value: "still-bad" } });
+    await waitFor(() => expect(screen.getByTestId("err").textContent).toBe("Invalid email"));
+  });
+});

--- a/packages/el-form-react-hooks/src/__tests__/reValidateMode.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/reValidateMode.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { z } from "zod";
+import { useForm } from "..";
+
+beforeEach(cleanup);
+const schema = z.object({ email: z.string().email("Invalid email") });
+
+function Demo() {
+  const { register, handleSubmit, formState } = useForm<{ email: string }>({
+    validators: { onChange: schema, onBlur: schema, onSubmit: schema },
+    reValidateMode: "onBlur",
+    defaultValues: { email: "" },
+  });
+  return (
+    <form onSubmit={handleSubmit(() => {})}>
+      <input aria-label="email" {...register("email")} />
+      <button type="submit">Submit</button>
+      <span data-testid="err">{formState.errors.email ?? ""}</span>
+    </form>
+  );
+}
+
+// el-form's register onChange handler clears the field error UNCONDITIONALLY (outside
+// the shouldValidate gate), then re-validation (gated by shouldValidate) re-adds it if
+// still invalid. So the observable effect of reValidateMode "onBlur" is: after submit,
+// an onChange to a still-invalid value clears the error and does NOT re-add it
+// (onChange re-validation suppressed); a blur re-adds it.
+describe("reValidateMode", () => {
+  it("after submit, an onChange does not re-validate (reValidateMode onBlur); a blur does", async () => {
+    render(<Demo />);
+    const input = screen.getByLabelText("email");
+
+    // Pre-submit: smart-validation runs onChange (reValidateMode inactive until submitted).
+    fireEvent.change(input, { target: { value: "bad" } });
+    await waitFor(() =>
+      expect(screen.getByTestId("err").textContent).toBe("Invalid email")
+    );
+
+    // Submit -> isSubmitted becomes true; the error stays.
+    fireEvent.click(screen.getByText("Submit"));
+    await waitFor(() =>
+      expect(screen.getByTestId("err").textContent).toBe("Invalid email")
+    );
+
+    // Post-submit onChange to another invalid value: the handler eager-clears the error,
+    // and reValidateMode:"onBlur" suppresses onChange re-validation, so it stays cleared.
+    // The 50ms wait gives any (incorrect) re-validation time to land — without the
+    // reValidateMode impl, smart-validation would re-add "Invalid email" here.
+    fireEvent.change(input, { target: { value: "alsobad" } });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.getByTestId("err").textContent).toBe("");
+
+    // A blur DOES re-validate (eventType === reValidateMode) -> the error returns.
+    fireEvent.blur(input);
+    await waitFor(() =>
+      expect(screen.getByTestId("err").textContent).toBe("Invalid email")
+    );
+  });
+
+  it("without reValidateMode set, post-submit onChange re-validates (unchanged default)", async () => {
+    function DefaultDemo() {
+      const { register, handleSubmit, formState } = useForm<{ email: string }>({
+        validators: { onChange: schema, onBlur: schema, onSubmit: schema },
+        defaultValues: { email: "" },
+      });
+      return (
+        <form onSubmit={handleSubmit(() => {})}>
+          <input aria-label="email" {...register("email")} />
+          <button type="submit">Submit</button>
+          <span data-testid="err2">{formState.errors.email ?? ""}</span>
+        </form>
+      );
+    }
+    render(<DefaultDemo />);
+    const input = screen.getByLabelText("email");
+    fireEvent.click(screen.getByText("Submit"));
+    await waitFor(() =>
+      expect(screen.getByTestId("err2").textContent).toBe("Invalid email")
+    );
+    // Default (no reValidateMode): post-submit onChange re-validates immediately.
+    fireEvent.change(input, { target: { value: "stillbad" } });
+    await waitFor(() =>
+      expect(screen.getByTestId("err2").textContent).toBe("Invalid email")
+    );
+  });
+});

--- a/packages/el-form-react-hooks/src/__tests__/valuesSync.runtime.test.tsx
+++ b/packages/el-form-react-hooks/src/__tests__/valuesSync.runtime.test.tsx
@@ -30,6 +30,9 @@ function makeApp() {
         <div data-testid="a">{form.formState.values.a ?? ""}</div>
         <div data-testid="b">{form.formState.values.b ?? ""}</div>
         <div data-testid="dirty">{String(form.formState.isDirty)}</div>
+        <div data-testid="dirtyFields">
+          {JSON.stringify(form.formState.dirtyFields)}
+        </div>
       </FormProvider>
     );
   }
@@ -39,6 +42,7 @@ function makeApp() {
 const a = () => screen.getByTestId("a").textContent;
 const b = () => screen.getByTestId("b").textContent;
 const dirty = () => screen.getByTestId("dirty").textContent;
+const dirtyFields = () => screen.getByTestId("dirtyFields").textContent;
 
 describe("useForm reactive `values`", () => {
   it("seeds initial values from `values` (precedence over defaultValues)", () => {
@@ -76,9 +80,12 @@ describe("useForm reactive `values`", () => {
       getApi().setValue("a", "edited");
     });
     expect(dirty()).toBe("true");
+    expect(JSON.parse(dirtyFields()!)).toEqual({ a: true });
     rerender(<App values={{ a: "2", b: "2" }} />);
     expect(a()).toBe("2"); // overwritten
     expect(dirty()).toBe("false");
+    // reactive dirtyFields must clear in lockstep with isDirty on overwrite-sync
+    expect(dirtyFields()).toBe("{}");
   });
 
   it("keepDirtyValues=true: preserves edited fields, syncs the rest", () => {

--- a/packages/el-form-react-hooks/src/types.ts
+++ b/packages/el-form-react-hooks/src/types.ts
@@ -55,6 +55,10 @@ export interface UseFormOptions<T extends Record<string, any>> {
   // Flexible validation timing
   validateOn?: "onChange" | "onBlur" | "onSubmit" | "manual";
 
+  // Opt-in: after the form is submitted, pin onChange/onBlur re-validation to a
+  // single event. Default (undefined) keeps the pre-submit timing unchanged.
+  reValidateMode?: "onChange" | "onBlur" | "onSubmit";
+
   // Zod schema for discriminated union support and enhanced validation
   schema?: any;
 

--- a/packages/el-form-react-hooks/src/types.ts
+++ b/packages/el-form-react-hooks/src/types.ts
@@ -23,6 +23,11 @@ export interface FormState<T extends Record<string, any>> {
   isSubmitSuccessful: boolean;
   /** Number of submit attempts. Reset by `reset()`. */
   submitCount: number;
+  /** True while any async validation is in flight. Reset by `reset()`. */
+  isValidating: boolean;
+  /** Per-field dirty map (flat, path-keyed) — the reactive twin of
+   *  `getDirtyFields()`. Reset by `reset()`. */
+  dirtyFields: Partial<Record<string, boolean>>;
 }
 
 export interface FormSnapshot<T extends Record<string, any>> {

--- a/packages/el-form-react-hooks/src/types.ts
+++ b/packages/el-form-react-hooks/src/types.ts
@@ -50,7 +50,7 @@ export interface UseFormOptions<T extends Record<string, any>> {
   fileValidators?: Partial<Record<keyof T, FileValidationOptions>>;
 
   // New validation mode (more flexible)
-  mode?: "onChange" | "onBlur" | "onSubmit" | "all";
+  mode?: "onChange" | "onBlur" | "onSubmit" | "all" | "onTouched";
 
   // Flexible validation timing
   validateOn?: "onChange" | "onBlur" | "onSubmit" | "manual";

--- a/packages/el-form-react-hooks/src/useForm.ts
+++ b/packages/el-form-react-hooks/src/useForm.ts
@@ -72,9 +72,11 @@ export function useForm<T extends Record<string, any>>(
     Partial<Record<keyof T, string | null>>
   >({});
 
-  // Tracks in-flight genuinely-async validations. `isValidating` is true while
-  // the counter is non-zero. Only the async validation entry points are wrapped
-  // (never the sync pass), so this never flips on a plain keystroke.
+  // Tracks in-flight validations. `isValidating` is true while the counter is
+  // non-zero. The onChange/onBlur keystroke paths wrap ONLY their async pass
+  // (`validateFieldAsync`), so a plain keystroke with no async validator never
+  // flips it. The explicit submit/`trigger()` actions wrap their whole
+  // validation pass (sync + async), so `isValidating` is briefly true there.
   const pendingValidationsRef = useRef(0);
   const runValidating = useCallback(
     async <R,>(fn: () => Promise<R>): Promise<R> => {
@@ -129,11 +131,13 @@ export function useForm<T extends Record<string, any>>(
       });
     } else {
       // Overwrite: the form now matches the new source of truth -> nothing dirty.
+      // Route through statePatch() (Set is now empty -> { isDirty: false,
+      // dirtyFields: {} }) so the reactive dirtyFields clears in lockstep.
       dirtyManager.clearDirtyState();
       setFormState((prev) => ({
         ...prev,
         values: { ...externalValues },
-        isDirty: false,
+        ...dirtyManager.statePatch(),
       }));
     }
   }, [externalValues, keepDirtyValues]);

--- a/packages/el-form-react-hooks/src/useForm.ts
+++ b/packages/el-form-react-hooks/src/useForm.ts
@@ -202,6 +202,16 @@ export function useForm<T extends Record<string, any>>(
         getNestedValue(formStateRef.current?.values || {}, name) ?? "";
       const isCheckbox = typeof fieldValue === "boolean";
 
+      // Build the latest shouldValidate context (touched + submitted) from the
+      // ref so onChange/onBlur read current state, not a stale render closure.
+      const validationCtx = (fieldPath: string) => ({
+        fieldTouched: !!getNestedValue(
+          formStateRef.current?.touched ?? {},
+          fieldPath
+        ),
+        isSubmitted: !!formStateRef.current?.isSubmitted,
+      });
+
       // Note: File input detection will be done via event.target.type in onChange
 
       const handleFileChange = async (
@@ -270,15 +280,7 @@ export function useForm<T extends Record<string, any>>(
         }
 
         // Run Zod validation if configured
-        if (
-          validationManager.shouldValidate("onChange", {
-            fieldTouched: !!getNestedValue(
-              formStateRef.current?.touched ?? {},
-              name
-            ),
-            isSubmitted: !!formStateRef.current?.isSubmitted,
-          })
-        ) {
+        if (validationManager.shouldValidate("onChange", validationCtx(name))) {
           const validationResult = await validationManager.validateField(
             fieldName,
             value,
@@ -370,13 +372,7 @@ export function useForm<T extends Record<string, any>>(
           // Use extracted validation utility
           const shouldValidateResult = validationManager.shouldValidate(
             "onChange",
-            {
-              fieldTouched: !!getNestedValue(
-                formStateRef.current?.touched ?? {},
-                name
-              ),
-              isSubmitted: !!formStateRef.current?.isSubmitted,
-            }
+            validationCtx(name)
           );
 
           if (shouldValidateResult) {
@@ -450,15 +446,7 @@ export function useForm<T extends Record<string, any>>(
             return { ...prev, touched: newTouched };
           });
 
-          if (
-            validationManager.shouldValidate("onBlur", {
-              fieldTouched: !!getNestedValue(
-                formStateRef.current?.touched ?? {},
-                name
-              ),
-              isSubmitted: !!formStateRef.current?.isSubmitted,
-            })
-          ) {
+          if (validationManager.shouldValidate("onBlur", validationCtx(name))) {
             const currentState = formStateRef.current!;
             const blurValue = currentState.values[fieldName];
             const result = await validationManager.validateField(

--- a/packages/el-form-react-hooks/src/useForm.ts
+++ b/packages/el-form-react-hooks/src/useForm.ts
@@ -62,6 +62,8 @@ export function useForm<T extends Record<string, any>>(
     isSubmitted: false,
     isSubmitSuccessful: false,
     submitCount: 0,
+    isValidating: false,
+    dirtyFields: {},
   });
 
   // Separate state for file previews
@@ -565,6 +567,8 @@ export function useForm<T extends Record<string, any>>(
         isSubmitted: false,
         isSubmitSuccessful: false,
         submitCount: 0,
+        isValidating: false,
+        dirtyFields: {},
       });
 
       // Clear file previews on reset

--- a/packages/el-form-react-hooks/src/useForm.ts
+++ b/packages/el-form-react-hooks/src/useForm.ts
@@ -259,7 +259,7 @@ export function useForm<T extends Record<string, any>>(
           ...prev,
           values: newValues,
           errors: newErrors,
-          isDirty: dirtyFieldsRef.current.size > 0,
+          ...dirtyManager.statePatch(),
         }));
       };
 
@@ -327,7 +327,7 @@ export function useForm<T extends Record<string, any>>(
               ...prev,
               values: newValues,
               errors: newErrors,
-              isDirty: dirtyFieldsRef.current.size > 0,
+              ...dirtyManager.statePatch(),
             };
           });
 

--- a/packages/el-form-react-hooks/src/useForm.ts
+++ b/packages/el-form-react-hooks/src/useForm.ts
@@ -71,6 +71,30 @@ export function useForm<T extends Record<string, any>>(
     Partial<Record<keyof T, string | null>>
   >({});
 
+  // Tracks in-flight genuinely-async validations. `isValidating` is true while
+  // the counter is non-zero. Only the async validation entry points are wrapped
+  // (never the sync pass), so this never flips on a plain keystroke.
+  const pendingValidationsRef = useRef(0);
+  const runValidating = useCallback(
+    async <R,>(fn: () => Promise<R>): Promise<R> => {
+      if (++pendingValidationsRef.current === 1) {
+        setFormState((prev) =>
+          prev.isValidating ? prev : { ...prev, isValidating: true }
+        );
+      }
+      try {
+        return await fn();
+      } finally {
+        if (--pendingValidationsRef.current === 0) {
+          setFormState((prev) =>
+            prev.isValidating ? { ...prev, isValidating: false } : prev
+          );
+        }
+      }
+    },
+    []
+  );
+
   // Compute canSubmit directly as a derived value
   const canSubmit = formState.isValid && !formState.isSubmitting;
 
@@ -142,12 +166,14 @@ export function useForm<T extends Record<string, any>>(
     onSubmit,
     fieldRefs,
     shouldFocusError,
+    runValidating,
   });
 
   const errorManagement = createErrorManagementManager<T>({
     formState,
     setFormState,
     validationManager,
+    runValidating,
   });
 
   const formHistory = createFormHistoryManager<T>({
@@ -380,8 +406,9 @@ export function useForm<T extends Record<string, any>>(
               const latestValues = name.includes(".")
                 ? setNestedValue(formStateRef.current?.values ?? {}, name, value)
                 : { ...(formStateRef.current?.values ?? {}), [name]: value };
-              void validationManager
-                .validateFieldAsync(fieldName, value, latestValues, "onChange")
+              void runValidating(() =>
+                validationManager.validateFieldAsync(fieldName, value, latestValues, "onChange")
+              )
                 .then((asyncResult) => {
                   // stale guard: drop the result if the field changed since
                   if (getNestedValue(formStateRef.current?.values ?? {}, name) !== value) return;
@@ -392,7 +419,8 @@ export function useForm<T extends Record<string, any>>(
                     const isValid = Object.values(newErrors).every((e) => !e);
                     return { ...prev, errors: newErrors, isValid };
                   });
-                });
+                })
+                .catch(() => {}); // rejecting async validator → unhandled-rejection guard; runValidating's finally still resets the flag
             }
           }
         },
@@ -427,8 +455,9 @@ export function useForm<T extends Record<string, any>>(
               const latestValues = name.includes(".")
                 ? setNestedValue(formStateRef.current?.values ?? {}, name, blurValue)
                 : { ...(formStateRef.current?.values ?? {}), [name]: blurValue };
-              void validationManager
-                .validateFieldAsync(fieldName, blurValue, latestValues, "onBlur")
+              void runValidating(() =>
+                validationManager.validateFieldAsync(fieldName, blurValue, latestValues, "onBlur")
+              )
                 .then((asyncResult) => {
                   // stale guard: drop the result if the field changed since
                   if (getNestedValue(formStateRef.current?.values ?? {}, name) !== blurValue) return;
@@ -439,7 +468,8 @@ export function useForm<T extends Record<string, any>>(
                     const isValid = Object.values(newErrors).every((e) => !e);
                     return { ...prev, errors: newErrors, isValid };
                   });
-                });
+                })
+                .catch(() => {}); // rejecting async validator → unhandled-rejection guard; runValidating's finally still resets the flag
             }
           }
         },
@@ -470,6 +500,7 @@ export function useForm<T extends Record<string, any>>(
       validationManager,
       fileValidators,
       formState.values,
+      runValidating,
     ]
   );
 

--- a/packages/el-form-react-hooks/src/useForm.ts
+++ b/packages/el-form-react-hooks/src/useForm.ts
@@ -268,7 +268,14 @@ export function useForm<T extends Record<string, any>>(
         }
 
         // Run Zod validation if configured
-        if (validationManager.shouldValidate("onChange")) {
+        if (
+          validationManager.shouldValidate("onChange", {
+            fieldTouched: !!getNestedValue(
+              formStateRef.current?.touched ?? {},
+              name
+            ),
+          })
+        ) {
           const validationResult = await validationManager.validateField(
             fieldName,
             value,
@@ -358,8 +365,15 @@ export function useForm<T extends Record<string, any>>(
           });
 
           // Use extracted validation utility
-          const shouldValidateResult =
-            validationManager.shouldValidate("onChange");
+          const shouldValidateResult = validationManager.shouldValidate(
+            "onChange",
+            {
+              fieldTouched: !!getNestedValue(
+                formStateRef.current?.touched ?? {},
+                name
+              ),
+            }
+          );
 
           if (shouldValidateResult) {
             // Use formStateRef.current to avoid stale closure in async validation
@@ -432,7 +446,14 @@ export function useForm<T extends Record<string, any>>(
             return { ...prev, touched: newTouched };
           });
 
-          if (validationManager.shouldValidate("onBlur")) {
+          if (
+            validationManager.shouldValidate("onBlur", {
+              fieldTouched: !!getNestedValue(
+                formStateRef.current?.touched ?? {},
+                name
+              ),
+            })
+          ) {
             const currentState = formStateRef.current!;
             const blurValue = currentState.values[fieldName];
             const result = await validationManager.validateField(

--- a/packages/el-form-react-hooks/src/useForm.ts
+++ b/packages/el-form-react-hooks/src/useForm.ts
@@ -37,6 +37,7 @@ export function useForm<T extends Record<string, any>>(
     fileValidators = {},
     mode = "onSubmit",
     validateOn,
+    reValidateMode,
     onSubmit,
     schema,
     shouldFocusError,
@@ -142,6 +143,7 @@ export function useForm<T extends Record<string, any>>(
     fieldValidators,
     mode,
     validateOn,
+    reValidateMode,
     schema, // Pass schema for discriminated union validation
   });
 
@@ -274,6 +276,7 @@ export function useForm<T extends Record<string, any>>(
               formStateRef.current?.touched ?? {},
               name
             ),
+            isSubmitted: !!formStateRef.current?.isSubmitted,
           })
         ) {
           const validationResult = await validationManager.validateField(
@@ -372,6 +375,7 @@ export function useForm<T extends Record<string, any>>(
                 formStateRef.current?.touched ?? {},
                 name
               ),
+              isSubmitted: !!formStateRef.current?.isSubmitted,
             }
           );
 
@@ -452,6 +456,7 @@ export function useForm<T extends Record<string, any>>(
                 formStateRef.current?.touched ?? {},
                 name
               ),
+              isSubmitted: !!formStateRef.current?.isSubmitted,
             })
           ) {
             const currentState = formStateRef.current!;

--- a/packages/el-form-react-hooks/src/useForm.ts
+++ b/packages/el-form-react-hooks/src/useForm.ts
@@ -557,18 +557,21 @@ export function useForm<T extends Record<string, any>>(
         dirtyManager.clearDirtyState();
       }
 
+      const dirtyPatch = options?.keepDirty
+        ? dirtyManager.statePatch()
+        : { isDirty: false, dirtyFields: {} };
+
       setFormState({
         values: newValues,
         errors: options?.keepErrors ? formState.errors : {},
         touched: options?.keepTouched ? formState.touched : {},
         isSubmitting: false,
         isValid: false,
-        isDirty: options?.keepDirty ? formState.isDirty : false,
         isSubmitted: false,
         isSubmitSuccessful: false,
         submitCount: 0,
         isValidating: false,
-        dirtyFields: {},
+        ...dirtyPatch,
       });
 
       // Clear file previews on reset

--- a/packages/el-form-react-hooks/src/utils/__tests__/formHistory.test.ts
+++ b/packages/el-form-react-hooks/src/utils/__tests__/formHistory.test.ts
@@ -45,6 +45,8 @@ function makeState(
     isSubmitted: false,
     isSubmitSuccessful: false,
     submitCount: 0,
+    isValidating: false,
+    dirtyFields: {},
     ...overrides,
   };
 }

--- a/packages/el-form-react-hooks/src/utils/__tests__/formState.test.ts
+++ b/packages/el-form-react-hooks/src/utils/__tests__/formState.test.ts
@@ -29,7 +29,11 @@ function createStateHarness<T extends Record<string, any>>(
 const createManager = (
   initial: Omit<
     FormState<TestValues>,
-    "isSubmitted" | "isSubmitSuccessful" | "submitCount"
+    | "isSubmitted"
+    | "isSubmitSuccessful"
+    | "submitCount"
+    | "isValidating"
+    | "dirtyFields"
   >,
   defaultValues: Partial<TestValues> = initial.values
 ) => {
@@ -37,6 +41,8 @@ const createManager = (
     isSubmitted: false,
     isSubmitSuccessful: false,
     submitCount: 0,
+    isValidating: false,
+    dirtyFields: {},
     ...initial,
   };
   const harness = createStateHarness(initialState);
@@ -138,6 +144,8 @@ describe("createFormStateManager", () => {
       isSubmitted: false,
       isSubmitSuccessful: false,
       submitCount: 0,
+      isValidating: false,
+      dirtyFields: {},
     });
     expect(dirtyManager.dirtyFieldsRef.current.size).toBe(0);
   });

--- a/packages/el-form-react-hooks/src/utils/arrayOperations.ts
+++ b/packages/el-form-react-hooks/src/utils/arrayOperations.ts
@@ -21,14 +21,14 @@ export function createArrayOperationsManager<T extends Record<string, any>>(
       setFormState((prev) => {
         const newValues = appendItem(prev.values, path, item);
         dirtyManager.addDirtyField(path);
-        return { ...prev, values: newValues, isDirty: true };
+        return { ...prev, values: newValues, ...dirtyManager.statePatch() };
       });
     },
     removeArrayItem: (path: string, index: number) => {
       setFormState((prev) => {
         const newValues = removeItemAt(prev.values, path, index);
         dirtyManager.addDirtyField(path);
-        return { ...prev, values: newValues, isDirty: true };
+        return { ...prev, values: newValues, ...dirtyManager.statePatch() };
       });
     },
   };

--- a/packages/el-form-react-hooks/src/utils/dirtyState.ts
+++ b/packages/el-form-react-hooks/src/utils/dirtyState.ts
@@ -25,6 +25,8 @@ export interface DirtyStateManager<T extends Record<string, any>> {
   clearDirtyState: () => void;
   removeDirtyField: (fieldName: string) => void;
   addDirtyField: (fieldName: string) => void;
+  toRecord: () => Record<string, boolean>;
+  statePatch: () => { isDirty: boolean; dirtyFields: Record<string, boolean> };
 }
 
 /**
@@ -101,5 +103,27 @@ export function createDirtyStateManager<T extends Record<string, any>>(
     addDirtyField: (fieldName: string): void => {
       dirtyFieldsRef.current.add(fieldName);
     },
+
+    // Snapshot the dirty Set as a `{ path: true }` record
+    toRecord: (): Record<string, boolean> => {
+      const out: Record<string, boolean> = {};
+      dirtyFieldsRef.current.forEach((path) => {
+        out[path] = true;
+      });
+      return out;
+    },
+
+    // Paired write helper: keep `isDirty` and `dirtyFields` consistent by
+    // deriving both from the same dirty Set in a single call. Implemented
+    // self-contained (does not call `toRecord`) to avoid `this`-binding
+    // issues on this object literal.
+    statePatch: () => ({
+      isDirty: dirtyFieldsRef.current.size > 0,
+      dirtyFields: (() => {
+        const out: Record<string, boolean> = {};
+        dirtyFieldsRef.current.forEach((p) => (out[p] = true));
+        return out;
+      })(),
+    }),
   };
 }

--- a/packages/el-form-react-hooks/src/utils/dirtyState.ts
+++ b/packages/el-form-react-hooks/src/utils/dirtyState.ts
@@ -35,6 +35,14 @@ export interface DirtyStateManager<T extends Record<string, any>> {
 export function createDirtyStateManager<T extends Record<string, any>>(
   dirtyFieldsRef: React.MutableRefObject<Set<string>>
 ): DirtyStateManager<T> {
+  // Module-private helper: snapshot the dirty Set as a `{ path: true }` record.
+  // Shared by `toRecord` and `statePatch` to avoid duplicating the loop.
+  const snapshot = (): Record<string, boolean> => {
+    const out: Record<string, boolean> = {};
+    dirtyFieldsRef.current.forEach((p) => (out[p] = true));
+    return out;
+  };
+
   return {
     dirtyFieldsRef,
 
@@ -105,25 +113,14 @@ export function createDirtyStateManager<T extends Record<string, any>>(
     },
 
     // Snapshot the dirty Set as a `{ path: true }` record
-    toRecord: (): Record<string, boolean> => {
-      const out: Record<string, boolean> = {};
-      dirtyFieldsRef.current.forEach((path) => {
-        out[path] = true;
-      });
-      return out;
-    },
+    toRecord: snapshot,
 
     // Paired write helper: keep `isDirty` and `dirtyFields` consistent by
-    // deriving both from the same dirty Set in a single call. Implemented
-    // self-contained (does not call `toRecord`) to avoid `this`-binding
-    // issues on this object literal.
+    // deriving both from the same dirty Set in a single call. Shares the
+    // module-private `snapshot` helper to avoid duplicating the loop.
     statePatch: () => ({
       isDirty: dirtyFieldsRef.current.size > 0,
-      dirtyFields: (() => {
-        const out: Record<string, boolean> = {};
-        dirtyFieldsRef.current.forEach((p) => (out[p] = true));
-        return out;
-      })(),
+      dirtyFields: snapshot(),
     }),
   };
 }

--- a/packages/el-form-react-hooks/src/utils/errorManagement.ts
+++ b/packages/el-form-react-hooks/src/utils/errorManagement.ts
@@ -16,6 +16,7 @@ export interface ErrorManagementOptions<T extends Record<string, any>> {
   formState: FormState<T>;
   setFormState: React.Dispatch<React.SetStateAction<FormState<T>>>;
   validationManager: ValidationManager<T>;
+  runValidating?: <R>(fn: () => Promise<R>) => Promise<R>;
 }
 
 /**
@@ -25,6 +26,9 @@ export function createErrorManagementManager<T extends Record<string, any>>(
   options: ErrorManagementOptions<T>
 ): ErrorManagementManager<T> {
   const { formState, setFormState, validationManager } = options;
+  // Default to pass-through so directly-constructed test managers are unaffected.
+  const run =
+    options.runValidating ?? (<R,>(fn: () => Promise<R>) => fn());
 
   return {
     // Clear errors
@@ -52,7 +56,8 @@ export function createErrorManagementManager<T extends Record<string, any>>(
     },
 
     // Manual validation trigger
-    trigger: (async (nameOrNames?: keyof T | (keyof T)[]) => {
+    trigger: ((nameOrNames?: keyof T | (keyof T)[]) =>
+      run(async () => {
       // Validate all fields
       if (!nameOrNames) {
         const { isValid, errors } = await validationManager.validateForm(
@@ -172,6 +177,6 @@ export function createErrorManagementManager<T extends Record<string, any>>(
         };
       });
       return finalValid;
-    }) as UseFormReturn<T>["trigger"],
+      })) as UseFormReturn<T>["trigger"],
   };
 }

--- a/packages/el-form-react-hooks/src/utils/fieldOperations.ts
+++ b/packages/el-form-react-hooks/src/utils/fieldOperations.ts
@@ -145,7 +145,7 @@ export function createFieldOperationsManager<T extends Record<string, any>>(
           values: newValues,
           errors: newErrors,
           touched: newTouched,
-          isDirty: dirtyManager.dirtyFieldsRef.current.size > 0,
+          ...dirtyManager.statePatch(),
         };
       });
     },

--- a/packages/el-form-react-hooks/src/utils/formHistory.ts
+++ b/packages/el-form-react-hooks/src/utils/formHistory.ts
@@ -133,6 +133,8 @@ export function createFormHistoryManager<T extends Record<string, any>>(
         isSubmitted: false,
         isSubmitSuccessful: false,
         submitCount: 0,
+        isValidating: false,
+        dirtyFields: {},
       });
     },
 

--- a/packages/el-form-react-hooks/src/utils/formHistory.ts
+++ b/packages/el-form-react-hooks/src/utils/formHistory.ts
@@ -129,12 +129,11 @@ export function createFormHistoryManager<T extends Record<string, any>>(
         touched,
         isSubmitting: false,
         isValid: Object.keys(errors).length === 0,
-        isDirty: dirtyManager.dirtyFieldsRef.current.size > 0,
         isSubmitted: false,
         isSubmitSuccessful: false,
         submitCount: 0,
         isValidating: false,
-        dirtyFields: {},
+        ...dirtyManager.statePatch(),
       });
     },
 

--- a/packages/el-form-react-hooks/src/utils/formState.ts
+++ b/packages/el-form-react-hooks/src/utils/formState.ts
@@ -89,6 +89,8 @@ export function createFormStateManager<T extends Record<string, any>>(
         isSubmitted: false,
         isSubmitSuccessful: false,
         submitCount: 0,
+        isValidating: false,
+        dirtyFields: {},
       });
     },
 

--- a/packages/el-form-react-hooks/src/utils/formState.ts
+++ b/packages/el-form-react-hooks/src/utils/formState.ts
@@ -38,7 +38,7 @@ export function createFormStateManager<T extends Record<string, any>>(
       setFormState((prev) => ({
         ...prev,
         values: setNestedValue(prev.values, path, value),
-        isDirty: dirtyManager.dirtyFieldsRef.current.size > 0,
+        ...dirtyManager.statePatch(),
       }));
     },
 
@@ -54,7 +54,7 @@ export function createFormStateManager<T extends Record<string, any>>(
         return {
           ...prev,
           values: newValues,
-          isDirty: dirtyManager.dirtyFieldsRef.current.size > 0,
+          ...dirtyManager.statePatch(),
         };
       });
     },
@@ -68,7 +68,7 @@ export function createFormStateManager<T extends Record<string, any>>(
       setFormState((prev) => ({
         ...prev,
         values: { ...prev.values, ...values },
-        isDirty: dirtyManager.dirtyFieldsRef.current.size > 0,
+        ...dirtyManager.statePatch(),
       }));
     },
 

--- a/packages/el-form-react-hooks/src/utils/submitOperations.ts
+++ b/packages/el-form-react-hooks/src/utils/submitOperations.ts
@@ -25,6 +25,7 @@ export interface SubmitOperationsOptions<T extends Record<string, any>> {
     Map<keyof T, HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
   >;
   shouldFocusError?: boolean;
+  runValidating?: <R>(fn: () => Promise<R>) => Promise<R>;
 }
 
 /**
@@ -41,6 +42,9 @@ export function createSubmitOperationsManager<T extends Record<string, any>>(
     fieldRefs,
     shouldFocusError,
   } = options;
+  // Default to pass-through so directly-constructed test managers are unaffected.
+  const run =
+    options.runValidating ?? (<R,>(fn: () => Promise<R>) => fn());
 
   return {
     // Handle submit - simplified
@@ -58,25 +62,27 @@ export function createSubmitOperationsManager<T extends Record<string, any>>(
         isSubmitSuccessful: false,
       }));
 
-        const { isValid, errors } = await validationManager.validateForm(
-          formState.values
-        );
-
         // Blocking async validation pass: only runs when sync validation passed
         // (keeps it consistent with the onChange/onBlur gate). A failing async
         // rule blocks submission and merges its errors into the written state.
-        let finalValid = isValid;
-        let finalErrors = errors;
-        if (finalValid) {
-          const asyncResult = await validationManager.validateFormAsync(
-            formState.values,
-            "onSubmit"
+        const { finalValid, finalErrors } = await run(async () => {
+          const { isValid, errors } = await validationManager.validateForm(
+            formState.values
           );
-          if (!asyncResult.isValid) {
-            finalValid = false;
-            finalErrors = { ...finalErrors, ...asyncResult.errors };
+          let v = isValid;
+          let e = errors;
+          if (v) {
+            const a = await validationManager.validateFormAsync(
+              formState.values,
+              "onSubmit"
+            );
+            if (!a.isValid) {
+              v = false;
+              e = { ...e, ...a.errors };
+            }
           }
-        }
+          return { finalValid: v, finalErrors: e };
+        });
 
         setFormState((prev) => ({
           ...prev,
@@ -129,24 +135,26 @@ export function createSubmitOperationsManager<T extends Record<string, any>>(
       }));
 
       try {
-        // Always validate before submitting
-        const { isValid, errors } = await validationManager.validateForm(
-          formState.values
-        );
-
+        // Always validate before submitting.
         // Blocking async validation pass: only runs when sync validation passed.
-        let finalValid = isValid;
-        let finalErrors = errors;
-        if (finalValid) {
-          const asyncResult = await validationManager.validateFormAsync(
-            formState.values,
-            "onSubmit"
+        const { finalValid, finalErrors } = await run(async () => {
+          const { isValid, errors } = await validationManager.validateForm(
+            formState.values
           );
-          if (!asyncResult.isValid) {
-            finalValid = false;
-            finalErrors = { ...finalErrors, ...asyncResult.errors };
+          let v = isValid;
+          let e = errors;
+          if (v) {
+            const a = await validationManager.validateFormAsync(
+              formState.values,
+              "onSubmit"
+            );
+            if (!a.isValid) {
+              v = false;
+              e = { ...e, ...a.errors };
+            }
           }
-        }
+          return { finalValid: v, finalErrors: e };
+        });
 
         setFormState((prev) => ({
           ...prev,
@@ -176,24 +184,26 @@ export function createSubmitOperationsManager<T extends Record<string, any>>(
       }));
 
       try {
-        // Always validate before submitting
-        const { isValid, errors } = await validationManager.validateForm(
-          formState.values
-        );
-
+        // Always validate before submitting.
         // Blocking async validation pass: only runs when sync validation passed.
-        let finalValid = isValid;
-        let finalErrors = errors;
-        if (finalValid) {
-          const asyncResult = await validationManager.validateFormAsync(
-            formState.values,
-            "onSubmit"
+        const { finalValid, finalErrors } = await run(async () => {
+          const { isValid, errors } = await validationManager.validateForm(
+            formState.values
           );
-          if (!asyncResult.isValid) {
-            finalValid = false;
-            finalErrors = { ...finalErrors, ...asyncResult.errors };
+          let v = isValid;
+          let e = errors;
+          if (v) {
+            const a = await validationManager.validateFormAsync(
+              formState.values,
+              "onSubmit"
+            );
+            if (!a.isValid) {
+              v = false;
+              e = { ...e, ...a.errors };
+            }
           }
-        }
+          return { finalValid: v, finalErrors: e };
+        });
 
         setFormState((prev) => ({
           ...prev,

--- a/packages/el-form-react-hooks/src/utils/validation.ts
+++ b/packages/el-form-react-hooks/src/utils/validation.ts
@@ -60,6 +60,7 @@ export interface ValidationManagerOptions<T extends Record<string, any>> {
   fieldValidators: Partial<Record<keyof T, ValidatorConfig>>;
   mode: "onChange" | "onBlur" | "onSubmit" | "all" | "onTouched";
   validateOn?: "onChange" | "onBlur" | "onSubmit" | "manual";
+  reValidateMode?: "onChange" | "onBlur" | "onSubmit";
   schema?: z.ZodTypeAny;
 }
 
@@ -75,6 +76,7 @@ export function createValidationManager<T extends Record<string, any>>(
     fieldValidators,
     mode,
     validateOn,
+    reValidateMode,
     schema,
   } = options;
 
@@ -114,7 +116,12 @@ export function createValidationManager<T extends Record<string, any>>(
       // Submit always validates.
       if (eventType === "onSubmit") return true;
 
-      // NOTE: Task 5 inserts the `reValidateMode` branch here (uses ctx.isSubmitted).
+      // Opt-in re-validation timing: once the form has been submitted, the caller
+      // can pin onChange/onBlur re-validation to a single event. Only active when
+      // `reValidateMode` is set AND the form is already submitted.
+      if (reValidateMode && ctx.isSubmitted) {
+        return eventType === reValidateMode;
+      }
 
       // Smart validation: if validators has the specific event, enable it
       // regardless of mode — except under `onTouched`, where an onChange on an

--- a/packages/el-form-react-hooks/src/utils/validation.ts
+++ b/packages/el-form-react-hooks/src/utils/validation.ts
@@ -25,7 +25,10 @@ export interface ValidationManager<T extends Record<string, any>> {
     eventType?: "onChange" | "onBlur" | "onSubmit"
   ) => Promise<{ isValid: boolean; errors: Record<keyof T, string> }>;
 
-  shouldValidate: (eventType: "onChange" | "onBlur" | "onSubmit") => boolean;
+  shouldValidate: (
+    eventType: "onChange" | "onBlur" | "onSubmit",
+    ctx?: { fieldTouched?: boolean; isSubmitted?: boolean }
+  ) => boolean;
 
   hasAsyncValidator: (
     fieldName: keyof T,
@@ -55,7 +58,7 @@ export interface ValidationManagerOptions<T extends Record<string, any>> {
   validationEngine: React.MutableRefObject<ValidationEngine>;
   validators: ValidatorConfig;
   fieldValidators: Partial<Record<keyof T, ValidatorConfig>>;
-  mode: "onChange" | "onBlur" | "onSubmit" | "all";
+  mode: "onChange" | "onBlur" | "onSubmit" | "all" | "onTouched";
   validateOn?: "onChange" | "onBlur" | "onSubmit" | "manual";
   schema?: z.ZodTypeAny;
 }
@@ -97,7 +100,8 @@ export function createValidationManager<T extends Record<string, any>>(
   return {
     // Determine if validation should run based on mode and validateOn option
     shouldValidate: (
-      eventType: "onChange" | "onBlur" | "onSubmit"
+      eventType: "onChange" | "onBlur" | "onSubmit",
+      ctx: { fieldTouched?: boolean; isSubmitted?: boolean } = {}
     ): boolean => {
       // New validateOn option takes precedence
       if (validateOn) {
@@ -107,16 +111,28 @@ export function createValidationManager<T extends Record<string, any>>(
         return false;
       }
 
-      // Smart validation: if validators has the specific event, enable it regardless of mode
+      // Submit always validates.
+      if (eventType === "onSubmit") return true;
+
+      // NOTE: Task 5 inserts the `reValidateMode` branch here (uses ctx.isSubmitted).
+
+      // Smart validation: if validators has the specific event, enable it
+      // regardless of mode — except under `onTouched`, where an onChange on an
+      // untouched field is suppressed until the field has been touched.
       const hasValidatorForEvent = validators && (validators as any)[eventType];
       if (hasValidatorForEvent) {
+        if (mode === "onTouched" && eventType === "onChange" && !ctx.fieldTouched)
+          return false;
         return true;
       }
 
       // Fallback to mode
-      if (mode === "all") return true;
+      if (mode === "all") return eventType === "onChange" || eventType === "onBlur";
+      if (mode === "onTouched") {
+        if (eventType === "onBlur") return true;
+        return !!ctx.fieldTouched;
+      }
       if (mode === eventType) return true;
-      if (eventType === "onSubmit") return true; // Always validate on submit
 
       return false;
     },


### PR DESCRIPTION
RHF-parity polish for `el-form-react-hooks` — four additive, backward-compatible features. A form that uses none of them behaves exactly as before.

## Features

| Feature | Behavior |
|---|---|
| `formState.isValidating` | `true` while validation is in flight. onChange/onBlur wrap only their async pass (`validateFieldAsync`); `submit`/`handleSubmit`/`trigger()` wrap the whole validation pass. Counter-based (`pendingValidationsRef` + `runValidating`), reset by `reset()`. |
| reactive `formState.dirtyFields` | Flat path-keyed `Partial<Record<string, boolean>>` (e.g. `{ "profile.name": true }`) — the reactive twin of `getDirtyFields()`. Written in lockstep with `isDirty` via a single `dirtyState.statePatch()` helper that replaces the ad-hoc `isDirty: size>0` writes, so the two can never drift. |
| `mode: "onTouched"` | Validate a field on its first blur, then on every change once touched. |
| opt-in `reValidateMode` | `"onChange" \| "onBlur" \| "onSubmit"`. Once the form has been submitted, pins post-submit re-validation to the chosen event. Default `undefined` = unchanged. `validateOn` overrides it. |

`shouldValidate` precedence (final): `validateOn` > `onSubmit` > `reValidateMode` (when submitted) > smart-validation (with the `onTouched` gate) > `mode`.

## Notes
- Built on top of the async-validation-dispatch fix (#90); the branch was rebased onto it and the `isValidating` task rewritten to wrap the new async methods rather than the sync pass (which would flicker the flag on every keystroke).
- Final whole-branch review caught one integration bug: the external-`values` overwrite sync cleared `isDirty` but left the new reactive `dirtyFields` stale — the one write site not routed through `statePatch()`. Fixed (6cdd5c2) with a regression test.

## Testing
- **154/154** hooks tests pass (new: `formstate-completeness`, `isValidating`, `onTouched`, `reValidateMode`, + strengthened `valuesSync`). All TDD, each new test verified to fail without its implementation.
- Lint clean · `build:packages` success (new fields confirmed in `dist/index.d.ts`) · docs build passes.
- Docs updated (form-state, use-form, llms.txt/llms-full.txt, changelog) and accuracy-reviewed against source.
- Changeset: `el-form-react-hooks` **minor**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)