### PR TITLE
docs(landing): coffee icon in home nav + open external links in new tab

### DIFF
--- a/docs/src/components/landing/Icons.tsx
+++ b/docs/src/components/landing/Icons.tsx
@@ -27,6 +27,27 @@ export function GithubIcon() {
   );
 }
 
+export function CoffeeIcon() {
+  return (
+    <svg
+      className="icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M18 8h1a4 4 0 0 1 0 8h-1" />
+      <path d="M2 8h16v9a4 4 0 0 1-4 4H6a4 4 0 0 1-4-4V8z" />
+      <line x1="6" y1="1" x2="6" y2="4" />
+      <line x1="10" y1="1" x2="10" y2="4" />
+      <line x1="14" y1="1" x2="14" y2="4" />
+    </svg>
+  );
+}
+
 export function CopyIcon() {
   return (
     <svg

--- a/docs/src/components/landing/Nav.tsx
+++ b/docs/src/components/landing/Nav.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import clsx from "clsx";
-import { ArrowIcon, GithubIcon, BrandMark } from "./Icons";
+import { ArrowIcon, GithubIcon, CoffeeIcon, BrandMark } from "./Icons";
 import { LINKS } from "./links";
 
 // Sticky top nav. Gains a hairline bottom border + denser background once the
@@ -25,15 +25,31 @@ export function Nav() {
           </span>
         </a>
         <nav className="nav-links" aria-label="Primary">
-          <a className="lnk" href={LINKS.docs}>
+          <a className="lnk" href={LINKS.docs} target="_blank" rel="noopener noreferrer">
             Docs
           </a>
-          <a className="lnk" href={LINKS.npm}>
+          <a className="lnk" href={LINKS.npm} target="_blank" rel="noopener noreferrer">
             npm
           </a>
-          <a className="lnk gh" href={LINKS.github} aria-label="GitHub repository">
+          <a
+            className="lnk gh"
+            href={LINKS.github}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="GitHub repository"
+          >
             <GithubIcon />
             <span>GitHub</span>
+          </a>
+          <a
+            className="lnk coffee"
+            href={LINKS.coffee}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Buy me a coffee"
+            title="Buy me a coffee"
+          >
+            <CoffeeIcon />
           </a>
           <a className="nav-cta" href={LINKS.docs}>
             Get Started

--- a/docs/src/components/landing/landing.css
+++ b/docs/src/components/landing/landing.css
@@ -259,6 +259,22 @@ html:has(.elform-landing) {
   color: var(--text);
   background: var(--panel);
 }
+/* GitHub link: space between the mark and the "GitHub" label. */
+.elform-landing .nav-links a.lnk.gh {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+/* Coffee: icon-only support link; tints Buy Me a Coffee yellow on hover. */
+.elform-landing .nav-links a.lnk.coffee {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 11px;
+}
+.elform-landing .nav-links a.lnk.coffee:hover {
+  color: #ffdd00;
+  background: rgba(255, 221, 0, 0.1);
+}
 .elform-landing .nav-cta {
   display: inline-flex;
   align-items: center;
@@ -280,7 +296,8 @@ html:has(.elform-landing) {
   .elform-landing .nav-links .lnk {
     display: none;
   }
-  .elform-landing .nav-links .lnk.gh {
+  .elform-landing .nav-links .lnk.gh,
+  .elform-landing .nav-links .lnk.coffee {
     display: inline-flex;
   }
 }

--- a/docs/src/components/landing/links.ts
+++ b/docs/src/components/landing/links.ts
@@ -10,6 +10,7 @@ export const LINKS = {
   github: "https://github.com/colorpulse6/el-form",
   npm: "https://www.npmjs.com/package/el-form-react",
   issues: "https://github.com/colorpulse6/el-form/issues",
+  coffee: "https://buymeacoffee.com/nicbarnes",
   portfolio: "https://nichalasbarnes.com",
 } as const;
 


### PR DESCRIPTION
Follow-up to the Buy Me a Coffee link — landing-page nav refinements.

## Changes
- **☕ coffee icon** in the landing nav (`Nav.tsx`), between GitHub and Get Started, linking to https://buymeacoffee.com/nicbarnes. Icon-only; tints Buy Me a Coffee yellow (`#ffdd00`) on hover; stays visible on mobile alongside the GitHub mark.
- **Open in new tab** — Docs, npm, GitHub, and the coffee link now use `target="_blank" rel="noopener noreferrer"`. **Get Started** intentionally stays same-tab.
- **GitHub spacing** — added a gap between the GitHub mark and its "GitHub" label (`.lnk.gh` → `inline-flex; gap: 7px`).

Docs-only — no package changes, so no changeset/npm publish.

## Verification
- `docusaurus build` succeeds
- Verified in a browser against the built site: coffee icon renders between GitHub and Get Started, GitHub icon/text spacing fixed
- Confirmed in built output: `target="_blank"` on Docs/npm/GitHub/coffee, none on Get Started; `.coffee:hover` yellow present in compiled CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)