### PR TITLE
docs: add Buy Me a Coffee support link (READMEs + docs navbar)

### DIFF
--- a/.changeset/buy-me-a-coffee-readme.md
+++ b/.changeset/buy-me-a-coffee-readme.md
@@ -1,0 +1,9 @@
+---
+"el-form-core": patch
+"el-form-react-hooks": patch
+"el-form-react-components": patch
+"el-form-react": patch
+"el-form-mcp": patch
+---
+
+docs: add a Buy Me a Coffee support badge to each package README (shown on the npm page).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![MIT License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Bundle Size](https://img.shields.io/bundlephobia/minzip/el-form-react)](https://bundlephobia.com/package/el-form-react)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/colorpulse6/el-form/ci.yml?branch=main)](https://github.com/colorpulse6/el-form/actions)
+[![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-ffdd00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/nicbarnes)
 
 **TypeScript-first React form library** with zero-boilerplate AutoForm and powerful useForm hook. The best React Hook Form alternative with schema-first validation (Zod, Yup, Valibot), built-in components, and enterprise-grade form management.
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -169,6 +169,12 @@ const config: Config = {
           type: "html",
           position: "right",
           value:
+            '<a href="https://buymeacoffee.com/nicbarnes" class="navbar-bmc-button" target="_blank" rel="noopener noreferrer" aria-label="Buy me a coffee — support El Form">☕ Buy me a coffee</a>',
+        },
+        {
+          type: "html",
+          position: "right",
+          value:
             '<a href="https://github.com/colorpulse6/el-form" class="inline-flex items-center gap-1 px-3 py-2 text-sm font-semibold text-white bg-gradient-to-r from-gray-800 to-black rounded-lg hover:from-gray-700 hover:to-gray-900 hover:-translate-y-0.5 transition-all duration-200 border border-white/10 shadow-md hover:shadow-lg ml-2 no-underline hover:no-underline hover:text-white" target="_blank" rel="noopener noreferrer">⭐ GitHub</a>',
         },
       ],

--- a/docs/src/tailwind.css
+++ b/docs/src/tailwind.css
@@ -577,6 +577,36 @@ select:focus {
 }
 */
 
+/* Compact "Buy me a coffee" text button in the navbar — sits beside the
+   ⭐ GitHub button, matching its shape/size but in Buy Me a Coffee yellow.
+   Self-contained CSS (not Tailwind utilities) because docusaurus.config.ts is
+   outside Tailwind's content globs, so utility classes there aren't generated. */
+.navbar-bmc-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-left: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1;
+  color: #0a0a0a;
+  background-color: #ffdd00;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: all 0.2s ease-in-out;
+  text-decoration: none !important;
+}
+
+.navbar-bmc-button:hover {
+  color: #0a0a0a;
+  background-color: #ffe533;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(255, 221, 0, 0.4);
+  text-decoration: none !important;
+}
+
 /* Buy Me a Coffee button styling in navbar */
 .bmc-button {
   display: inline-block;

--- a/packages/el-form-core/README.md
+++ b/packages/el-form-core/README.md
@@ -2,6 +2,8 @@
 
 🔧 **Framework-agnostic form validation engine - TypeScript schema validation core**
 
+[![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-ffdd00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/nicbarnes)
+
 The foundational validation logic that powers the entire el-form ecosystem.
 
 ## 🧭 **Choose the Right Package**

--- a/packages/el-form-mcp/README.md
+++ b/packages/el-form-mcp/README.md
@@ -4,6 +4,8 @@ A [Model Context Protocol](https://modelcontextprotocol.io) server that gives AI
 agents accurate, up-to-date knowledge of [El Form](https://elform.dev) — plus a
 tool that generates ready-to-paste form code.
 
+[![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-ffdd00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/nicbarnes)
+
 ## Why
 
 If an agent is scaffolding a React form, this server lets it pull El Form's real

--- a/packages/el-form-react-components/README.md
+++ b/packages/el-form-react-components/README.md
@@ -2,6 +2,8 @@
 
 🎨 **Zero-boilerplate React AutoForm - Generate beautiful forms instantly from Zod schemas**
 
+[![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-ffdd00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/nicbarnes)
+
 Perfect for developers who want plug-and-play form components that look great out of the box. Skip the tedious form building - generate complete, production-ready forms instantly.
 
 **AutoForm advantages:**

--- a/packages/el-form-react-hooks/README.md
+++ b/packages/el-form-react-hooks/README.md
@@ -2,6 +2,8 @@
 
 🪝 **React Hook Form alternative - TypeScript-first useForm hook with enterprise-grade state management**
 
+[![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-ffdd00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/nicbarnes)
+
 Perfect React Hook Form alternative for developers who want to build custom UIs with full control over styling and components.
 
 **Why choose el-form-react-hooks over React Hook Form:**

--- a/packages/el-form-react/README.md
+++ b/packages/el-form-react/README.md
@@ -2,6 +2,8 @@
 
 ⚡ **Best React Hook Form alternative - Complete TypeScript form library with zero-boilerplate AutoForm**
 
+[![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-ffdd00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/nicbarnes)
+
 This is the **all-in-one** package that includes everything you need for modern React forms. Perfect alternative to React Hook Form + manual component building, or complex form builders like Formik.
 
 **Why developers choose el-form-react:**


### PR DESCRIPTION
Adds a Buy Me a Coffee support link (https://buymeacoffee.com/nicbarnes) in two places.

## READMEs (GitHub + npm)
- Badge in the root `README.md` badge row
- Badge under the tagline of each published package README — `el-form-react`, `el-form-react-hooks`, `el-form-react-components`, `el-form-core`, `el-form-mcp` — so it appears on every npm package page

## Docs (persistent, top of every page)
- A yellow **☕ Buy me a coffee** button in the Docusaurus navbar, next to the ⭐ GitHub button — the always-visible top-bar equivalent used on the other sites
- Styled via a dedicated `.navbar-bmc-button` class in `tailwind.css` (rather than Tailwind utilities), because `docusaurus.config.ts` sits outside Tailwind's content globs and utility classes there aren't generated

## Release
- Patch changeset for the 5 packages whose README changed, so the badge reaches the npm pages on the next publish

## Verification
- `docusaurus build` succeeds
- Confirmed the compiled CSS bundle contains `.navbar-bmc-button` with the yellow background (`#ffdd00`) and dark text scoped to the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)