### PR TITLE
docs: load el-form CSS + live themed AutoForm showcase

### DIFF
--- a/docs/docs/guides/styling-and-themes.md
+++ b/docs/docs/guides/styling-and-themes.md
@@ -10,6 +10,8 @@ keywords:
   - tailwind-free forms
 ---
 
+import { ThemeShowcase } from "@site/src/components/examples/ThemeShowcase";
+
 # Styling & Themes
 
 `AutoForm` ships with hand-authored, **Tailwind-free** CSS. The base styles are
@@ -55,6 +57,13 @@ Pass the `theme` prop. There are three official values:
 The prop sets a `data-el-form-theme` attribute on the form container, and the
 theme's variable block is already bundled in the shipped `styles.css` — there's
 **nothing extra to import**.
+
+### See the themes live
+
+These are real `AutoForm`s rendered from the same schema, one per theme, plus a
+`classNames` override — exactly what you get from the snippets above:
+
+<ThemeShowcase />
 
 ## 3. Restyle with `classNames` slots
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,6 +26,7 @@
     "clsx": "^2.0.0",
     "el-form-core": "workspace:^",
     "el-form-react": "workspace:^",
+    "el-form-react-components": "workspace:^",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/docs/src/components/examples/ThemeShowcase.tsx
+++ b/docs/src/components/examples/ThemeShowcase.tsx
@@ -1,0 +1,100 @@
+import BrowserOnly from "@docusaurus/BrowserOnly";
+import { AutoForm } from "el-form-react";
+import { z } from "zod";
+
+// A small schema covering a few field types so the themes have something to
+// render: text, email, a <select> (enum), an optional <textarea>, and a
+// checkbox.
+const schema = z.object({
+  name: z.string().min(2),
+  email: z.string().email(),
+  role: z.enum(["admin", "user", "guest"]),
+  bio: z.string().optional(),
+  subscribe: z.boolean().optional(),
+});
+
+// No-op submit handler — this showcase is about appearance, not behavior.
+const noop = () => {};
+
+/**
+ * ThemeShowcase renders the SAME schema through AutoForm once per official
+ * theme, plus a `classNames` override demo, so readers can see the live themes
+ * on the page.
+ *
+ * Wrapped in <BrowserOnly> because Docusaurus server-renders pages and
+ * AutoForm's file-field detection references `FileList`, which is not defined
+ * in the Node SSR environment.
+ */
+export function ThemeShowcase() {
+  return (
+    <BrowserOnly
+      fallback={
+        <p>
+          <em>Loading live theme previews…</em>
+        </p>
+      }
+    >
+      {() => (
+        <div style={{ display: "grid", gap: "2.5rem", marginTop: "1.5rem" }}>
+          {/* Default theme */}
+          <section>
+            <h4>Default theme</h4>
+            <p>
+              The shipped light theme — same as omitting the <code>theme</code>{" "}
+              prop.
+            </p>
+            <AutoForm schema={schema} theme="default" onSubmit={noop} />
+          </section>
+
+          {/* Dark theme — rendered on a dark surface so it's visible on the
+              light docs page. */}
+          <section>
+            <h4>Dark theme</h4>
+            <p>
+              <code>theme="dark"</code>, shown on a dark background so the
+              dark-surface styling reads correctly.
+            </p>
+            <div
+              style={{
+                background: "#0b1220",
+                padding: "1.5rem",
+                borderRadius: "0.75rem",
+              }}
+            >
+              <AutoForm schema={schema} theme="dark" onSubmit={noop} />
+            </div>
+          </section>
+
+          {/* Minimal theme */}
+          <section>
+            <h4>Minimal theme</h4>
+            <p>
+              <code>theme="minimal"</code> — a flatter, lower-chrome variant.
+            </p>
+            <AutoForm schema={schema} theme="minimal" onSubmit={noop} />
+          </section>
+
+          {/* classNames override — proves the cascade: an unlayered class
+              appended via classNames beats the layered base styles. */}
+          <section>
+            <h4>
+              <code>classNames</code> override
+            </h4>
+            <p>
+              Appending a custom class through <code>classNames</code> (here{" "}
+              <code>submitButton</code>) overrides the base styling without
+              specificity wars — unlayered CSS always beats the{" "}
+              <code>@layer el-form</code> base.
+            </p>
+            <style>{".ts-custom-submit{background:#7c3aed}"}</style>
+            <AutoForm
+              schema={schema}
+              onSubmit={noop}
+              classNames={{ submitButton: "ts-custom-submit" }}
+            />
+          </section>
+        </div>
+      )}
+    </BrowserOnly>
+  );
+}

--- a/docs/src/components/examples/index.ts
+++ b/docs/src/components/examples/index.ts
@@ -39,6 +39,9 @@ export {
 // Quick Start example
 export { QuickStartExample } from "./QuickStartExample";
 
+// Styling & Themes live showcase
+export { ThemeShowcase } from "./ThemeShowcase";
+
 export * from "./UseFormArraysExample";
 export * from "./FormExamples";
 

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -1,3 +1,11 @@
+/* Load el-form's shipped, Tailwind-free CSS so the docs site's LIVE AutoForm
+   examples render styled. This is el-form-react-components/styles.css (the
+   canonical stylesheet with .el-form-* classes, @layer el-form, --el-form-*
+   tokens, and [data-el-form-theme] blocks). Do NOT use el-form-react/styles.css
+   — that copy is stale (old class names). Imported first so Tailwind (loaded
+   via src/tailwind.css) stays last in the cascade. */
+@import "el-form-react-components/styles.css";
+
 /* Essential Docusaurus overrides only */
 
 /* Define CSS custom properties that automatically change with theme */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       el-form-react:
         specifier: workspace:^
         version: link:../packages/el-form-react
+      el-form-react-components:
+        specifier: workspace:^
+        version: link:../packages/el-form-react-components
       prism-react-renderer:
         specifier: ^2.3.0
         version: 2.4.1(react@18.3.1)


### PR DESCRIPTION
Adds live, interactive themed example forms to the **Styling & Themes** guide, and fixes a styling regression in the docs.

## What
- **Live themed showcase** (`ThemeShowcase.tsx`, embedded in the styling guide): the same AutoForm rendered in `default` / `dark` / `minimal` themes + a `classNames` override demo (purple submit, proving an unlayered class beats the `@layer el-form` base). Renders from the workspace source — works immediately at localhost and after deploy, not gated on the npm publish.
- **Regression fix:** the docs site never imported el-form's CSS. Now that AutoForm emits semantic `.el-form-*` classes (Tailwind-free), every live AutoForm example in the docs (`auto-form`, `quick-start`, etc.) had silently gone unstyled. The docs now import `el-form-react-components/styles.css` globally (via `custom.css`), restyling them all.

## Notes
- Added `el-form-react-components` as a direct docs dep (to resolve the `./styles.css` export — `el-form-react/styles.css` is stale and not used).
- `ThemeShowcase` is wrapped in `<BrowserOnly>` (SSR-safe; AutoForm touches `FileList`).
- Reviewed: the global el-form CSS is fully class-scoped (`.el-form-*`), `@layer`-contained, `--el-form-*`-prefixed — no impact on Docusaurus chrome. Verified site-wide + a real-browser screenshot (0 console errors).
- Docs-only; no changeset / npm release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)