### PR TITLE
docs(changelog): note interactive Playground + live theme previews

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -85,6 +85,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   async errors and can gate submission where they previously passed silently.
 - See the updated [Async Validation Guide](./guides/async-validation.md).
 
+## [Unreleased] — Docs
+
+### 📚 Interactive Playground + live theme previews
+
+- **Interactive Playground & inline sandboxes.** [elform.dev](https://elform.dev) now has a
+  live [Playground](https://elform.dev/playground) and editable code sandboxes embedded
+  throughout the docs, so you can run `AutoForm` / `useForm` examples directly in the browser.
+- **Live theme previews.** The new [Styling & Themes guide](./guides/styling-and-themes.md)
+  renders the `default` / `minimal` / `dark` themes — plus a `classNames` override — as live,
+  interactive forms.
+
 ## [3.15.0] - 2026-06-09
 
 Released: `el-form-react-hooks@3.15.0`, `el-form-react-components@4.7.2`,


### PR DESCRIPTION
Adds a `[Unreleased] — Docs` note to the changelog for two recent docs improvements that weren't logged:

- **Interactive Playground & inline sandboxes** (elform.dev/playground + embedded editable examples).
- **Live theme previews** in the new Styling & Themes guide (default / minimal / dark + a `classNames` override rendered as live forms).

The library work (theming, formState parity, async-validators fix) was already in `[Unreleased]`. Per-package `CHANGELOG.md` files are untouched (changeset-generated at publish). Docs-only; both internal links verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)